### PR TITLE
adding governance scope to 2i2c document

### DIFF
--- a/about/structure.md
+++ b/about/structure.md
@@ -9,6 +9,7 @@ This page describes the major organizational structures of 2i2c, and how they re
 - All decisions made by the 2i2c Steering Council or Teams must abide by the policies of its host organization, {ref}`structure:icsi`.
 :::
 
+(structure:steerco)=
 ## Steering Council
 
 The Steering Council defines the mission, vision, and values of 2i2c. It also sets the strategic direction and priorities for 2i2c. The Steering Council provides oversight to the Executive Director of 2i2c and the Operations Team.
@@ -23,6 +24,7 @@ The Steering Council makes decisions via consensus (all members voting in the af
 The current Steering Council is [listed on the 2i2c website](https://2i2c.org/about/#steering-council).
 :::
 
+(structure:ed)=
 ## Executive Director
 
 The Executive Director oversees the execution of the mission and strategy provided by the Steering Council.
@@ -58,3 +60,44 @@ You can find a list of teams below.
 ## International Computer Science Institute (ICSI)
 
 [ICSI](https://icsi.berkeley.edu) is the host organization of 2i2c. It provides administrative and strategic resources for 2i2c and leadership to support them in their mission. ICSI supports 2i2c by assisting in managing partnerships with 2i2c collaborators and contracts with 2i2c customers, connecting with the larger open research and education community, fundraising, grant and financial management, assuming legal and financial risk for 2i2c, and hiring and management of staff.
+
+## Scope of governance
+
+There are several kinds of governance scopes within 2i2c, described below.
+
+### Decisions that require a full steering council vote
+
+The [Steering Council](structure:steerco) defines the strategy and major direction of 2i2c. It must vote on major decisions that have strong implications for 2i2c's strategy or financial well-being. See [the Steering Council structure page](structure:steerco) for information about how it votes.
+
+Here are some major decision areas that require a full steering council vote.
+
+- Unplanned financial decisions over $20,000 (e.g., deciding to hire a contractor that has not been written into a grant)
+- Decisions that have significant implication for 2i2c's financial health.
+- Major changes in strategic direction and roadmaps for business or technical development.
+- Changes to governance.
+- Hiring Director-level positions within the 2i2c org.
+- Defining salaries for Director-level positions within 2i2c.
+- Changes to the Code of Conduct.
+
+For other kinds of decisions, the [Executive Director](structure:ed) is given authority to decide.
+
+### Decisions that require notification, but not a vote
+
+These decisions are significant or public-facing, and would benefit from SC input, but do not require a vote to move forward.
+The Steering Council should be notified via the `@steering-council` handle, and discussion left open for a reasonable amount of time so that the SC has time to give input.
+Any SC member can request a vote on any of these topics if they believe it requires consensus.
+
+Here are some decisions that would require notification, but not a vote.
+
+- Significant public-facing changes to the 2i2c website.
+- Significant hiring decisions that were already planned.
+- Operational policy for 2i2c staff (unless they have major financial implications).
+- Decisions about grants to pursue and submit.
+- Operational decisions around the "Hubs as a Service" business, within the strategic plan defined by the Steering Council.
+
+### Decisions that do not require notification/consultation
+
+These are decisions that should be visible to the steering council, but not strictly required that they are consulted.
+
+- In general, decisions that are more about execution of pre-defined strategy/goals/plans, rather than _changing_ strategy, goals, and plans.
+- Any decision that doesn't fit in the above categories.


### PR DESCRIPTION
# Background

In https://github.com/2i2c-org/meta/issues/145 we discussed formalizing the scope of governance (AKA, what decisions lie solely with the steering council, what decisions can be delegated to the ED or others in the org). This is an attempt at formalizing these boundaries.

I think that because this PR is changing our governance, it requires a steering council vote! I will keep this in `Draft status` until folks are OK with the language, and then activate the PR to trigger a vote.

closes https://github.com/2i2c-org/meta/issues/145