### PR TITLE
Time off for the team

### DIFF
--- a/practices/coordination.md
+++ b/practices/coordination.md
@@ -145,12 +145,28 @@ The 2i2c team uses [a shared Google Calendar](https://calendar.google.com/calend
 Everyone at 2i2c has access to it, and has the ability to add events to this calendar.
 
 **Use the Calendar to let the team know you're taking time off**.
-To do so, add an event to this calendar with a title like the following:
+Here are the reasons that you might do so:
+
+**Personal Time Off**: If you're taking personal time off (e.g., vacation, holidays, personal leave, etc), add an event to this calendar with a title to let others know you'll be away.
+
+For example:
 
 ```
 AWAY: <your name> - <optional reason>
 ```
 
-This should be done for any reason that you think you'll be away - vacation, holidays, personal leave, etc.
+**Reduced time**: If you expect to be on **reduced time** for an extended period, please use the calendar for this as well.
 
-In addition, please add any national holidays for your location of residence if you expect that you (or others in your location) may take time off for this as well.
+For example:
+
+```
+REDUCED: <your name> - <optional reason>
+```
+
+**Holidays**: Please add any national holidays for your location of residence if you expect that you (or others in your location) may take time off for this as well.
+
+For example:
+
+```
+HOLIDAY: <holiday name>
+```

--- a/practices/coordination.md
+++ b/practices/coordination.md
@@ -136,3 +136,21 @@ Here is the process for our team syncs.
 While these syncs happen once a week, the process of communicating with team members and working on tasks / deliverables can be dynamic and constantly updating.
 The syncs are just to get everyone on the same page.
 ```
+
+## Taking time off
+
+First and foremost, 2i2c fosters a culture of healthy balance between work and life. All 2i2c team members should take the time they need to thrive - this will both make you happier and help us accomplish our mission most effectively.
+
+The 2i2c team uses [a shared Google Calendar](https://calendar.google.com/calendar/u/2?cid=Y19pNTJqZGNhbTZ0M3FsaDF1NTNqdG42MjNwY0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t) to keep track of when team members will be away.
+Everyone at 2i2c has access to it, and has the ability to add events to this calendar.
+
+**Use the Calendar to let the team know you're taking time off**.
+To do so, add an event to this calendar with a title like the following:
+
+```
+AWAY: <your name> - <optional reason>
+```
+
+This should be done for any reason that you think you'll be away - vacation, holidays, personal leave, etc.
+
+In addition, please add any national holidays for your location of residence if you expect that you (or others in your location) may take time off for this as well.


### PR DESCRIPTION
This is a lightweight proposal for telling one another when we have expected time away or reduced time. Mostly, it is just "Use a shared team Google Calendar to tell others when you're away".

see https://github.com/2i2c-org/team-compass/discussions/82 for more discussion around this.