### PR TITLE
Adding a code of conduct

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -72,5 +72,6 @@ intersphinx_mapping = {
     "pi": ('https://2i2c.org/pilot', None),
     "ph": ('https://2i2c.org/pilot-hubs', None)
 }
+myst_url_schemes = ["http", "https", "mailto", "ftp"]
 
 panels_add_bootstrap_css = False

--- a/culture/code-of-conduct.md
+++ b/culture/code-of-conduct.md
@@ -91,7 +91,7 @@ In some cases we may decide to share an update about a major incident with 2i2c 
 
 In addition to having a code of conduct, we have four lightweight [social rules](social-rules.md). The social rules are different and separate from the code of conduct. They help us create a better learning environment by giving names to counterproductive behavior and acting as a release valve so that frustration doesn't build up over time. We understand and anticipate people to unintentionally break the social rules from time to time. Doing this doesn't make you a bad person or a bad community member. When this happens, it's not a big deal. Just apologize and move on.
 
-The enforcement provisions in this code of conduct do not apply to the social rules. We definitely won't give you a strong warning or expel you from the 2i2c community just for breaking a social rule.
+The enforcement provisions in this code of conduct do not apply to the social rules. We won't give you a strong warning or expel you from the 2i2c community just for breaking a social rule.
 
 If you have any questions about any part of the code of conduct or social rules, please reach out to any 2i2c team member.
 

--- a/culture/code-of-conduct.md
+++ b/culture/code-of-conduct.md
@@ -37,7 +37,7 @@ Maliciousness towards other community members
 : deliberately attempting to make others feel bad, name-calling, singling out others for derision or exclusion. For example, telling someone they’re not a real programmer or that they don’t belong at 2i2c.
 
 Being especially unpleasant
-: for example, if we’ve received reports from multiple 2i2c users, team members, or collaborators of annoying, rude, or especially distracting behavior.
+: for example, if we’ve received reports from multiple 2i2c users, team members, or collaborators of agitating, rude, or especially distracting behavior over an extended period of time.
 
 ## Scope
 
@@ -47,15 +47,20 @@ In addition, the 2i2c community and experience often extends outside those space
 
 The 2i2c Code of Conduct does not apply to users of any hubs that we manage on behalf of other organizations, though we encourage leaders in those communities to adopt a Code of Conduct for their hub infrastructure. The Code of Conduct **does** apply to any 2i2c Team Member that is acting in a community's hub.
 
+:::{important}
 When in doubt, please {ref}`report <coc:reporting>` unacceptable behavior to us. If someone’s behavior outside of a 2i2c space makes you feel unsafe at 2i2c, that is absolutely relevant and actionable for us.
-
+:::
 
 ## Enforcement
 
 We’ve categorized unacceptable behavior into abuse and unwelcoming behavior in the section above.
 
-If we witness or receive a report about abusive behavior, we will contact the perpetrator to have a conversation with them and verify what has transpired, and they will be removed from the 2i2c community. Their Slack account will be deactivated, and permissions will be removed from any 2i2c-related repositories. They will not be welcome in any physical or digital spaces covered by the 2i2c Code of Conduct.
+If we witness or receive a report about abusive behavior, we will contact the perpetrator to have a conversation with them and verify what has transpired. We will [follow this response protocol](response-protocol.md).
 
+If we verify abusive behavior, they will be removed from the 2i2c community. Their Slack account will be deactivated, and permissions will be removed from any 2i2c-related repositories. They will not be welcome in any physical or digital spaces covered by the 2i2c Code of Conduct.
+
+If we verify unwelcome, but non-abusive behavior, we will have a conversation with the person so they understand the expectation that they not repeat the behavior a second time. See [the follow-up protocol for more information](coc:reporting:follow-up).
+ 
 [This is the protocol](response-protocol.md) that 2i2c Directors and Steering Council members will use to respond to reports of code of conduct violations.
 
 (coc:reporting)=
