### PR TITLE
adding github labels to team conventions

### DIFF
--- a/index.md
+++ b/index.md
@@ -31,6 +31,7 @@ practices/info-location
 practices/expectations
 practices/communication
 practices/coordination
+practices/github-conventions
 practices/team-compass
 ```
 

--- a/practices/communication.md
+++ b/practices/communication.md
@@ -15,9 +15,9 @@ By default, try to keep it async!
 For those who are doing daily work with 2i2c, we use [GitHub Discussions](https://docs.github.com/en/discussions) for our asynchronous conversation.
 There are a few different discussion forums depending on the kind of conversation you'd like to have:
 
-- General team discussion: [https://2i2c-org/team-compass/discussions](2i2c-org/team-compass/discussions)
-- Discussion specifically about the pilot hubs: [https://2i2c-org/pilot-hubs/discussions](2i2c-org/pilot-hubs/discussions)
-- Team discussion that needs to be private (this should be low-volume): [https://2i2c-org/meta/discussions](2i2c-org/meta/discussions)
+- General team discussion: [2i2c-org/team-compass/discussions](https://2i2c-org/team-compass/discussions)
+- Discussion specifically about the pilot hubs: [2i2c-org/pilot-hubs/discussions](https://2i2c-org/pilot-hubs/discussions)
+- Team discussion that needs to be private (this should be low-volume): [2i2c-org/meta/discussions](https://2i2c-org/meta/discussions)
 
 ### To-do items and deliverables
 

--- a/practices/github-conventions.md
+++ b/practices/github-conventions.md
@@ -1,6 +1,6 @@
 # GitHub repository conventions
 
-This page describes team 
+This page describes the use of GitHub Issue labels across the repositories within the 2i2c organization. 
 
 ## Issue labels
 

--- a/practices/github-conventions.md
+++ b/practices/github-conventions.md
@@ -7,6 +7,11 @@ This page describes team
 There are a few issue labels that we use to provide key metadata in our issues.
 These are added to all `2i2c-org/` repositories, and share the same meaning across each.
 
+:::{note}
+- Only **Issue Type** is required for all issues.
+- Repositories may define their own labels in addition to the ones described here for a given category, unless otherwise noted.
+:::
+
 ### Issue Type
 
 **REQUIRED**

--- a/practices/github-conventions.md
+++ b/practices/github-conventions.md
@@ -1,6 +1,6 @@
 # GitHub repository conventions
 
-This page describes the use of GitHub Issue labels across the repositories within the 2i2c organization. 
+This page describes some common conventions and patterns that we follow in our GitHub repositories.
 
 ## Issue labels
 
@@ -24,7 +24,6 @@ There are a few issue types that are defined for all repositories:
 - {badge}`type: enhancement, badge-info`: an improvement to be made to the repository.
 - {badge}`type: bug, badge-info`: something that is not working or incorrect in the repository.
 - {badge}`type: task, badge-info`: an action to take that is not well-categorized by enhancement/bug.
-- {badge}`type: goal, badge-info`: a high-level goal or outcome that we should work towards, with a specific completion criteria.
 
 In addition, other repositories may use repository-specific types, with the caveat that **all issues must still only have one `type` label**.
 
@@ -54,20 +53,3 @@ Here are some example tags:
 - {badge}`🏷: CI/CD,badge-warning`: related to continuous integration/deployment
 - {badge}`🏷: documentation,badge-warning`: related to data access functionality
 - {badge}`🏷: hub admin,badge-warning`: related to hub administrator functionality
-
-### Issue State
-
-**OPTIONAL**
-
-Issue state describes the current state of an issue, and implies the next action that must be taken in order to close it.
-Issue states are mutually-exclusive - there should not be more than one state label for an issue.
-Issues without a state label are assumed to be ready for implementation.
-
-There are a few issue states that are defined for all repositories:
-
-- {badge}`state: needs-info, badge-secondary`: the issue requires more information from the author in order to move forward. It may be closed after a few days of non-response.
-- {badge}`state: needs-discussion, badge-secondary`: the issue requires discussion and scoping from the team to create an actionable path.
-- {badge}`state: duplicate, badge-secondary`: the issue has already been reported. It may be closed with a link the the original issue.
-- {badge}`state: invalid, badge-secondary`: the reported problem cannot be reproduced, or the requested feature or task is not appropriate. It may be closed.
-- {badge}`state: upstream, badge-secondary`: resolution depends on actions of other 3rd party projects. It may be closed if necessary, or left open if needed for tracking.
-- {badge}`state: wontfix, badge-secondary`: determined to be a real issue, but for strong reasons the behavior will not be changed. It may be closed.

--- a/practices/github-conventions.md
+++ b/practices/github-conventions.md
@@ -1,0 +1,68 @@
+# GitHub repository conventions
+
+This page describes team 
+
+## Issue labels
+
+There are a few issue labels that we use to provide key metadata in our issues.
+These are added to all `2i2c-org/` repositories, and share the same meaning across each.
+
+### Issue Type
+
+**REQUIRED**
+
+Issue type determines the kind of issue and implies what sorts of actions must be taken to close it.
+Issue types are mutually-exclusive - there may only be one issue type per issue.
+
+There are a few issue types that are defined for all repositories:
+
+- {badge}`type: enhancement, badge-info`: an improvement to be made to the repository.
+- {badge}`type: bug, badge-info`: something that is not working or incorrect in the repository.
+- {badge}`type: task, badge-info`: an action to take that is not well-categorized by enhancement/bug.
+- {badge}`type: goal, badge-info`: a high-level goal or outcome that we should work towards, with a specific completion criteria.
+
+In addition, other repositories may use repository-specific types, with the caveat that **all issues must still only have one `type` label**.
+
+### Issue priority
+
+**OPTIONAL**
+
+Issue priority is used to classify some issues as requiring action before others.
+Any issue without a priority tag should be assumed as lower priority than {badge}`prio: low,badge-danger`.
+ 
+Here are the priority labels for our issues:
+
+- {badge}`prio: high, badge-danger`
+- {badge}`prio: medium, badge-danger`
+- {badge}`prio: low, badge-danger`
+
+### Issue tag
+
+**OPTIONAL**
+
+Tag labels provide hints about what topics that issue is relevant to.
+They are highly repository-specific, optional, and non-exclusive (so issues may have many tags associated with them).
+
+Here are some example tags:
+
+- {badge}`🏷: documentation,badge-warning`: related to documentation in a repository
+- {badge}`🏷: CI/CD,badge-warning`: related to continuous integration/deployment
+- {badge}`🏷: documentation,badge-warning`: related to data access functionality
+- {badge}`🏷: hub admin,badge-warning`: related to hub administrator functionality
+
+### Issue State
+
+**OPTIONAL**
+
+Issue state describes the current state of an issue, and implies the next action that must be taken in order to close it.
+Issue states are mutually-exclusive - there should not be more than one state label for an issue.
+Issues without a state label are assumed to be ready for implementation.
+
+There are a few issue states that are defined for all repositories:
+
+- {badge}`state: needs-info, badge-secondary`: the issue requires more information from the author in order to move forward. It may be closed after a few days of non-response.
+- {badge}`state: needs-discussion, badge-secondary`: the issue requires discussion and scoping from the team to create an actionable path.
+- {badge}`state: duplicate, badge-secondary`: the issue has already been reported. It may be closed with a link the the original issue.
+- {badge}`state: invalid, badge-secondary`: the reported problem cannot be reproduced, or the requested feature or task is not appropriate. It may be closed.
+- {badge}`state: upstream, badge-secondary`: resolution depends on actions of other 3rd party projects. It may be closed if necessary, or left open if needed for tracking.
+- {badge}`state: wontfix, badge-secondary`: determined to be a real issue, but for strong reasons the behavior will not be changed. It may be closed.


### PR DESCRIPTION
This is a proposal to adopt a standard set of issue labels across all of our repositories. It defines a few common categories and their meaning.

Note that the PR is not really strict about forcing repositories to use these labels (except for the `type:` label), but is mostly concerned with standardizing structure and meaning. In the future if this system makes sense, we can consider requiring more of them, but I think it's best to start out simple.

closes #92  