### PR TITLE
updating some organizational info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,4 +20,4 @@ help:
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 live:
-	sphinx-autobuild . _build/html/
+	sphinx-autobuild --ignore */.github/* . _build/html/

--- a/about.md
+++ b/about.md
@@ -16,4 +16,4 @@ You can find more information about 2i2c's current team in the [About page of it
 
 ## What is 2i2c's legal designation?
 
-2i2c a “project” of [The International Computer Science Institute](http://www.icsi.berkeley.edu/) (ICSI), a 501(c)(3) non-profit organization. It acts independently of ICSI, though collaborates with it and relies on it for administrative duties. All 2i2c employees are technically employed by ICSI.
+2i2c a project of [The International Computer Science Institute](http://www.icsi.berkeley.edu/) (ICSI), a 501(c)(3) non-profit organization. It acts independently of ICSI, though collaborates with it and relies on it for administrative duties. All 2i2c employees are technically employed by ICSI.

--- a/conf.py
+++ b/conf.py
@@ -39,7 +39,7 @@ templates_path = ['_templates']
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', ".github"]
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/index.md
+++ b/index.md
@@ -28,7 +28,6 @@ team/tech/sync/index
 :hidden:
 :caption: Roadmap
 strategy
-projects
 ```
 
 ## How to use the team compass

--- a/org-goals.md
+++ b/org-goals.md
@@ -1,0 +1,110 @@
+---
+orphan:
+---
+# Organizational FAQ
+
+What kind of an organization does 2i2c aspire to be?
+This page should help provide some answers and goals.
+
+:::{note}
+This is aspirational and subject to change!
+It reflects much of current thinking, but is not set in stone.
+We are a young organization and still trying to understand how we can best-accomplish our mission.
+:::
+
+
+## What kind of things does 2i2c do?
+
+2i2c wants to do a few kinds of things:
+
+- **Manage services** for research and education that use 100% open source infrastructure, and that [respect a customer's right to replicate](https://2i2c.org/right-to-replicate).
+- **Develop and maintain** open infrastructure and open-source tools that underlie these services.
+- **Provide technical collaboration** with researchers and educators on focused projects.
+- **Provide guidance and strategy assistance** to organizations trying to navigate their decisions around cloud and open-source infrastructure.
+- **Provide OS community and project support** for the major open source projects that align with our mission and values.
+
+
+## What kind of organization will 2i2c be?
+
+This is still something we are exploring. Broadly speaking, 2i2c wishes to be a bridge between the research and educational communities, and open source communities that create tools. It aims to be a bi-directional channel of information, resources, and technology between these two (large and diverse) communities.
+
+A good start is to think of 2i2c as some combination of three kinds of organizations:
+
+- **A business** that manages and develops infrastructure for interactive computing, with a focus on customers in research and education.
+- **An R&D shop** that pushes the boundaries of what this open-source stack can do.
+- **An advocacy organization** that tries to advocate for open practices and assist others in growing these models in their institutions.
+ 
+## What phase of development is 2i2c in right now?
+
+Currently 2i2c is in a bootstrap mode.
+It was just created a few months ago, and is getting its sea legs, hiring initial people, and building an organizational model.
+It is currnently prototyping several hub deployments in order to understand both a pricing and sustainability model for them, and to build technical infrastructure underneath it all.
+The first employees at 2i2c will play a critical role in defining this vision and model for 2i2c, as well as its culture.
+
+## What will engineers do on a regular basis?
+
+We are still working out these processes as well, but it will probably be a combination of these three things:
+
+1. Dev-ops for a collection of JupyterHub infrastructure for various customers/communities in research/education. (e.g., improving our deployment infrastructure to reduce downtime and human toil)
+2. Focused collaboration with one or more of those communities. (e.g., providing support and customization for a specific JupyterHub)
+3. Focused development in the open-source tools that we use (e.g., improving collaboration and sharing in JupyterHub)
+4. General open source work on these projects (e.g., running team meetings, issue triage and code review, etc).
+
+We plan for our engineering team to work with one another closely, particularly when it comes to overseeing the centralized hub infrastructure that we run.
+However, engineers will also likely also have specific projects that they focus on, and will need to report back to the team as necessary to keep others in the loop.
+
+
+## The open source communities we work with
+
+These are the open source communities that we are particularly invested in.
+As a general rule, we want most of our infrastructure improvements to happen via upstream contributions in these communities.
+Moreover, we encourage our engineers to spend part of their time doing broader community work (reviews, triage, community support, leadership) in these communities.
+
+:::{note}
+This will be an ever-changing list as this ecosystem evolves!
+:::
+
+- [JupyterHub / Binder](https://github.com/jupyterhub)
+- [JupyterLab](https://github.com/jupyterlab)
+- [Jupyter core](https://github.com/jupyter)
+- [Dask](https://github.com/dask)
+- [ExecutableBooks](https://github.com/executablebooks)
+
+In addition, we will likely interface heavily with projects in the broader PyData ecosystem (e.g., [xarray](http://github.com/pydata/xarray) or [holoviz](https://github.com/holoviz)).
+
+## The virtuous cycle we aim to enable
+
+We wish to create a virtuous cycle between research and education. It goes something like this:
+
+Research and education organizations need help with dev-ops, deployments, customizations, and navigating the cloud landscape. They want to use and support open soruce tools, but need assistance in accomplishing this.
+
+Open source communities need support from organizations that are using their tools. Most organizations use these tools without contributing back substantially. For these communities to survive, we need more organizations committed to contributing back.
+
+This leads to the virtuous cycle:
+
+2i2c wishes to **support research and education** by providing managed services and development that use open source tools. This will **generate resources**, that it then funnels back into **open source support** for both communities and tools that underlie the infrastructure it creates. This will lead to better tools, which makes this stack more attractive for research and education, thus increasing demand for managed services and development.
+
+
+## Why is 2i2c a non-profit?
+
+If 2i2c is effectively creating a business unit, so a reasonable question to ask is: why not start a company instead? We thought a lot about this, and ultimately came down to a few reasons:
+
+1. There's no reason that non-profits can't generate revenue, as long as they do so in accordance with their mission.
+2. We want to design 2i2c beyond its initial founding team. This means adding organizational (and legal!) constraints that ensure it aligns with its founding values.
+3. We believe a non-profit is best-positioned to advocate for open source ecosystems as a relatively neutral third party.
+4. We believe that being a non-profit makes a strong statement about our commitment to our mission and values, and that this will make us a more attractive partner to research and education.
+
+
+## What is 2i2c's relationship to Jupyter?
+
+2i2c's goal is to be another stakeholder in the Jupyter community, but with no "special" status or authority.
+We think that Jupyter is unique because of its multi-organizational structure, and we want 2i2c to boost this rather than overshadow it.
+2i2c plans to support many people doing work throughout the Jupyter community, and will support its team members to spend part of their time doing work across the community.
+However, it does not plan to *restrict* itself to only doing work with Jupyter.
+Ultimately, 2i2c's goal is to serve research and education via open source tools in interactive computing - this is a fairly broad definition, and intentionally so.
+We plan to evolve our own organization and practices as the landscape around us evolves.
+
+
+## What is our organizational roadmap?
+
+The best place to learn about our next plans for the organization is here: [](strategy.md).

--- a/reference.md
+++ b/reference.md
@@ -26,3 +26,15 @@ For-profit companies with interesting histories that we should avoid becoming.
 
 - [Ithaka](https://en.wikipedia.org/wiki/Ithaka_Harbors) - is a non-profit organizations that provides scholarly services for the academic community.
 
+
+## Terminology
+
+Here are some helpful terms that we use at 2i2c.
+
+```{glossary}
+Single Source of Truth
+  Remote teams and open communities need to balance information across team members, and ensure that everyone is on the same page. For this reason, it is recommended to adopt a "single source of truth" for anything important. This is an authoritative source that everyone can look to in order to know the current status and plan for anything we do at 2i2c.
+
+ICSI
+  The [International Computer Science Institute](http://www.icsi.berkeley.edu/) is the parent organization of 2i2c and its fiscal sponsor. It is a non-profit organization dedicated to fostering international collaboration in computer science, based out of Berkeley, CA. All employees of 2i2c are employees of ICSI.
+```


### PR DESCRIPTION
This adds an "orphan" page to the team compass that describes some of the organizational goals / directions of 2i2c. It's an "orphan" so that it won't be easily discoverable, because we likely want to iterate on the text a bit more. However, I wanted to send it to the two OSIE candidates so that they have an idea for what kind of organization 2i2c aspires to be.