### PR TITLE
Adding information about structure and governance.

### DIFF
--- a/about.md
+++ b/about.md
@@ -6,6 +6,10 @@ This page contains information about the 2i2c organization and community.
 
 Your best place to learn about 2i2c's values is to check out [the About pages](https://2i2c.org/about/) on the 2i2c website. Those give an idea for the kind of organization that 2i2c strives to be, and the impact that it wishes to have on the world.
 
+## 2i2c's structure and governance
+
+Check out [](about/structure.md) for more information about this.
+
 ## Where is 2i2c located?
 
 While 2i2c is housed under the [International Computer Science Institute](https://icsi.berkeley.edu), located in Berkeley, CA, 2i2c team members are distributed across the globe and 2i2c claims no formal physical center. All of its work is done online.

--- a/about/structure.md
+++ b/about/structure.md
@@ -1,0 +1,60 @@
+# Structure and governance of 2i2c
+
+2i2c is an initiative dedicated to supporting open infrastructure in interactive computing for research and education, as well as the open source communities that underlie this infrastructure. Its host organization is {ref}`structure:icsi`.
+
+This page describes the major organizational structures of 2i2c, and how they relate to governance and operations.
+
+:::{admonition} A few notes on governance
+- All 2i2c members act as individuals, and not on behalf of their affiliated institutions.
+- All decisions made by the 2i2c Steering Council or Teams must abide by the policies of its host organization, {ref}`structure:icsi`.
+:::
+
+## Steering Council
+
+The Steering Council defines the mission, vision, and values of 2i2c. It also sets the strategic direction and priorities for 2i2c. The Steering Council provides oversight to the Executive Director of 2i2c and the Operations Team.
+
+The Steering Council makes decisions via consensus, and is restricted by the legal obligations and policies of ICSI. It uses the following process for these decisions:
+
+* Open an issue in the `meta/` GitHub repository using [the {guilabel}`decision` template](https://github.com/2i2c-org/meta/issues/new?assignees=&labels=decision&template=decision.md&title=%7B%7B+Decision+Summary+%7D%7D).
+* Have conversation around the decision in that issue. This may happen in the issue directly, or in ancillary issues, meetings, etc that are relevant. The decision issue should link to these relevant spaces.
+* Once everybody has voted, note the decision in the issue and close it.
+
+:::{seealso}
+The current Steering Council is [listed on the 2i2c website](https://2i2c.org/about/#steering-council).
+:::
+
+## Executive Director
+
+The Executive Director oversees the execution of the mission and strategy provided by the Steering Council.
+They are the primary interface to {ref}`ICSI's <structure:icsi>` administration, and coordinate activity in the 2i2c Teams.
+The Executive Director oversees each team, and makes tie-breaking decisions if they are at an impasse in decision-making.
+The Executive Director reports to the Steering Council.
+
+:::{seealso}
+The current Executive Director of 2i2c is listed on the [Our Team page of the website](https://2i2c.org/about/#our-team).
+:::
+
+
+## 2i2c Teams
+
+2i2c Teams carry out the mission of 2i2c with a specific focus or project.
+They are made up of staff funded through ICSI, employees at other organizations providing in-kind support, or volunteers contributing their time to 2i2c.
+Each team has a decision-making process as well as a scope.
+
+You can find a list of teams below.
+
+```{contents}
+:local: true
+:backlinks: none
+```
+
+### 2i2c Open Engineering Team
+
+**Team focus:** Build infrastructure for the 2i2c Hub service, contributions to open source contributions for projects that underlie this infrastructure, and development of a bootstrap business model around that service.
+
+**Governance:** [Lazy consensus-seeking](http://smallcultfollowing.com/babysteps/blog/2019/04/19/aic-adventures-in-consensus/), or via delegation to individuals or groups within that team. This does not currently follow a formal process, but is made in good-faith conversation across the 2i2c repositories and issues.
+
+(structure:icsi)=
+## International Computer Science Institute (ICSI)
+
+[ICSI](https://icsi.berkeley.edu) is the host organization of 2i2c. It provides administrative and strategic resources for 2i2c and leadership to support them in their mission. ICSI supports 2i2c by assisting in managing partnerships with 2i2c collaborators and contracts with 2i2c customers, connecting with the larger open research and education community, fundraising, grant and financial management, assuming legal and financial risk for 2i2c, and hiring and management of staff.

--- a/about/structure.md
+++ b/about/structure.md
@@ -1,6 +1,6 @@
 # Structure and governance of 2i2c
 
-2i2c is an initiative dedicated to supporting open infrastructure in interactive computing for research and education, as well as the open source communities that underlie this infrastructure. Its host organization is {ref}`structure:icsi`.
+2i2c is an organization dedicated to supporting open infrastructure in interactive computing for research and education, as well as the open source communities that underlie this infrastructure. Its host organization is {ref}`structure:icsi`.
 
 This page describes the major organizational structures of 2i2c, and how they relate to governance and operations.
 
@@ -13,11 +13,11 @@ This page describes the major organizational structures of 2i2c, and how they re
 
 The Steering Council defines the mission, vision, and values of 2i2c. It also sets the strategic direction and priorities for 2i2c. The Steering Council provides oversight to the Executive Director of 2i2c and the Operations Team.
 
-The Steering Council makes decisions via consensus, and is restricted by the legal obligations and policies of ICSI. It uses the following process for these decisions:
+The Steering Council makes decisions via consensus (all members voting in the affirmative), and is restricted by the legal obligations and policies of ICSI. It uses the following process for these decisions:
 
 * Open an issue in the `meta/` GitHub repository using [the {guilabel}`decision` template](https://github.com/2i2c-org/meta/issues/new?assignees=&labels=decision&template=decision.md&title=%7B%7B+Decision+Summary+%7D%7D).
 * Have conversation around the decision in that issue. This may happen in the issue directly, or in ancillary issues, meetings, etc that are relevant. The decision issue should link to these relevant spaces.
-* Once everybody has voted, note the decision in the issue and close it.
+* Once everybody has voted, if all vote in favor, then the vote passes. If anyone votes against, the vote does not pass. Either way, note the decision in the issue, close it, and take necessary action.
 
 :::{seealso}
 The current Steering Council is [listed on the 2i2c website](https://2i2c.org/about/#steering-council).

--- a/index.md
+++ b/index.md
@@ -4,6 +4,7 @@
 :hidden:
 :caption: 2i2c Information
 about
+about/structure
 positions
 reference
 ```

--- a/reference.md
+++ b/reference.md
@@ -34,7 +34,4 @@ Here are some helpful terms that we use at 2i2c.
 ```{glossary}
 Single Source of Truth
   Remote teams and open communities need to balance information across team members, and ensure that everyone is on the same page. For this reason, it is recommended to adopt a "single source of truth" for anything important. This is an authoritative source that everyone can look to in order to know the current status and plan for anything we do at 2i2c.
-
-ICSI
-  The [International Computer Science Institute](http://www.icsi.berkeley.edu/) is the host organization of 2i2c and is the manager of 2i2c's grants and other assets. It is a non-profit organization dedicated to fostering international collaboration in computer science, based out of Berkeley, CA.
 ```


### PR DESCRIPTION
This PR defines our current governance and general structure of 2i2c, as well as our relationship to ICSI. It closes https://github.com/2i2c-org/meta/issues/133.

To re-iterate, the point here is not to create new governance, but to put names and labels to our current governing structures. For suggestions about *improvements* to our governance, see https://github.com/2i2c-org/meta/issues/158. But let's focus this PR around "describing" rather than changing.

I am not sure whether this PR requires a formal vote from the @2i2c-org/founders. On the one hand, it is a change related to governance, which in general I think requires votes. On the other hand, it is not trying to change the substance of our governance, only describe it explicitly.

If anybody believes that we need to have a founding team vote for this, please do not hesitate to suggest one. Otherwise, I'll plan to leave this open for several days to give people a chance to provide input.

You can find a preview of the page here: https://2i2c-team-compass--38.org.readthedocs.build/en/38/about/structure.html

closes https://github.com/2i2c-org/meta/issues/150
closes https://github.com/2i2c-org/meta/issues/133