### PR TITLE
updating tech team coordination to include goals

### DIFF
--- a/team/tech/coordination.md
+++ b/team/tech/coordination.md
@@ -12,7 +12,7 @@ Here are the goals we optimize for in organizing our team coordination practices
 
 We want to do this with high efficiency so that people can quickly get on the same page and focus efforts around decision-making and collaboration. We also wish to do it in a 💯 remote-friendly way since we are split across many different time-zones.
 
-## Defining our active projects and to-do items
+## Overview of what happens where
 
 **Active projects list**: The 2i2c team compass has [a projects page](https://2i2c.org/team-compass/projects/) that has details about major projects that we run at 2i2c. We use this as {term}`Source of Truth` for the major projects that we are working on, and this can be a combination of development-focused things and higher-level project-focused things. These projects should contain links to the location that daily "project management" and goal-setting are happening.
 
@@ -20,15 +20,46 @@ We want to do this with high efficiency so that people can quickly get on the sa
 
 **Discussion around team practices**: For discussion around strategy that doesn't have a natural place elsewhere, we use `team-compass` issues and PRs. If an issue, it should be actionable (and "closeable"), generally in a way that results in a change to the team compass. If a PR, it should be a proposal to change the team compass and thus update some strategic information in there.
 
+(coordination:team-activity)=
+## How we organize team goals and activity
+
+Most of the conversations and issues for the 2i2c Hub engineers happens in [the `pilot-hubs/` repository](https://github.com/2i2c-org/pilot-hubs).
+
+### Issues to track hubs
+
+When a new hub is created, [create a new GitHub issue for the hub](https://github.com/2i2c-org/pilot-hubs/issues/new) using the "New Hub" template.
+This issue is a "meta" issue that tracks the state of this hub over time.
+These issues serve both as a "Source of Truth" of information about the hub, as well as a place for conversation around operating that hub.
+
+### Team goals
+
+Team goals are high-level goals (AKA, there's no single action that will "complete" them) and span a longer period of time.
+Goals generally contain pointers to other issues / PRs / discussions where the work of more specific tasks is getting done.
+You should regularly communicate with other team members about which goals you're focusing on (e.g., via Slack, GitHub Issues, or via the [](coordination:team-syncs))
+
+:::{tip}
+When opening a new issue in the 2i2c `pilot-hubs/` repository, first check if it would be better to add it to the to-do list of a pre-existing goal.
+:::
+
+We keep track of team goals via the [{guilabel}`goal` label in GitHub](https://github.com/2i2c-org/pilot-hubs/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3Agoal).
+
+
+(coordination:team-syncs)=
 ## Bi-weekly team syncs
 
-By-weekly team syncs happen **every other Monday**. They are a way to synchronize our team goals and practices. Here's how to conduct a team sync.
+Every other Monday, the 2i2c Hub Operations team conducts a team sync to get on the same page and coordinate their work for the week.
 
 1. **Create an issue in the [`team-compass`](https://github.com/2i2c-org/team-compass)**. This is where we'll keep track of the "to-do" for the team sync.
 2. **Clean up [the HackMD](https://hackmd.io/i2Siurp1TkmPYgn3ZgxFQw?both) for the sync**. We'll use [this HackMD](https://hackmd.io/i2Siurp1TkmPYgn3ZgxFQw?both) to run the team sync. At the top is a set of questions to answer, and we can We'll initially use the HackMD to give responses. You can create it from the following template:
 3. **Team members give their responses**. You can copy/paste the template, and then give your responses below. You shouldn't feel forced to add content if you can't think of anything, use it as much as is useful.
 4. **We'll leave the HackMD open for 48hrs**, not counting weekends or holidays. That should give enough time for those of us across many time zones to respond.
 5. **Merge into the [dev team sync notes](sync/index.md)**. This is where we'll store our sync notes for each team sync, and refer to them later.
+  
+
+```{note}
+While these syncs happen every two weeks, the process of communicating with team members and working on goals / issues / etc can be dynamic and constantly updating.
+The syncs are just to get everyone on the same page.
+```
 
 ## What about stuff that shouldn't be public?
 

--- a/team/tech/sync/2021.md
+++ b/team/tech/sync/2021.md
@@ -1,6 +1,55 @@
 # Team Sync 2021
 
 
+## 2021-02-15
+
+### Chris Holdgraf
+
+#### Thanks I'd like to give 🙌
+- Cathryn and Jim have both been very helpful in helping me think through some high-level strategic questions about 2i2c!
+- Ryan Abernathy and Georgiana both helped interview our job candidates, and their feedback was invaluable!
+ 
+#### Updates from last two weeks ✔ 
+- The last two weeks have all been about doing diligence on our applicants, and working with ICSI to understand how we can open up our first sales with them.
+
+#### What I'm up to next ⬜
+- The work with ICSI is ongoing, but I think that we are getting closer. I've got a draft of a contract that they're sending to a lawyer soon, and then we should be able to start accepting money for running hubs.
+- In addition, I hope to hear back from the two job candidates in the next few weeks about their decision!
+
+### Erik Sundell
+
+#### Thanks I'd like to give 🙌
+- I'm thankful for all 2i2c members for their efforts into building this org! :heart:
+- I'm thankful for Yuvi's positive and uplifting comments and help reviewing various PRs! :heart:
+ 
+#### Updates from last two weeks ✔ 
+- I've done a little bit of this and a little bit of that across the JupyterHub org (Example [general maintenance PR](https://github.com/jupyterhub/jupyterhub-idle-culler/pull/20)), but I'm currently most excited about [this pr](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/2033). It is finally getting the z2jh configuration reference updated to fully cover the available config options and at the same time including a jsonschema file that `helm` can use to catch various config errors for users of the chart and provide sensible messages while doing so.
+
+#### What I'm up to next ⬜
+- Pushing onwards to z2jh 1.0.0, after the schema validation logic I want to acquire an "official status" on artifacthub.io where it is listed and make do a pass at the z2jh documentation so it is updated with lessons learned across time.
+
+#### Links to items for discussion 💬
+- @yuvipanda I've love to hear your suggestions on pod resource requests or empirical data on pod resource consumption as you hint you could share! To me, that would be one of those nice 1.0.0 features we can ship with the documentation.
+  
+  I'd be very happy to format and writeup the documentation and such based on a more raw knowledge input btw.
+  
+  Related: https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/2034
+
+### Georgiana Dolocan
+
+#### Thanks I'd like to give 🙌
+- To Chris for giving me the opportunity to participate in the interview process, it was a great learning oportunity
+- To Yuvi for explaining every technical concept so well.
+- To Erik for all the work in z2jh and making jupyter-server-proxy fully compatible with JupyterLab3
+ 
+#### Updates from last two weeks ✔ 
+- These past weeks, I've worked on setting a new hub for the Mills College, upgrading the hub version in pilot-hubs as part of the process. I also tried to make the hub health checks more robust and investigated the use JupyterLab3 with the pilot-hubs.
+
+#### What I'm up to next ⬜
+- TLJH needs some <3, so I'll try to get it a bit more up to date
+- Investigate if our current Auth0 setup can support multiple hub authentication methods
+
+
 ## 2021-01-27
 
 ### Erik Sundell


### PR DESCRIPTION
This updates our tech team process with information about how we keep track of team goals, and how this works with the team sync process.

Done in conjunction with https://github.com/2i2c-org/pilot-hubs/pull/236

cc @yuvipanda 

also updates with our latest team sync: closes https://github.com/2i2c-org/team-compass/issues/32