### PR TITLE
Adding code of conduct and decision-making structure

### DIFF
--- a/about/structure.md
+++ b/about/structure.md
@@ -9,20 +9,122 @@ This page describes the major organizational structures of 2i2c, and how they re
 - All decisions made by the 2i2c Steering Council or Teams must abide by the policies of its host organization, {ref}`structure:icsi`.
 :::
 
+(structure:steerco)=
 ## Steering Council
 
-The Steering Council defines the mission, vision, and values of 2i2c. It also sets the strategic direction and priorities for 2i2c. The Steering Council provides oversight to the Executive Director of 2i2c and the Operations Team.
+The Steering Council defines the mission, vision, and values of 2i2c. It also sets the strategic direction and priorities for 2i2c. The Steering Council provides oversight to the Executive Director of 2i2c and the Operations Team. The Steering Council group (`[steering-council@2i2c.org](mailto:steering-council@2i2c.org)`) is the only “official” way to communicate with others on the Steering Council.
 
-The Steering Council makes decisions via consensus (all members voting in the affirmative), and is restricted by the legal obligations and policies of ICSI. It uses the following process for these decisions:
+The Steering Council makes decisions via consensus (specifically, it strives for [rough consensus](https://tools.ietf.org/html/rfc7282)). It is restricted by the legal obligations and policies of ICSI, 2i2c's host organization.
 
-* Open an issue in the `meta/` GitHub repository using [the {guilabel}`decision` template](https://github.com/2i2c-org/meta/issues/new?assignees=&labels=decision&template=decision.md&title=%7B%7B+Decision+Summary+%7D%7D).
-* Have conversation around the decision in that issue. This may happen in the issue directly, or in ancillary issues, meetings, etc that are relevant. The decision issue should link to these relevant spaces.
-* Once everybody has voted, if all vote in favor, then the vote passes. If anyone votes against, the vote does not pass. Either way, note the decision in the issue, close it, and take necessary action.
+See the [Proposal process section](proposal-process) for information about how the Steering Council makes decisions and conducts discussion.
 
 :::{seealso}
 The current Steering Council is [listed on the 2i2c website](https://2i2c.org/about/#steering-council).
 :::
 
+(proposal-process)=
+### Proposal discussion and voting process
+
+The following sections describe our process for officially communicating and proposing changes to 2i2c policy with the Steering Council.
+
+#### How are proposals encoded?
+
+There are two major places where each proposal is encoded/tracked:
+
+- A Google Doc for the proposal language (and discussion). Each proposal should [follow this proposal template](https://docs.google.com/document/d/103B-WfaDte8PB1rfO86MHvYGCGrRJPm9Cbb0cPjq67k/edit?usp=sharing).
+- An Issue in a GitHub repository to track the “to-do” item of discussing the proposal. Cross-link the issue with the Google Doc.
+
+#### How do we discover and discuss proposals?
+
+We use the [Steering Council group](mailto:steering-council@2i2c.org) to describe and discuss all proposals.
+
+In addition:
+
+- The Executive Director of 2i2c should provide regular (e.g., weekly) updates to the Steering Council email about active proposals or proposals that are currently being discussed and/or voted on.
+- We maintain [a shared Google Calendar](https://calendar.google.com/calendar/u/2?cid=Y184ZmhrOXBtZmxocWM3OWI2bWY0dnEwYjlwc0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t) that contains voting dates as well as Steerco meeting dates.
+
+#### When does voting happen, and how long do we discuss?
+
+Proposals should be open for feedback and discussion for a minimum of 2 weeks. After 2 weeks, the proposal author may decide to call a vote (if necessary) or to accept and implement the proposal (if a vote is not required). Any Steering Council member may request that the discussion period be extended.
+
+Votes happen on either the first or the third week of the month. When a proposal is made, add 2 weeks to the date, then find the next voting day. This is the assumed day of the vote (or implementation, if a vote is not needed) unless requested otherwise by a steering council member.
+
+#### How does voting work?
+
+Votes are encoded in a table at the top of the document.
+
+For proposals that require a vote, we track the “stage” of the discussion at the top of the Google Doc. Once a proposal is in the “voting” stage (where people are recording their votes), the proposal should not substantively change. Steering Council members then put their votes in this table.
+
+#### How are proposals implemented?
+
+If a vote passes, or if a proposal does not require a vote and enough time has passed to move forward, we implement it via changes to the Team Compass. The actions that implement a policy should be linked to from the Google Doc.
+
+#### How are proposals archived?
+
+After a decision has been made about the proposal (regardless of whether a vote was needed), then take these steps:
+
+- If relevant, add links to any pull requests that implement the proposal (e.g., in the Team Compass).
+- Move the proposal [to the proposal archive](https://drive.google.com/drive/folders/1y0nxUPj_d2TJt388rD-ewt_08-UM2kGB?usp=sharing).
+ 
+:::{note}
+We do not yet have a policy about whether / how proposals should be made public.
+For now, the proposal archive is only available to 2i2c team members.
+:::
+
+#### What kind of changes must follow this process?
+
+Policy changes that require a steering council vote or notification must follow this process. See the [Proposal Guidelines](proposal-guidelines) below.
+
+(proposal-guidelines)=
+### Policies and guidelines for consulting the Steering Council
+
+The Steering Council provides valuable perspective and insight for strategic decisions of major importance. As such, the Executive Director should leverage the Steering Council by asking for its counsel on a regular basis, particularly for strategic and organizational matters.
+
+In addition to generally consulting the Steering Council when it is helpful, there are also some situations where the Executive Director _should_ or _must_ consult the Steering Council and/or get approval before moving forward. This section describes those scenarios.
+
+#### Decisions that require a full steering council vote
+
+The [Steering Council](https://2i2c-team-compass--61.org.readthedocs.build/en/61/about/structure.html#structure-steerco) defines the strategy and major direction of 2i2c. It must vote on major decisions that have strong implications for 2i2c’s strategy or financial well-being. See [the proposal process section](proposal-process) for information about how it votes.
+
+Here are some major decision areas that require a full steering council vote.
+
+- Unplanned financial decisions over $20,000 (e.g., deciding to hire a contractor that has not been written into a grant)
+- Decisions that have significant implication for 2i2c’s financial health.
+- Major changes in strategic direction and roadmaps for business or technical development.
+- Changes to governance.
+- Hiring Director-level positions within the 2i2c org.
+- Defining salaries for Director-level positions within 2i2c.
+- Changes to the Code of Conduct.
+
+For other kinds of decisions, the [Executive Director](structure:ed) is given authority to decide.
+
+#### Decisions that require notification, but not a vote
+
+These decisions are significant or public-facing, and would benefit from SC input, but do not require a vote to move forward. The Steering Council should be notified via the `@steering-council` handle, and discussion left open for a reasonable amount of time so that the SC has time to give input. Any SC member can request a vote on any of these topics if they believe it requires consensus.
+
+Here are some decisions that would require notification, but not a vote.
+
+- Significant public-facing changes to the 2i2c website.
+- Significant Human Resources (hiring, firing ,etc) decisions that were already planned.
+- Operational policy for 2i2c staff (unless they have major financial implications).
+- Decisions about grants to pursue and submit.
+- Operational decisions around the “Managed Hub Service” business, within the strategic plan defined by the Steering Council.
+
+#### Decisions that do not require notification/consultation
+
+These are decisions that should be visible to the steering council, but not strictly required that they are consulted.
+
+- In general, decisions that are more about execution of pre-defined strategy/goals/plans, rather than _changing_ strategy, goals, and plans.
+- Any decision that doesn’t fit in the above categories.
+
+:::{admonition} To Do
+These are items that we should clarify in future conversations:
+
+- Create a job description of the Executive Director position
+- Create an annual review process + subcommittee for the Executive Director
+:::
+
+(structure:ed)=
 ## Executive Director
 
 The Executive Director oversees the execution of the mission and strategy provided by the Steering Council.

--- a/code-of-conduct/index.md
+++ b/code-of-conduct/index.md
@@ -1,0 +1,125 @@
+(code-of-conduct)=
+# Code of Conduct
+
+Our goal is to create one of the best communities in the world for learning, using, and creating open infrastructure for interactive computing. Our mission is to build this community in a way that promotes fairness and justice for all - especially those from traditionally marginalized groups. This allows every member of our community to thrive and to make the biggest positive impact in their work and on others. Our Code of Conduct defines expected behavior and guidelines that help create such a community.
+
+Accordingly, anyone who participates in a 2i2c space is expected to show respect and courtesy to others in all interactions, whether in GitHub repositories, our Slack channel, in in-person events, when representing 2i2c in public, or in events and spaces associated with [ICSI](structure:icsi).
+
+To make sure that everyone has a common understanding of “show respect and courtesy to each other,” we have adopted the following code of conduct. The code of conduct is enforced by the [2i2c Executive Director](structure:ed) and [the Steering Council](structure:steerco).
+
+## Unacceptable behavior
+
+The following types of behavior are unacceptable in 2i2c spaces, both online and in-person, and constitute code of conduct violations.
+
+### Abusive behavior
+
+**Harassment**: including offensive verbal comments related to gender, sexual orientation, disability, physical appearance, body size, race, or religion, as well as sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, inappropriate physical contact, and unwelcome sexual or romantic attention.
+
+**Threats**: threatening someone physically or verbally. For example, threatening to publicize sensitive information about someone’s personal life.
+
+(coc:unwelcoming-behavior)=
+### Unwelcoming behavior
+
+**Blatant -isms**: saying things that assume negative characteristics in a blanket fashion because of identification with a particular group. This is especially true for -isms around traditionally marginalized groups (e.g., explicitly racist, sexist, homophobic, or transphobic statements) For example, arguing that some people are less intelligent because of their gender, race , religion. [Subtle -isms](social:subtle-isms) and small mistakes made in conversation are not code of conduct violations. However, repeating something after it has been pointed out to you that you broke a social rule, or antagonizing or arguing with someone who has pointed out your subtle -ism is considered unwelcoming behavior, and is not allowed at 2i2c.
+
+**Maliciousness towards other community members**: deliberately attempting to make others feel bad, name-calling, singling out others for derision or exclusion. For example, telling someone they’re not a real programmer or that they don’t belong at 2i2c. If somebody makes such a statement without malice, they may still be in violation of the Code of Conduct if their actions are deemed especially/repeatedly unpleasant (see below).
+
+**Being especially or repeatedly unpleasant**: for example, if we’ve received reports from multiple 2i2c users, team members, or collaborators of agitating, rude, or especially distracting behavior over an extended period of time.
+
+## Scope
+
+2i2c community members are held to the standards outlined in this code of conduct when interacting in the 2i2c Slack or GitHub repositories, when interacting in-person at events where they could represent 2i2c (this is most professional events), in physical spaces with other 2i2c team members or collaborators, or in any [`ICSI`](structure:icsi) space.
+
+In addition, the 2i2c community and experience often extends outside those spaces—2i2c community members may go on walks together to get lunch, attend meetups or conferences as a group, communicate on social media, or interact with each other in other communities. Abusive or unwelcoming behavior between community members still has a profound impact on individuals and on the community when it happens beyond our walls. The 2i2c Executive Director and the Steering Council will use our discretion when deciding whether to enforce this code of conduct and potentially remove someone from the 2i2c community after reports of such behavior happening outside of 2i2c, taking into account the impact on the individual community members involved as well as the impact on the community at large.
+
+The 2i2c Code of Conduct does not apply to interactions between users of a Managed JupyterHub, though we encourage leaders in those communities to adopt a Code of Conduct for their hub infrastructure. The Code of Conduct does apply to any interaction between a user of a Managed JupyterHub and a 2i2c Team Member.
+
+:::\{important}
+When in doubt, please [report unacceptable behavior](coc:reporting) to us. If someone’s behavior outside of a 2i2c space makes you feel unsafe at 2i2c, that is absolutely relevant and actionable for us.
+:::
+
+## Enforcement
+
+We’ve categorized unacceptable behavior into abuse and unwelcoming behavior in the section above.
+
+If we witness or receive a report about abusive behavior, we will contact the perpetrator to have a conversation with them and verify what has transpired. We will [follow this response protocol](response-protocol.md).
+
+If we verify abusive behavior, they will be removed from the 2i2c community and, if applicable, their employment with 2i2c will be terminated. Their Slack account will be deactivated, and permissions will be removed from any 2i2c-related repositories. They will not be welcome in any physical or digital spaces covered by the 2i2c Code of Conduct.
+
+If we verify unwelcome, but non-abusive behavior, we will have a conversation with the person so they understand the expectation that they not repeat the behavior or other behaviors that would violate the Code of Conduct a second time. See the follow-up protocol for more information.
+
+[This is the protocol](response-protocol.md) that 2i2c Executive Director and Steering Council members will use to respond to reports of code of conduct violations.
+
+```{toctree}
+response-protocol
+```
+
+(coc:reporting)=
+## Reporting
+
+If you see a violation of our code of conduct, please [report it to the 2i2c Code of Conduct Stewards](https://docs.google.com/forms/d/e/1FAIpQLSeKFuoghGzftqqgaa0xllZyocdUJsWZmoSaFFlerimg4n_Y8A/viewform?usp=sf_link).
+
+### Why should I report?
+
+- You are responsible for making 2i2c a safe and comfortable space for everyone. Everyone in our community shares this responsibility. 2i2c Team and Steering Council members are not around the online spaces or at 2i2c events all the time, so we cannot enforce the code of conduct without your help.
+- The consequences for the 2i2c community of not reporting bad behavior outweigh the consequences for one person of reporting it. We sometimes hear “I don’t want X person to meet consequences because I told someone about their bad behavior.” Consider the impact on everyone else at 2i2c of letting their behavior continue unchecked.
+- 2i2c only works as an open, participatory, community-driven community because of shared trust between community members. Reporting code of conduct violations helps us identify when this trust is broken, to prevent that from happening in the future.
+
+### Where and how to report
+
+Please report all code of conduct violations using [our reporting form](https://docs.google.com/forms/d/e/1FAIpQLSeKFuoghGzftqqgaa0xllZyocdUJsWZmoSaFFlerimg4n_Y8A/viewform?usp=sf_link). This is a short Google Form that will be sent to any Steering Council member acting as a Code of Conduct Steward (see below for details). Alternatively, if you wish to report to one of the Code of Conduct stewards specifically, email them directly.
+
+### Who responds to violation reports
+
+Any Steering Council members with the "Code of Conduct steward" role must monitor this reporting form. The minimal set of people that serve in this role are
+
+- The Executive Director
+- At least one other Steering Council member
+
+The people serving in these roles will be listed on the 2i2c website’s Steering Council page. Anyone with this role must have training in violation response.
+
+### Confidentiality
+
+We will keep all reports confidential, except if we've discussed with you and agreed otherwise. When we discuss incidents with people who are reported, we will anonymize details as much as we can to protect reporter privacy.
+
+However, some incidents happen in one-on-one interactions, and even if the details are anonymized, the reported person may be able to guess who made the report. If you have concerns about retaliation or your personal safety, and do not want us to share the details of your report with anyone (including the perpetrator) please let us know explicitly in your report. Unfortunately, in that situation we won't be able to conclude that an individual has violated the CoC based on this report alone..
+
+In some cases we may decide to share an update about a major incident with 2i2c team members, or with the entire 2i2c community. If that's the case, the identities of all victims and reporters will remain confidential unless those individuals instruct us otherwise.
+
+## Social rules
+
+In addition to having a code of conduct, we have four lightweight [social rules](social-rules.md). The social rules are different and separate from the code of conduct. They help us create a better environment by giving names to counterproductive behavior and acting as a release valve so that frustration doesn't build up over time. We understand and anticipate people to unintentionally break the social rules from time to time. Doing this doesn't make you a bad person or a bad community member. When this happens, it's not a big deal. Just apologize and move on.
+
+The enforcement provisions in this code of conduct do not apply to the social rules. We won't give you a strong warning or expel you from the 2i2c community just for breaking a social rule.
+
+If you have any questions about any part of the code of conduct or social rules, please reach out to [any 2i2c team member](https://2i2c.org/about/#our-team).
+
+```{toctree}
+social-rules
+```
+
+## How we developed the code of conduct
+
+We arrived at these policies by a combination of:
+
+- Listening to feedback and suggestions we've heard from open source communities over many years
+- Reading the codes of conduct of other organizations we find to be thoughtful (see some examples below)
+- Considering our experiences in other communities and projects in the past
+
+## Other things that don’t fit in to the code of conduct
+
+### When to seek help immediately
+
+Instead of filling out a code of conduct violation report, please contact law enforcement directly to report criminal activity (e.g. physical assault, sexual assault, theft), or to report a dangerous physical situation (e.g. fire, serious injury, fear that someone will hurt themselves or someone else).
+
+### Getting help
+
+If you or someone else at 2i2c is struggling and needs help, don’t hesitate to reach out to the 2i2c Executive Director and [Steering Council members](https://2i2c.org/about/#steering-council) in person or over email.
+
+## License
+
+The 2i2c code of conduct is available under the terms of the [CC0 license](https://creativecommons.org/share-your-work/public-domain/cc0/).
+
+Parts of it are based on the [Recurse Center Code of Conduct](https://www.recurse.com/code-of-conduct), the [Jupyter Code of Conduct](https://jupyter.org/governance/conduct/code_of_conduct.html), the [PyLadies Handbook](http://kit.pyladies.com/en/latest/organizer/difficult/responding.html), and the [example conference anti-harassment policy](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy) on the Geek Feminism Wiki, created by the Ada Initiative and other volunteers. It also takes inspiration from [projectinclude's guidelines for Codes of Conduct](https://projectinclude.org/writing_cocs).
+
+The Recurse Center Code of Conduct and the Geek Feminism conference anti-harassment policy are available under the terms of the CC0 license. The Project Jupyter Code of Conduct and the PyLadies handbook is available under the terms of the [Creative Commons Attribution 3.0 Unported License](https://creativecommons.org/licenses/by/3.0/).

--- a/code-of-conduct/response-protocol.md
+++ b/code-of-conduct/response-protocol.md
@@ -1,0 +1,33 @@
+(coc:response-protocol)=
+
+# CoC Report Response Protocol
+
+When a report is submitted through [the submission form](https://docs.google.com/forms/d/e/1FAIpQLSeKFuoghGzftqqgaa0xllZyocdUJsWZmoSaFFlerimg4n_Y8A/viewform?usp=sf_link), an email alert will be sent to the Code of Conduct Stewards of 2i2c.
+
+Within two business days of receiving an email alert, the Code of Conduct Stewards will:
+
+## Read the report to determine whether there has been a code of conduct violation
+
+- If not, they will reply to the reporter, explain that our code of conduct was not violated, and suggest other remediation options (e.g., meeting to get advice on how to resolve an interpersonal conflict).
+- If yes, the Director will determine whether they are the best person to respond to the situation, or if it is more appropriate to hand off the report to another Director or Steering Council member (for example, if someone else already has a relationship with the reporter or the accused).
+
+## Follow up with the reporter
+
+- We’ll email to acknowledge that we’ve received the report, and are taking action
+- We’ll ask any follow-up questions we need to better understand the situation
+- We’ll confirm that we can contact the accused individual
+
+(coc:reporting:follow-up)=
+
+## Follow up with the community member who violated our code of conduct
+
+- We will reach out to the community member over email, let them know that we’ve received a report of a code of conduct violation, and invite them to speak to us about the incident in person if possible, over video chat if not.
+- If the report was of abusive behavior, or the second report of unwelcoming behavior:
+  - During our meeting we will tell the community member we’re removing them from the community, and disable their accounts.
+- If the report was of unwelcoming behavior:
+  - We will explain how their behavior violates our code of conduct, and what we expect of them moving forward.
+  - We will warn them that a second code of conduct violation will result in them being removed from the 2i2c community.
+
+If the Director or Steering Council member someone finds a report of a code of conduct violation somewhere other than our reporting form (e.g. on Slack, in an anonymous note, or in-person), that person will fill out the reporting form with all the information they can, and then the same process described above will be followed.
+
+If a report is made anonymously without an email address provided for follow-up, or if the reporter indicates that they do not give us permission to act on their report, we will unfortunately not be able to take any action.

--- a/code-of-conduct/social-rules.md
+++ b/code-of-conduct/social-rules.md
@@ -1,0 +1,70 @@
+(social-rules)=
+# Social Rules
+
+2i2c has a few social rules. They help ensure that the 2i2c community lives up to [our values](https://2i2c.org/values/), which is a fundamental part of 2i2c’s mission. They also create a friendly, intellectual environment where you can spend as much of your energy as possible on interactive computing, open infrastructure, learning, discovery, and collaboration.
+
+The social rules are:
+
+- No well-actually’s
+- No feigning surprise
+- No backseat driving
+- No subtle -isms
+
+One thing that often confuses people about the social rules is that we expect people to break them from time to time. This means they’re different and totally separate from [our code of conduct](https://github.com/2i2c-org/team-compass/blob/1d1e71a38049307f1d47800a8589dd1fad367e4d/culture/code-of-conduct.md).
+
+## No well-actually’s
+
+> **Alice**: I just installed Linux on my computer!
+> 
+> **Bob**: It's actually called GNU/Linux.
+
+
+A well-actually is when you correct someone about something that’s not relevant to the conversation or tangential to what they’re trying to say. They’re bad because they aren’t helpful, break the flow of conversation, and focus attention on the person making the well actually.
+
+This rule can be a bit tricky because there isn’t a clear line between relevant to the conversation and not. Sometimes your correction might actually be necessary, and it could still come off as annoying when you make it. The best rule of thumb is, if you’re not sure whether something needs to be said right now, hold off and see what happens. You can always say it later if it turns out there’s no way for the conversation to move forward without your correction.
+
+## No feigning surprise
+
+> **Dan**: What's the command line?
+> 
+> **Carol**: Wait, you've never used the command line?
+
+Feigned surprise is when you act surprised when someone doesn’t know something. Responding with surprise in this situation makes people feel bad for not knowing things and less likely to ask questions in the future, which makes it harder for them to learn.
+
+_No feigning surprise_ isn’t a great name. When someone acts surprised when you don’t know something, it doesn’t matter whether they’re pretending to be surprised or actually surprised. The effect is the same: the next time you have a question, you’re more likely to keep your mouth shut. An accurate name for this rule would be _no acting surprised when someone doesn’t know something_, but it’s a mouthful, and at this point, the current name has stuck.
+
+## No backseat driving
+
+> **Bob**: What's the best tool for data science with tables?
+> 
+> **Alice**: NumPy.
+> 
+> **Eve**: _(from across the room)_ No, you should use Pandas. It's better.
+
+Backseat driving is when you lob advice from across the room (or across the online chat) without really joining or engaging in a conversation. Because you haven’t been participating in the conversation, it’s easy to miss something important and give advice that’s not actually helpful. Even if your advice is correct, it’s rude to bust into a conversation without asking. If you overhear a conversation where you could be helpful, the best thing to do is to ask to join.
+
+(social:subtle-isms)=
+
+## No subtle -isms
+
+> **Carol**: Windows is hard to use.
+> 
+> **Bob**: No way. Windows is so easy to use that even my mom can use it.
+
+Subtle -isms are subtle expressions that assume negative characteristics in a blanket fashion because of identification with a particular group. This is especially true for -isms around traditionally marginalized groups (e.g., subtly racist, sexist, homophobic, or transphobic statements). They are not as blatant as [Blatant -isms](coc:unwelcoming-behavior), and may not be intentional. They are small things that make others feel unwelcome, things that we all sometimes do by mistake. Subtle -isms make people feel like they don’t belong in the 2i2c community.
+
+Subtle -isms can also be things that you do instead of say. This includes things like boxing out the only woman at the whiteboard during a discussion or assuming someone isn’t a programmer because of their race or gender.
+
+The fourth social rule is more complicated than the others. Not everyone agrees on what constitutes a subtle -ism. Subtle -isms are baked into society in ways that can make them hard to recognize. And not everyone experiences subtle -isms in the same way: subtle homophobia won’t hurt someone who’s straight in the same way it hurts someone who’s gay. Subtle -isms can also be intersectional (for instance, statements that imply negative characteristics to a particular combination of race and gender) in ways that can multiply the harm.
+
+There’s another part of _no subtle -isms:_ If you see racism, sexism, etc. outside of 2i2c, please consider the welfare of marginalized groups in 2i2c spaces before bringing it in. It is important to make space for complex and difficult discussions relating to subtle -isms, but constant conversation about these topics - or publicly discussing particularly difficult or traumatic topics - can become exclusionary on its own. For example, people from oppressed groups often find discussions of racism, sexism, etc. particularly hard to tune out. Before bringing up these topics, consider their impact on other participants in 2i2c spaces, and consider whether to have them in “general” conversation spaces, or to create a private or “opt-in” space for this conversation. When in doubt, optimize for the welfare of marginalized groups in our spaces.
+
+## How do they work?
+
+The social rules are lightweight. Breaking one doesn’t make you a bad person. If someone says, "hey, you just feigned surprise," or "that’s subtly sexist," don’t worry. Just apologize, reflect for a second, and move on.
+
+The social rules aren’t for punishing people. They help make 2i2c a pleasant environment where everyone is free to be themselves, to tackle things outside their comfort zone, and to focus on creating, learning, and collaborating.
+
+## Code of conduct
+
+The social rules don’t cover harassment or discrimination. For that, we have a separate [code of conduct](https://www.recurse.com/code-of-conduct) enforced by the 2i2c Code of Conduct Stewards. All members of the 2i2c community are expected to abide by our code of conduct.

--- a/index.md
+++ b/index.md
@@ -55,6 +55,7 @@ Contains information about the 2i2c team and our projects, and some useful resou
 ```{toctree}
 :maxdepth: 1
 :caption: Team Reference
+code-of-conduct/index
 reference/projects
 reference/hubs
 reference/inspiration


### PR DESCRIPTION
This PR implements several proposals that were approved by the @2i2c-org/steering-council - specifically, it closes these issues:

- closes https://github.com/2i2c-org/meta/issues/170 (process for policy changes)
- closes https://github.com/2i2c-org/meta/issues/87 (code of conduct)
- closes https://github.com/2i2c-org/meta/issues/145 (when to consult the steerco)
- closes https://github.com/2i2c-org/meta/issues/182 (communication space for steerco)

As these proposals have already been discussed and voted on, we can't change the language significantly. However I'll leave this open for a little bit in case others have non-controversial improvements or suggestions.