### PR TITLE
Adding updates to tech sync process

### DIFF
--- a/.github/ISSUE_TEMPLATE/team-update.md
+++ b/.github/ISSUE_TEMPLATE/team-update.md
@@ -5,7 +5,7 @@ labels: team-sync
 title: "Team Sync - {{ date | date('dddd, MMMM Do') }}"
 ---
 
-This is a @2i2c-org/tech-team sync 🎉🎉🎉! This is a way for 2i2c Team Members to triage work, point out issues that require attention, and make sure we are working well as a team.
+This is a @2i2c-org/tech-team sync 🎉🎉🎉! This is a way for 2i2c Team Members to triage work, point out issues that require attention, and make sure we are working well as a team. This issue will be closed in 24 hours.
 
 ### Team Goals
 

--- a/.github/ISSUE_TEMPLATE/team-update.md
+++ b/.github/ISSUE_TEMPLATE/team-update.md
@@ -15,9 +15,7 @@ See the [Team Goal label](https://github.com/2i2c-org/pilot-hubs/issues?q=is%3Ai
 
 These issues require attention quickly:
 
-- **New Hubs**: The [Needs Hub issues](https://github.com/2i2c-org/pilot-hubs/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22Needs+Hub%22) are new hubs that need deployments.
-- **Needs Triage**: The [Needs Triage issues](https://github.com/2i2c-org/pilot/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3Aneeds%3Atriage) require an initial assessment and labeling.
-- **Priority Issues**: The [Priority Label issues](https://github.com/2i2c-org/pilot-hubs/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3Apriority) are important and should be given attention over other issues.
+{GENERATE PROGRAMMATICALLY OR ADD HERE BY HAND}
 
 ### Team Updates
 

--- a/.github/ISSUE_TEMPLATE/team-update.md
+++ b/.github/ISSUE_TEMPLATE/team-update.md
@@ -2,7 +2,7 @@
 name: "🙌 Team sync"
 about: Syncronize the team's goals and actions
 labels: team-sync
-title: "Team Sync - [DATE]"
+title: "Team Sync - {{ date | date('dddd, MMMM Do') }}"
 ---
 
 This is a 2i2c Tech Team sync 🎉🎉🎉! This is a way for 2i2c Team Members to triage work, point out issues that require attention, and make sure we are working well as a team.

--- a/.github/ISSUE_TEMPLATE/team-update.md
+++ b/.github/ISSUE_TEMPLATE/team-update.md
@@ -5,7 +5,7 @@ labels: team-sync
 title: "Team Sync - {{ date | date('dddd, MMMM Do') }}"
 ---
 
-This is a 2i2c Tech Team sync 🎉🎉🎉! This is a way for 2i2c Team Members to triage work, point out issues that require attention, and make sure we are working well as a team.
+This is a @2i2c-org/tech-team sync 🎉🎉🎉! This is a way for 2i2c Team Members to triage work, point out issues that require attention, and make sure we are working well as a team.
 
 ### Team Goals
 
@@ -30,7 +30,7 @@ _Copy and paste these questions below, and answer them as you wish!_
 - So-and-so helped me out a lot with XXX...
 - Thanks for Jo's work on the XXX repo...
 
-**Updates from last two weeks ✔ **
+**Updates from last week ✔ **
 - I worked towards goal: <link-to-goal>
 - I merged issues XYZ
 - I had a meeting with ABC

--- a/.github/ISSUE_TEMPLATE/team-update.md
+++ b/.github/ISSUE_TEMPLATE/team-update.md
@@ -1,21 +1,47 @@
 ---
-name: Team updates
-about: Giving a team update
-title: "Tech Team Update: [DATE]"
-labels: team-process
+name: "🙌 Team sync"
+about: Syncronize the team's goals and actions
+labels: team-sync
+title: "Team Sync - [DATE]"
 ---
 
-Hey @2i2c-org/tech-team - time to fill in some updates about what you've been up to the last couple of weeks!
-Can folks fill out the [HackMD](https://hackmd.io/i2Siurp1TkmPYgn3ZgxFQw) with their own updates? ✨ 
+This is a 2i2c Tech Team sync 🎉🎉🎉! This is a way for 2i2c Team Members to triage work, point out issues that require attention, and make sure we are working well as a team.
 
-- **Updates HackMD**: https://hackmd.io/i2Siurp1TkmPYgn3ZgxFQw
-- **Team Sync history**: https://2i2c.org/team-compass/team/tech/sync/
+### Team Goals
 
-# ToDo
+See the [Team Goal label](https://github.com/2i2c-org/pilot-hubs/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3Agoal) for a list of team goals that we are currently working towards.
 
-- [ ] Clean up the [HackMD](https://hackmd.io/i2Siurp1TkmPYgn3ZgxFQw) for this update
-- [ ] Ping the team members in [`#tech-updates`](https://2i2c.slack.com/archives/C01GLCC1VCN)
-- [ ] Wait 2-3 days
-- [ ] Copy/paste into the `team-compass` repository
-- [ ] Clean up the HackMD
-- [ ] Link to new updates in `team-compass/` in [`#tech-updates`](https://2i2c.slack.com/archives/C01GLCC1VCN)
+### Issues Requiring attention
+
+These issues require attention quickly:
+
+- **New Hubs**: The [Needs Hub issues](https://github.com/2i2c-org/pilot-hubs/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22Needs+Hub%22) are new hubs that need deployments.
+- **Needs Triage**: The [Needs Triage issues](https://github.com/2i2c-org/pilot/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3Aneeds%3Atriage) require an initial assessment and labeling.
+- **Priority Issues**: The [Priority Label issues](https://github.com/2i2c-org/pilot-hubs/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3Apriority) are important and should be given attention over other issues.
+
+### Team Updates
+
+Please respond to this issue with your team update! That means anyone on the @2i2c-org/tech-team. Use the template below for your update.
+
+_Copy and paste these questions below, and answer them as you wish!_
+
+```
+**Thanks I'd like to give 🙌**
+- So-and-so helped me out a lot with XXX...
+- Thanks for Jo's work on the XXX repo...
+
+**Updates from last two weeks ✔ **
+- I worked towards goal: <link-to-goal>
+- I merged issues XYZ
+- I had a meeting with ABC
+
+**What I'm up to next ⬜**
+- I'd like to focus on goal <link-to-goal>
+- Developing on ABC feature
+- Focusing on XXX hubs
+
+**Links to items for discussion 💬**
+- I'm have a question about goal <link-to-goal>
+- Can @XXX give a comment on issue #NN ?
+- I opened #NN for discussion, please chime in
+```

--- a/.github/ISSUE_TEMPLATE/team-update.md
+++ b/.github/ISSUE_TEMPLATE/team-update.md
@@ -5,7 +5,7 @@ labels: team-sync
 title: "Team Sync - {{ date | date('dddd, MMMM Do') }}"
 ---
 
-This is a @2i2c-org/tech-team sync 🎉🎉🎉! This is a way for 2i2c Team Members to triage work, point out issues that require attention, and make sure we are working well as a team. This issue will be closed in 24 hours.
+This is a @2i2c-org/tech-team sync 🎉🎉🎉! This is a way for 2i2c Team Members to triage work, point out issues that require attention, and make sure we are working well as a team. This issue will be closed at the end of the day.
 
 ### Team Goals
 

--- a/.github/sync-requirements.txt
+++ b/.github/sync-requirements.txt
@@ -1,0 +1,3 @@
+nbclient
+ghapi
+ipython

--- a/.github/workflows/close-team-sync.yaml
+++ b/.github/workflows/close-team-sync.yaml
@@ -4,6 +4,8 @@ on:
   schedule:
   # Run every tuesday at 08:00 (which is Midnight California time)
   - cron: "00 08 * * 2"
+  workflow_dispatch:
+  
 jobs:
   close-sync-issue:
     runs-on: ubuntu-latest

--- a/.github/workflows/close-team-sync.yaml
+++ b/.github/workflows/close-team-sync.yaml
@@ -1,0 +1,14 @@
+# From https://github.com/marketplace/actions/close-matching-issues
+name: Close a weekly team sync issue
+on:
+  schedule:
+  # Run every tuesday at 08:00 (which is Midnight California time)
+  - cron: "00 08 * * 2"
+jobs:
+  close-sync-issue:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: lee-dohm/close-matching-issues@v2
+        with:
+          query: 'label:team-sync'
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/team-sync.yaml
+++ b/.github/workflows/team-sync.yaml
@@ -8,9 +8,18 @@ jobs:
   open-sync-issue:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: JasonEtco/create-an-issue@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          filename: .github/ISSUE_TEMPLATE/team-update.md
+    - uses: actions/checkout@v2
+
+    # Install dependencies
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+
+    - name: Install dependencies
+      run: |
+        pip install -r .github/sync-requirements.txt
+
+    - name: Post sync md
+      run: |
+        python scripts/post-team-sync.py

--- a/.github/workflows/team-sync.yaml
+++ b/.github/workflows/team-sync.yaml
@@ -1,5 +1,5 @@
 # From https://github.com/JasonEtco/create-an-issue
-name: Create an issue on push
+name: Open a weekly team sync issue
 on:
   schedule:
   # Run every monday at 00:00

--- a/.github/workflows/team-sync.yaml
+++ b/.github/workflows/team-sync.yaml
@@ -1,0 +1,16 @@
+# From https://github.com/JasonEtco/create-an-issue
+name: Create an issue on push
+on:
+  schedule:
+  # Run every monday at 00:00
+  - cron: "0 0 * * 1"
+jobs:
+  stuff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          filename: .github/ISSUE_TEMPLATE/team-update.md

--- a/.github/workflows/team-sync.yaml
+++ b/.github/workflows/team-sync.yaml
@@ -5,7 +5,7 @@ on:
   # Run every monday at 00:00
   - cron: "0 0 * * 1"
 jobs:
-  stuff:
+  open-sync-issue:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/conf.py
+++ b/conf.py
@@ -68,6 +68,7 @@ myst_enable_extensions = [
     "deflist",
     "linkify",
 ]
+myst_url_schemes = ["https:", "http:", "ftp:"]
 intersphinx_mapping = {
     "pi": ('https://2i2c.org/pilot', None),
     "ph": ('https://2i2c.org/pilot-hubs', None)

--- a/scripts/post-team-sync.py
+++ b/scripts/post-team-sync.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+# ---
+# jupyter:
+#   jupytext:
+#     formats: py:percent
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.10.3
+#   kernelspec:
+#     display_name: Python 3
+#     language: python
+#     name: python3
+# ---
+
+# %%
+from ghapi.all import GhApi
+from IPython.display import Markdown
+from textwrap import dedent
+from datetime import date
+
+# %%
+# Initialize the GH API and our markdown
+api = GhApi()
+md = ""
+
+# %% [markdown]
+# # New Hubs
+
+# %%
+issues = api.issues.list_for_repo("2i2c-org", "pilot-hubs", labels="Needs Hub")
+md += "**New Hubs**: _The [Needs Hub issues](https://github.com/2i2c-org/pilot-hubs/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22Needs+Hub%22) are new hubs that need deployments._\n"
+if issues:
+    md += "\n".join([f"* [{issue.title}]({issue.url})" for issue in issues])+ "\n\n"
+else:
+    md += "No new hubs to deploy! 🎉\n\n"
+
+# %% [markdown]
+# # Needs Triage
+
+# %%
+issues = api.issues.list_for_repo("2i2c-org", "pilot", labels="needs:triage")
+md += "**Needs Triage**: _The [Needs Triage issues](https://github.com/2i2c-org/pilot/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3Aneeds%3Atriage) require an initial assessment and labeling._\n"
+if issues:
+    md += "\n".join([f"* [{issue.title}]({issue.url})" for issue in issues])+ "\n\n"
+else:
+    md += "No issues need triage! 🎉\n\n"
+
+# %% [markdown]
+# # Priority issues
+
+# %%
+issues = api.issues.list_for_repo("2i2c-org", "pilot-hubs", labels="priority")
+md += "**Priority Issues**: _The [Priority Label issues](https://github.com/2i2c-org/pilot-hubs/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3Apriority) are important and should be given attention over other issues._\n"
+if issues:
+    md += "\n".join([f"* [{issue.title}]({issue.url})" for issue in issues])+ "\n\n"
+else:
+    md += "\nNo priority issues to tackle! 🎉\n\n"
+
+# %% [markdown]
+# # Display for demo
+
+# %%
+Markdown(md)
+
+# %% [markdown]
+# # Create an issue
+
+# %%
+# Grab our issue template
+from base64 import b64decode
+template = api.repos.get_content("2i2c-org", "team-compass", ".github/ISSUE_TEMPLATE/team-update.md")
+template = b64decode(template.content).decode("utf-8")
+template = template.replace("{GENERATE PROGRAMMATICALLY OR ADD HERE BY HAND}", md)
+
+# This removes the header bracketed by ---
+template = "---".join(template.split("---")[2:]).strip()
+
+# %%
+# Now create an issue with this content
+resp = api.issues.create("2i2c-org", "team-compass", title=f"Team Sync - {date.today():%b %d, %Y}", body=template, labels=["team-sync"])
+url = f"https://github.com/{resp.url.split('repos/')[-1]}"
+print(f"Finished posting team sync to {url} !")

--- a/team/tech/coordination.md
+++ b/team/tech/coordination.md
@@ -8,7 +8,7 @@ As a totally distributed team, it is important to have team practices that give 
 
 Every Monday, the 2i2c Hub Operations team conducts a team sync to get on the same page and coordinate their work for the week.
 
-1. **Create an issue using [the team sync issue template](https://github.com/2i2c-org/pilot-hubs/issues/new?assignees=&labels=team-sync&template=team-sync.md)**. This issue is our space to discuss, update, and sync.
+1. **Create an issue using [the team sync issue template](https://github.com/2i2c-org/team-compass/issues/new?assignees=&labels=team-sync&template=team-sync.md)**. This issue is our space to discuss, update, and sync.
 2. **Team members give their responses**. You can copy/paste the template, and then give your responses in comments to the issue. You shouldn't feel forced to add content if you can't think of anything, use it as much as is useful.
 3. **Discuss and agree on next steps for 48hrs**. The goal is to ensure that important issues have somebody paying attention to them, and that team members are supported in the goals they work towards. After 48 hours, we'll close the issue.
 

--- a/team/tech/coordination.md
+++ b/team/tech/coordination.md
@@ -10,7 +10,7 @@ Every Monday, the 2i2c Hub Operations team conducts a team sync to get on the sa
 
 1. **Create an issue using [the team sync issue template](https://github.com/2i2c-org/team-compass/issues/new?assignees=&labels=team-sync&template=team-sync.md)**. This issue is our space to discuss, update, and sync.
 2. **Team members give their responses**. You can copy/paste the template, and then give your responses in comments to the issue. You shouldn't feel forced to add content if you can't think of anything, use it as much as is useful.
-3. **Discuss and agree on next steps for 48hrs**. The goal is to ensure that important issues have somebody paying attention to them, and that team members are supported in the goals they work towards. After 48 hours, we'll close the issue.
+3. **Discuss and agree on next steps throughout the day**. The goal is to ensure that important issues have somebody paying attention to them, and that team members are supported in the goals they work towards. At the end of the day we'll close the issue.
 
 
 ```{note}

--- a/team/tech/coordination.md
+++ b/team/tech/coordination.md
@@ -8,7 +8,7 @@ As a totally distributed team, it is important to have team practices that give 
 
 Every Monday, the 2i2c Hub Operations team conducts a team sync to get on the same page and coordinate their work for the week.
 
-1. **Create an issue using [the team sync issue template]([https://](https://github.com/2i2c-org/pilot-hubs/issues/new?assignees=&labels=team-sync&template=team-sync.md))**. This is where we'll keep track of the "to-do" for the team sync.
+1. **Create an issue using [the team sync issue template](https://github.com/2i2c-org/pilot-hubs/issues/new?assignees=&labels=team-sync&template=team-sync.md)**. This issue is our space to discuss, update, and sync.
 2. **Team members give their responses**. You can copy/paste the template, and then give your responses in comments to the issue. You shouldn't feel forced to add content if you can't think of anything, use it as much as is useful.
 3. **Discuss and agree on next steps for 48hrs**. The goal is to ensure that important issues have somebody paying attention to them, and that team members are supported in the goals they work towards. After 48 hours, we'll close the issue.
 

--- a/team/tech/coordination.md
+++ b/team/tech/coordination.md
@@ -2,6 +2,22 @@
 
 As a totally distributed team, it is important to have team practices that give one another insight into what we're working on, identify opportunities to collaborate, and un-block one another. This page describes some of the practices that we adopt towards these goals.
 
+
+(coordination:team-syncs)=
+## Weekly team syncs
+
+Every Monday, the 2i2c Hub Operations team conducts a team sync to get on the same page and coordinate their work for the week.
+
+1. **Create an issue using [the team sync issue template]([https://](https://github.com/2i2c-org/pilot-hubs/issues/new?assignees=&labels=team-sync&template=team-sync.md))**. This is where we'll keep track of the "to-do" for the team sync.
+2. **Team members give their responses**. You can copy/paste the template, and then give your responses in comments to the issue. You shouldn't feel forced to add content if you can't think of anything, use it as much as is useful.
+3. **Discuss and agree on next steps for 48hrs**. The goal is to ensure that important issues have somebody paying attention to them, and that team members are supported in the goals they work towards. After 48 hours, we'll close the issue.
+
+
+```{note}
+While these syncs happen once a week, the process of communicating with team members and working on goals / issues / etc can be dynamic and constantly updating.
+The syncs are just to get everyone on the same page.
+```
+
 ## Our goals
 
 Here are the goals we optimize for in organizing our team coordination practices.
@@ -43,23 +59,6 @@ When opening a new issue in the 2i2c `pilot-hubs/` repository, first check if it
 
 We keep track of team goals via the [{guilabel}`goal` label in GitHub](https://github.com/2i2c-org/pilot-hubs/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3Agoal).
 
-
-(coordination:team-syncs)=
-## Bi-weekly team syncs
-
-Every other Monday, the 2i2c Hub Operations team conducts a team sync to get on the same page and coordinate their work for the week.
-
-1. **Create an issue in the [`team-compass`](https://github.com/2i2c-org/team-compass)**. This is where we'll keep track of the "to-do" for the team sync.
-2. **Clean up [the HackMD](https://hackmd.io/i2Siurp1TkmPYgn3ZgxFQw?both) for the sync**. We'll use [this HackMD](https://hackmd.io/i2Siurp1TkmPYgn3ZgxFQw?both) to run the team sync. At the top is a set of questions to answer, and we can We'll initially use the HackMD to give responses. You can create it from the following template:
-3. **Team members give their responses**. You can copy/paste the template, and then give your responses below. You shouldn't feel forced to add content if you can't think of anything, use it as much as is useful.
-4. **We'll leave the HackMD open for 48hrs**, not counting weekends or holidays. That should give enough time for those of us across many time zones to respond.
-5. **Merge into the [dev team sync notes](sync/index.md)**. This is where we'll store our sync notes for each team sync, and refer to them later.
-  
-
-```{note}
-While these syncs happen every two weeks, the process of communicating with team members and working on goals / issues / etc can be dynamic and constantly updating.
-The syncs are just to get everyone on the same page.
-```
 
 ## What about stuff that shouldn't be public?
 


### PR DESCRIPTION
This updates our team sync process in the following ways:

- Weekly instead of bi-weekly
- Uses updated github issue template instead of HackMD
- Updates the process describing this
- Adds a GitHub Action to open the weekly check-in on a CRON job

cc @GeorgianaElena @yuvipanda @consideRatio in case they have thoughts on whether this is a good approach!