@@ -73,7 +78,7 @@ If you see a violation of our code of conduct, please [report it to the 2i2c Exe
 
 ### Where and how to report
 
-Please report all code of conduct violations using [our reporting form](https://docs.google.com/forms/d/e/1FAIpQLSeKFuoghGzftqqgaa0xllZyocdUJsWZmoSaFFlerimg4n_Y8A/viewform?usp=sf_link). This is a short Google Form that will be sent to the Executive Director.
+Please report all code of conduct violations using [our reporting form](https://docs.google.com/forms/d/e/1FAIpQLSeKFuoghGzftqqgaa0xllZyocdUJsWZmoSaFFlerimg4n_Y8A/viewform?usp=sf_link). This is a short Google Form that will be sent to the Executive Director. If you prefer, you may also [email the Executive Director directly](mailto:director@2i2c.org).
 
 If you would rather discuss the matter in person with a team member, send a direct message in the 2i2c Slack, or email a Steering Council member to schedule a time to talk.
 
@@ -93,7 +98,7 @@ In addition to having a code of conduct, we have four lightweight [social rules]
 
 The enforcement provisions in this code of conduct do not apply to the social rules. We won't give you a strong warning or expel you from the 2i2c community just for breaking a social rule.
 
-If you have any questions about any part of the code of conduct or social rules, please reach out to any 2i2c team member.
+If you have any questions about any part of the code of conduct or social rules, please reach out to [any 2i2c team member](https://2i2c.org/about/#our-team).
 
 
 ## How we developed the code of conduct
@@ -113,7 +118,7 @@ Instead of filling out a code of conduct violation report, please contact law en
 
 ### Getting help
 
-If you or someone else at 2i2c is struggling and needs help, don’t hesitate to reach out to the 2i2c Directors and Steering Council members in person or over email.
+If you or someone else at 2i2c is struggling and needs help, don’t hesitate to reach out to the [2i2c Director](mailto:director@2i2c.org) and [Steering Council members](https://2i2c.org/about/#steering-council) in person or over email.
 
 ## License
 

--- a/culture/code-of-conduct.md
+++ b/culture/code-of-conduct.md
@@ -89,7 +89,7 @@ In some cases we may decide to share an update about a major incident with 2i2c 
 
 ## Social rules
 
-In addition to having a code of conduct, we have four lightweight [social rules](social-rules.md). The social rules are different and separate from the code of conduct. They help us create a better learning environment by giving names to counterproductive behavior and acting as a release valve so that frustration doesn't build up over time. We expect people to unintentionally break the social rules from time to time. Doing this doesn't make you a bad person or a bad community member. When this happens, it's not a big deal. Just apologize and move on.
+In addition to having a code of conduct, we have four lightweight [social rules](social-rules.md). The social rules are different and separate from the code of conduct. They help us create a better learning environment by giving names to counterproductive behavior and acting as a release valve so that frustration doesn't build up over time. We understand and anticipate people to unintentionally break the social rules from time to time. Doing this doesn't make you a bad person or a bad community member. When this happens, it's not a big deal. Just apologize and move on.
 
 The enforcement provisions in this code of conduct do not apply to the social rules. We definitely won't give you a strong warning or expel you from the 2i2c community just for breaking a social rule.
 

--- a/culture/code-of-conduct.md
+++ b/culture/code-of-conduct.md
@@ -1,0 +1,124 @@
+# Code of Conduct
+
+```{toctree}
+:hidden:
+response-protocol
+```
+
+## Why have a code of conduct?
+
+Our goal is to create the best community in the world for learning, using, and creating open infrastructure for interactive computing.
+We want every member of the 2i2c community to be able to focus their full attention on building amazing tools and developing a thriving culture of collaboration and inclusion around them.
+This is impossible to do if you are being harassed, stalked, or discriminated against.
+
+Accordingly, anyone that participates in a 2i2c space is expected to show respect and courtesy to each other in all interactions, whether in GitHub repositories, our Slack channel, in in-person events, when representing 2i2c in public, or in events and spaces associated with {term}`ICSI`.
+
+To make sure that everyone has a common understanding of “show respect and courtesy to each other,” we have adopted the following code of conduct. The code of conduct is enforced by the 2i2c Executive Director and the Steering Council.
+
+## Unacceptable behavior
+
+The following types of behavior are unacceptable in 2i2c spaces, both online and in-person, and constitute code of conduct violations.
+
+### Abusive behavior
+
+Harassment
+: including offensive verbal comments related to gender, sexual orientation, disability, physical appearance, body size, race, or religion, as well as sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, inappropriate physical contact, and unwelcome sexual or romantic attention.
+
+Threats
+: threatening someone physically or verbally. For example, threatening to publicize sensitive information about someone’s personal life.
+
+### Unwelcoming behavior
+
+
+Blatant -isms
+: saying things that are explicitly racist, sexist, homophobic, etc. For example, arguing that some people are less intelligent because of their gender, race or religion. {ref}`Subtle -isms <social:subtle-isms>` and small mistakes made in conversation are not code of conduct violations. However, repeating something after it has been pointed out to you that you broke a social rule, or antagonizing or arguing with someone who has pointed out your subtle -ism is considered unwelcoming behavior, and is not allowed at 2i2c.
+
+Maliciousness towards other community members
+: deliberately attempting to make others feel bad, name-calling, singling out others for derision or exclusion. For example, telling someone they’re not a real programmer or that they don’t belong at 2i2c.
+
+Being especially unpleasant
+: for example, if we’ve received reports from multiple 2i2c users, team members, or collaborators of annoying, rude, or especially distracting behavior.
+
+## Scope
+
+2i2c community members are held to the standards outlined in this code of conduct when interacting in the 2i2c Slack or GitHub repositories, when interacting in-person at events where they could represent 2i2c (this is most professional events), in physical spaces with other 2i2c team members or collaborators, or in any {term}`ICSI` space.
+
+In addition, the 2i2c community and experience often extends outside those spaces—2i2c community members may go on walks together to get lunch, attend meetups or conferences as a group, communicate on social media, or interact with each other in other communities. Abusive or unwelcoming behavior between community members still has a profound impact on individuals and on the community when it happens beyond our walls. 2i2c Directors and the Steering Council will use our discretion when deciding whether to enforce this code of conduct and potentially remove someone from the 2i2c community after reports of such behavior happening outside of 2i2c, taking into account the impact on the individual community members involved as well as the impact on the community at large.
+
+The 2i2c Code of Conduct does not apply to users of any hubs that we manage on behalf of other organizations, though we encourage leaders in those communities to adopt a Code of Conduct for their hub infrastructure. The Code of Conduct **does** apply to any 2i2c Team Member that is acting in a community's hub.
+
+When in doubt, please {ref}`report <coc:reporting>` unacceptable behavior to us. If someone’s behavior outside of a 2i2c space makes you feel unsafe at 2i2c, that is absolutely relevant and actionable for us.
+
+
+## Enforcement
+
+We’ve categorized unacceptable behavior into abuse and unwelcoming behavior in the section above.
+
+If we witness or receive a report about abusive behavior, we will contact the perpetrator to have a conversation with them and verify what has transpired, and they will be removed from the 2i2c community. Their Slack account will be deactivated, and permissions will be removed from any 2i2c-related repositories. They will not be welcome in any physical or digital spaces covered by the 2i2c Code of Conduct.
+
+[This is the protocol](response-protocol.md) that 2i2c Directors and Steering Council members will use to respond to reports of code of conduct violations.
+
+(coc:reporting)=
+## Reporting
+
+If you see a violation of our code of conduct, please [report it to the 2i2c Executive Director](https://docs.google.com/forms/d/e/1FAIpQLSeKFuoghGzftqqgaa0xllZyocdUJsWZmoSaFFlerimg4n_Y8A/viewform?usp=sf_link).
+
+
+### Why should I report?
+
+* **You are responsible for making 2i2c a safe and comfortable space for everyone.** Everyone in our community shares this responsibility. 2i2c Team and Steering Council members are not around the online spaces or at 2i2c events all the time, so we cannot enforce the code of conduct without your help.
+* **The consequences for the 2i2c community of not reporting bad behavior outweigh the consequences for one person of reporting it.** We sometimes hear “I don’t want X person to meet consequences because I told someone about their bad behavior.” Consider the impact on everyone else at 2i2c of letting their behavior continue unchecked.
+* 2i2c only works as an open, participatory, community-driven community because of shared trust between community members. **Reporting code of conduct violations helps us identify when this trust is broken, to prevent that from happening in the future.**
+
+
+### Where and how to report
+
+Please report all code of conduct violations using [our reporting form](https://docs.google.com/forms/d/e/1FAIpQLSeKFuoghGzftqqgaa0xllZyocdUJsWZmoSaFFlerimg4n_Y8A/viewform?usp=sf_link). This is a short Google Form that will be sent to the Executive Director.
+
+If you would rather discuss the matter in person with a team member, send a direct message in the 2i2c Slack, or email a Steering Council member to schedule a time to talk.
+
+
+### Confidentiality
+
+We will keep all reports confidential, except if we've discussed with you and agreed otherwise. When we discuss incidents with people who are reported, we will anonymize details as much as we can to protect reporter privacy.
+
+However, some incidents happen in one-on-one interactions, and even if the details are anonymized, the reported person may be able to guess who made the report. If you have concerns about retaliation or your personal safety, and do not want us to share the details of your report with anyone (including the perpetrator) please let us know explicitly in your report. Unfortunately, in that situation we will not be able to take any action.
+
+In some cases we may decide to share an update about a major incident with 2i2c team members, or with the entire 2i2c community. If that's the case, the identities of all victims and reporters will remain confidential unless those individuals instruct us otherwise.
+
+
+## Social rules
+
+In addition to having a code of conduct, we have four lightweight [social rules](social-rules.md). The social rules are different and separate from the code of conduct. They help us create a better learning environment by giving names to counterproductive behavior and acting as a release valve so that frustration doesn't build up over time. We expect people to unintentionally break the social rules from time to time. Doing this doesn't make you a bad person or a bad community member. When this happens, it's not a big deal. Just apologize and move on.
+
+The enforcement provisions in this code of conduct do not apply to the social rules. We definitely won't give you a strong warning or expel you from the 2i2c community just for breaking a social rule.
+
+If you have any questions about any part of the code of conduct or social rules, please reach out to any 2i2c team member.
+
+
+## How we developed the code of conduct
+
+We arrived at these policies by a combination of:
+
+* Listening to feedback and suggestions we've heard from open source communities over many years
+* Reading the codes of conduct of other organizations we find to be thoughtful (see some examples below)
+* Considering our experiences in other communities and projects in the past
+
+
+## Other things that don’t fit in to the code of conduct
+
+### When to seek help immediately
+
+Instead of filling out a code of conduct violation report, please contact law enforcement directly to report criminal activity (e.g. physical assault, sexual assault, theft), or to report a dangerous physical situation (e.g. fire, serious injury, fear that someone will hurt themselves or someone else).
+
+### Getting help
+
+If you or someone else at 2i2c is struggling and needs help, don’t hesitate to reach out to the 2i2c Directors and Steering Council members in person or over email.
+
+## License
+
+The 2i2c code of conduct is available under the terms of the [CC0 license](https://creativecommons.org/share-your-work/public-domain/cc0/).
+
+Parts of it are based on the [Recurse Center Code of Conduct](https://www.recurse.com/code-of-conduct), the [Jupyter Code of Conduct](https://jupyter.org/governance/conduct/code_of_conduct.html), the [PyLadies Handbook](http://kit.pyladies.com/en/latest/organizer/difficult/responding.html), and the [example conference anti-harassment policy](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy) on the Geek Feminism Wiki, created by the Ada Initiative and other volunteers.
+
+The Recurse Center Code of Conduct and the Geek Feminism conference anti-harassment policy are available under the terms of the CC0 license. The Project Jupyter Code of Conduct and the PyLadies handbook is available under the terms of the [Creative Commons Attribution 3.0 Unported License](https://creativecommons.org/licenses/by/3.0/).

--- a/culture/response-protocol.md
+++ b/culture/response-protocol.md
@@ -15,6 +15,7 @@ Within two business days of receiving an email alert, the director will:
 * We’ll ask any follow-up questions we need to better understand the situation
 * We’ll confirm that we can contact the accused individual
 
+(coc:reporting:follow-up)=
 ## Follow up with the community member who violated our code of conduct
 
 * We will reach out to the community member over email, let them know that we’ve received a report of a code of conduct violation, and invite them to speak to us about the incident in person if possible, over video chat if not.

--- a/culture/response-protocol.md
+++ b/culture/response-protocol.md
@@ -1,0 +1,29 @@
+# CoC Report Response Protocol
+
+When a report is submitted through [the submission form](https://docs.google.com/forms/d/e/1FAIpQLSeKFuoghGzftqqgaa0xllZyocdUJsWZmoSaFFlerimg4n_Y8A/viewform?usp=sf_link), an email alert will be sent to the Executive Director of 2i2c.
+
+Within two business days of receiving an email alert, the director will:
+
+## Read the report to determine whether there has been a code of conduct violation
+
+* If not, they will reply to the reporter, explain that our code of conduct was not violated, and suggest other remediation options (e.g. meeting to get advice on how to resolve an interpersonal conflict).
+* If yes, the Director will determine whether they are the best person to respond to the situation, or if it is more appropriate to hand off the report to another Director or Steering Council member (for example, if someone else already has a relationship with the reporter or the accused).
+
+## Follow up with the reporter
+
+* We’ll email to acknowledge that we’ve received the report, and are taking action
+* We’ll ask any follow-up questions we need to better understand the situation
+* We’ll confirm that we can contact the accused individual
+
+## Follow up with the community member who violated our code of conduct
+
+* We will reach out to the community member over email, let them know that we’ve received a report of a code of conduct violation, and invite them to speak to us about the incident in person if possible, over video chat if not.
+* If the report was of abusive behavior, or the second report of unwelcoming behavior:
+  * During our meeting we will tell the community member we’re removing them from the community, and disable their accounts.
+* If the report was of unwelcoming behavior:
+  * We will explain how their behavior violates our code of conduct, and what we expect of them moving forward.
+  * We will warn them that a second code of conduct violation will result in them being removed from the 2i2c community.
+
+If a Director or Steering Council member someone finds a report of a code of conduct violation somewhere other than our reporting form (e.g. on Slack, in an anonymous note, or in-person), that person will fill out the reporting form with all the information they can, and then follow the same protocol detailed above.
+
+If a report is made anonymously without an email address provided for follow-up, or if the reporter indicates that they do not give us permission to act on their report, we will unfortunately not be able to take any action.

--- a/culture/social-rules.md
+++ b/culture/social-rules.md
@@ -1,0 +1,82 @@
+# Social Rules
+
+2i2c has a few social rules. They help create a friendly, intellectual environment where you can spend as much of your energy as possible on interactive computing and open infrastructure.
+
+The social rules are:
+
+- No well-actually’s
+- No feigning surprise
+- No backseat driving
+- No subtle -isms
+
+One thing that often confuses people about the social rules is that we expect people to break them from time to time. This means they’re different and totally separate from [our code of conduct](code-of-conduct.md).
+
+## No well-actually’s
+
+```{epigraph}
+> **Alice**: I just installed Linux on my computer!
+> 
+> **Bob**: It’s actually called GNU/Linux.
+```
+
+A well-actually is when you correct someone about something that’s not relevant to the conversation or tangential to what they’re trying to say.[^1] They’re bad because they aren’t helpful, break the flow of conversation, and focus attention on the person making the well actually.
+
+This rule can be a bit tricky because there isn’t a clear line between relevant to the conversation and not. Sometimes your correction might actually be necessary, and it could still come off as annoying when you make it. The best rule of thumb is, if you’re not sure whether something needs to be said right now, hold off and see what happens. You can always say it later if it turns out there’s no way for the conversation to move forward without your correction.
+
+## No feigning surprise
+
+```{epigraph}
+> **Dan**: What’s the command line?
+> 
+> **Carol**: Wait, you’ve never used the command line?
+```
+
+Feigned surprise is when you act surprised when someone doesn’t know something. Responding with surprise in this situation makes people feel bad for not knowing things and less likely to ask questions in the future, which makes it harder for them to learn.
+
+_No feigning surprise_ isn’t a great name. When someone acts surprised when you don’t know something, it doesn’t matter whether they’re pretending to be surprised or actually surprised. The effect is the same: the next time you have a question, you’re more likely to keep your mouth shut. An accurate name for this rule would be _no acting surprised when someone doesn’t know something_, but it’s a mouthful, and at this point, the current name has stuck.
+
+
+## No backseat driving
+
+```{epigraph}
+> **Bob**: What’s the best tool for data science with tables?
+> 
+> **Alice**: NumPy.
+> 
+> **Eve**: _(from across the room)_ No, you should use Pandas. It’s better.
+```
+
+Backseat driving is when you lob advice from across the room (or across the online chat) without really joining or engaging in a conversation. Because you haven’t been participating in the conversation, it’s easy to miss something important and give advice that’s not actually helpful. Even if your advice is correct, it’s rude to bust into a conversation without asking. If you overhear a conversation where you could be helpful, the best thing to do is to ask to join.
+
+(social:subtle-isms)=
+## No subtle -isms
+
+```{epigraph}
+> **Carol**: Windows is hard to use.
+> 
+> **Bob**: No way. Windows is so easy to use that even my mom can use it.
+```
+
+Subtle -isms are subtle expressions of racism, sexism, ageism, homophobia, transphobia and other kinds of bias and prejudice. They are small things that make others feel unwelcome, things that we all sometimes do by mistake. Subtle -isms make people feel like they don’t belong in the 2i2c community. We want to create an environment where everyone can focus all their energy on interactive computing. It’s hard to do that if you’re regularly being made to wonder whether you belong.
+
+Subtle -isms can also be things that you do instead of say. This includes things like boxing out the only woman at the whiteboard during a discussion or assuming someone isn’t a programmer because of their race or gender.
+
+The fourth social rule is more complicated than the others. Not everyone agrees on what constitutes a subtle -ism. Subtle -isms are baked into society in ways that can make them hard to recognize. And not everyone experiences subtle -isms in the same way: subtle homophobia won’t hurt someone who’s straight in the same way it hurts someone who’s gay.
+
+There’s another part of _no subtle -isms:_ If you see racism, sexism, etc. outside of 2i2c, please don’t bring it in. For example, please don’t start a discussion about the latest offensive comment from Random Tech Person Y. Everyone who comes to 2i2c should have the same opportunity to focus on interactive computing, and people from oppressed groups often find discussions of racism, sexism, etc. particularly hard to tune out. There are many places to discuss and debate these issues, but there are few where people can avoid them. 2i2c spaces are some of those places.[^2]
+
+
+## How do they work?
+
+The social rules are lightweight. You should not be afraid of breaking a social rule. These are things that everyone does, and breaking one doesn’t make you a bad person. If someone says, "hey, you just feigned surprise," or "that’s subtly sexist," don’t worry. Just apologize, reflect for a second, and move on.
+
+The social rules aren’t for punishing people. They help make RC a pleasant environment where you are free to be yourself, tackle things outside your comfort zone, and focus on programming.
+
+
+## Code of conduct
+
+The social rules don’t cover harassment or discrimination. For that, we have a separate [code of conduct](https://www.recurse.com/code-of-conduct) enforced by the RC faculty. All members of the RC community are expected to abide by our code of conduct.
+
+
+[^1]: As far as we know, [Miguel de Icaza](https://tirania.org/) coined the term _well-actually_.
+[^2]: It is ok to have these conversations in private or opt-in spaces (e.g. a `#feminism` channel on Slack). The goal is to make the default 2i2c experience free of outside -isms.

--- a/culture/social-rules.md
+++ b/culture/social-rules.md
@@ -75,7 +75,7 @@ The social rules aren’t for punishing people. They help make RC a pleasant env
 
 ## Code of conduct
 
-The social rules don’t cover harassment or discrimination. For that, we have a separate [code of conduct](https://www.recurse.com/code-of-conduct) enforced by the RC faculty. All members of the RC community are expected to abide by our code of conduct.
+The social rules don’t cover harassment or discrimination. For that, we have a separate [code of conduct](https://www.recurse.com/code-of-conduct) enforced by the 2i2c team members. All members of the 2i2c community are expected to abide by our code of conduct.
 
 
 [^1]: As far as we know, [Miguel de Icaza](https://tirania.org/) coined the term _well-actually_.

--- a/culture/social-rules.md
+++ b/culture/social-rules.md
@@ -70,7 +70,7 @@ There’s another part of _no subtle -isms:_ If you see racism, sexism, etc. out
 
 The social rules are lightweight. You should not be afraid of breaking a social rule. These are things that everyone does, and breaking one doesn’t make you a bad person. If someone says, "hey, you just feigned surprise," or "that’s subtly sexist," don’t worry. Just apologize, reflect for a second, and move on.
 
-The social rules aren’t for punishing people. They help make RC a pleasant environment where you are free to be yourself, tackle things outside your comfort zone, and focus on programming.
+The social rules aren’t for punishing people. They help make 2i2c a pleasant environment where you are free to be yourself, tackle things outside your comfort zone, and focus on programming.
 
 
 ## Code of conduct

--- a/index.md
+++ b/index.md
@@ -17,6 +17,13 @@ sre
 ```
 
 ```{toctree}
+:caption: 2i2c Culture
+:hidden:
+culture/code-of-conduct
+culture/social-rules
+```
+
+```{toctree}
 :caption: Team Coordination
 :hidden:
 team/tech/coordination


### PR DESCRIPTION
This adds a Code of Conduct for 2i2c spaces. It is heavily inspired by the [Recurse Center Code of Conduct](https://www.recurse.com/code-of-conduct), which I find to be a nice balance between online+physical spaces and open communities (e.g., it is more "big tent" than CoC's designed specifically for employees of an organization, and more "focused" than CoC's designed for gigantic open communities).

I've taken three documents from that CoC and made adaptations so that they are more appropriate for 2i2c spaces:

- Code of Conduct - the main CoC document
- Response process - the process we'll follow if a CoC report is made
- Social rules - rules that 2i2c community members _should follow_ but that are occasionally expected to break (unintentionally). These are more like guidelines than rules for Conduct Violations.

In addition, I've created a [Code of Conduct Reporting Form](https://docs.google.com/forms/d/10FAGD_DT9V7xdU2JMIESOPvfVjH8Q_j-wPKG_0uBgK8/edit) in our Slack. This form will send the Executive Director (me, currently) an email when it is submitted. However, it is available to all 2i2c team members.

I welcome any feedback, suggested changes, etc. I would like us to get this merged sooner than later, because we currently have no official CoC governing our community spaces (GitHub repositories, Slack, etc).

I think this is a Governance question, and thus **should require a vote from all Steering Council members**. We can discuss this at our next team meeting if need be.

# Questions

- This centralizes the reporting process on the Executive Director, do we want this?
- It includes in the Steering Council and and Director-level positions as people that can be part of reporting, is this acceptable to steerco members?

closes #https://github.com/2i2c-org/meta/issues/87