### PR TITLE
Fix broken Hugo website link

### DIFF
--- a/practices/info-location.md
+++ b/practices/info-location.md
@@ -26,7 +26,7 @@ There are three main ways that 2i2c communicates with the outside world:
 - Newsletter: [using Mailchimp](https://mailchimp.com/)
   - Users sign up to the newsletter via our landing page's contact form at [2i2c.org#contact](https://2i2c.org#contact). Email addresses are imported into Mailchimp for the newsletter.
 - Blog: [2i2c.org/blog]
-  - The blog is managed by our [Hugo website repository](https://github.com/2i2c-org/2i2c.github.io). All new posts are automatically sent to the mailing list on a weekly basis.
+  - The blog is managed by our [Hugo website repository](https://github.com/2i2c-org/2i2c-org.github.io). All new posts are automatically sent to the mailing list on a weekly basis.
 
 ## Slack
 


### PR DESCRIPTION
I found a broken link to the Hugo website repository when going through the team-compass docs, this PR should fix it :)