### PR TITLE
renaming handbook to team compass

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -17,7 +17,7 @@
 
 # -- Project information -----------------------------------------------------
 
-project = '2i2c Handbook'
+project = '2i2c Team Compass'
 copyright = '2020, 2i2c'
 author = '2i2c'
 
@@ -48,7 +48,7 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 #
 html_theme = 'sphinx_book_theme'
 
-html_title = "The 2i2c Handbook"
+html_title = "The 2i2c Team Compass"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
@@ -57,7 +57,7 @@ html_static_path = ['_static']
 
 show_navbar_depth = 3
 html_theme_options = {
-    "repository_url": "https://github.com/2i2c-org/handbook",
+    "repository_url": "https://github.com/2i2c-org/team-compass",
     "repository_branch": "main",
     "use_repository_button": True,
     "use_edit_page_button": True,

--- a/index.md
+++ b/index.md
@@ -1,4 +1,4 @@
-# The 2i2c Handbook
+# The 2i2c Team Compass
 
 ```{toctree}
 :hidden:
@@ -23,41 +23,41 @@ projects
 strategy
 ```
 
-## How to use the handbook
+## How to use the team compass
 
-As a general rule, 2i2c team members should document everything relevant to operating the organization in the 2i2c handbook, and give it precedence over all other kinds of documentation unless explicitly stated otherwise in the handbook.
+As a general rule, 2i2c team members should document everything relevant to operating the organization in the 2i2c team compass, and give it precedence over all other kinds of documentation unless explicitly stated otherwise in the team compass.
 
 Use it for both high- and low-level things - this book describes the culture, aspirations, operations, and activities of 2i2c at any moment in time. It should have enough information for any newcomer or team member to get up-to-speed with any question they may have about 2i2c.
 
-The handbook should not be the *only* place for information in 2i2c, but it should contain pointers to other sources of truth, updates, etc as needed. For example, it should not contain much project-specific information as this is better suited for project repositories, but it should have information about *where to find* information for any given project.
+The team compass should not be the *only* place for information in 2i2c, but it should contain pointers to other sources of truth, updates, etc as needed. For example, it should not contain much project-specific information as this is better suited for project repositories, but it should have information about *where to find* information for any given project.
 
 ## This is the source of truth
 
-Any information that is in this handbook should be considered the **source of truth** for 2i2c. Its information should be complete and updated frequently.
+Any information that is in this team compass should be considered the **source of truth** for 2i2c. Its information should be complete and updated frequently.
 
-If you see information here that is out of date, please propose an edit in [the handbook repository](https://github.com/2i2c-org/handbook).
+If you see information here that is out of date, please propose an edit in [the team compass repository](https://github.com/2i2c-org/team-compass).
 
-## Propose a change to the handbook
+## Propose a change to the team compass
 
-If you'd like to update information in this book, you can do so via editing the book's source files. These are a collection of markdown files in [the book's repository](https://github.com/2i2c-org/handbook).
+If you'd like to update information in this book, you can do so via editing the book's source files. These are a collection of markdown files in [the book's repository](https://github.com/2i2c-org/team-compass).
 
 Do not hesitate to propose changes to this book - you may do so either via forking and cloning the book's repo, or simply by proposing changes via GitHub's interactive markdown editor.
 
 As a general rule, this book should be updated as open as possible, in order to ensure that its content is accurate and up to date!
 
-## Build the handbook
+## Build the team compass
 
-This handbook is built using Sphinx, along with themes and extensions that are used by the [Jupyter Book project](https://jupyterbook.org). It is hosted via GitHub Pages and changes are auto-deployed via GitHub Actions.
+This book is built using Sphinx, along with themes and extensions that are used by the [Jupyter Book project](https://jupyterbook.org). It is hosted via GitHub Pages and changes are auto-deployed via GitHub Actions.
 
 To preview the book locally:
 
 Get your own copy of the book:
 
 ```
-git clone https://github.com/2i2c-org/handbook
-cd handbook
+git clone https://github.com/2i2c-org/team-compass
+cd team-compass
 ```
-Install the requirements to build this handbook:
+Install the requirements to build this book:
 
 ```
 pip install -r requirements.txt
@@ -73,7 +73,12 @@ This will build the book using Sphinx, and put HTML outputs in `_build/html`. Yo
 
 ## Inspiration
 
-This handbook is inspired by several open company handbooks from companies and organizations dedicated to transparency. In particular:
+This team-compass is inspired by the team compass repositories used across the Jupyter ecosystem. For example:
+
+- [The JupyterHub team compass](https://jupyterhub-team-compass.readthedocs.io/)
+- [The JupyterLab team compass](https://github.com/jupyterlab/team-compass)
+
+In addition, it is inspired by several open company handbooks from companies and organizations dedicated to transparency. In particular:
 
 - [The GitLab Company handbook](https://about.gitlab.com/handbook/)
 - [The Basecamp Company handbook](https://basecamp.com/handbook)

--- a/practices.md
+++ b/practices.md
@@ -1,8 +1,8 @@
 # Team practices
 
-## The 2i2c handbook
+## The 2i2c team compass
 
-The primary {term}`source of truth <Single Source of Truth>` for information about 2i2c and its teams is the [2i2c Handbook](https://2i2c.org/handbook). This contains information for new and current 2i2c team members, as well as the latest information about the status of various projects (or pointers to where you should look).
+The primary {term}`source of truth <Single Source of Truth>` for information about 2i2c and its teams is the [Team Compass](https://2i2c.org/team-compass). This contains information for new and current 2i2c team members, as well as the latest information about the status of various projects (or pointers to where you should look).
 
 ## General organizational information / documents / brainstorms
 
@@ -14,11 +14,11 @@ The folder is organized into a few top-level folders that *should* be relatively
 
 ## Todos, project plans and management
 
-2i2c uses [the Handbook Projects page](projects.md) to keep track of the major projects that it is working on. That page has links to the location of project-specific to-do lists, deliverables, etc.
+2i2c uses [the Team Compass Projects page](projects.md) to keep track of the major projects that it is working on. That page has links to the location of project-specific to-do lists, deliverables, etc.
 
 More organization-specific discussion and items we track can also be found in [the private 2i2c `meta` repository](https://github.com/2i2c-org/meta).
 
-Generally speaking the daily specifics of activity on a project are recorded *outside* of the handbook, as they are more dynamic. The important thing is that the handbook make it clear *where* to find this information, and that the information is kept up-to-date for all.
+Generally speaking the daily specifics of activity on a project are recorded *outside* of the team compass, as they are more dynamic. The important thing is that the team compass make it clear *where* to find this information, and that the information is kept up-to-date for all.
 
 ## Team Conversation
 
@@ -49,7 +49,7 @@ You are *encouraged* but not *required* to take part in conversation on Slack.
 
 2i2c is a remote-first organization, and believes strongly in following practices that are inclusive, participatory, and collaborative. It has team members spread out over many time zones working on a variety of projects. There are many guides and tips for working remotely[^remote-work1], and we've tried to distill a few key components for our workflows:
 
-1. **Have a single source of truth**. For any information or projects in 2i2c, there should be one source of truth. Any conflicting information will defer to this source of truth, and it should be updated first and often. The default source of truth is this handbook, unless otherwise specified.
+1. **Have a single source of truth**. For any information or projects in 2i2c, there should be one source of truth. Any conflicting information will defer to this source of truth, and it should be updated first and often. The default source of truth is this team compass, unless otherwise specified.
 
 2. **Document everything**. Documentation is the most important tool for coordinating and distributing information across remote teams. It is crucial that 2i2c team members document all relevant information about their projects, what they are working on, etc.
 


### PR DESCRIPTION
After some discussion with @yuvipanda , I think it would be useful to rename this from "handbook" to "team compass". This more closely follows the practices we already follow in the Jupyter repositories, and which has worked well. This PR renames references to `handbook/` to instead use "team compass"