### PR TITLE
Adding team calendar and monthly team meetings information

### DIFF
--- a/index.md
+++ b/index.md
@@ -58,6 +58,7 @@ Contains information about the 2i2c team and our projects, and some useful resou
 code-of-conduct/index
 reference/projects
 reference/hubs
+reference/calendar
 reference/inspiration
 reference/terminology
 meetings/eng/index

--- a/practices/coordination.md
+++ b/practices/coordination.md
@@ -48,7 +48,7 @@ There are two Project Backlogs at 2i2c:
 (coordination:deliverables)=
 ### Deliverables
 
-Deliverables represent incremental amounts of value we can deliver to a particular stakeholder, and should be completable in a week or two. 
+Deliverables represent incremental amounts of value we can deliver to a particular stakeholder, and should be completable in a week or two.
 
 Most issues in our repositories are deliverables, in varying states of readiness. When a deliverable is first created, it may lack information, be improperly scoped, or have an unclear path to implementation. We improve this through _deliverable refinement_ (see below).
 
@@ -136,6 +136,15 @@ Here is the process for our team syncs.
 While these syncs happen once a week, the process of communicating with team members and working on tasks / deliverables can be dynamic and constantly updating.
 The syncs are just to get everyone on the same page.
 ```
+
+## Monthly team meetings
+
+The 2i2c Team meets the **first Monday of each month** for two hours.
+This is an opportunity to speak face-to-face, discuss major issues and work items, and coordinate around our major next steps.
+
+We use [this HackMD for our team meeting notes and agenda](https://hackmd.io/Y5SBMxV7R6CMqzeTXgm5kA).
+
+See the [Team Calendar page](team/calendar) for information about when and where the meetings are held.
 
 ## Taking time off
 

--- a/reference/calendar.md
+++ b/reference/calendar.md
@@ -1,0 +1,7 @@
+(team/calendar)=
+# 2i2c Team Calendar
+
+Below is a calendar with some relevant events for the 2i2c Team and Community.
+You can find a [link to the team calendar here](https://calendar.google.com/calendar/embed?src=c_4hjjouojd8psql9i1a8nd1uff4%40group.calendar.google.com&ctz=America%2FLos_Angeles).
+
+<iframe src="https://calendar.google.com/calendar/embed?height=600&amp;wkst=1&amp;bgcolor=%23ffffff&amp;ctz=America%2FLos_Angeles&amp;src=Y180aGpqb3VvamQ4cHNxbDlpMWE4bmQxdWZmNEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t&amp;src=Y19pNTJqZGNhbTZ0M3FsaDF1NTNqdG42MjNwY0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t&amp;src=Y184ZmhrOXBtZmxocWM3OWI2bWY0dnEwYjlwc0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t&amp;color=%23009688&amp;color=%23616161&amp;color=%234285F4&amp;showTitle=0&amp;showPrint=0&amp;showTabs=0&amp;showCalendars=1" style="border:solid 1px #777" width="800" height="600" frameborder="0" scrolling="no"></iframe>


### PR DESCRIPTION
This PR adds a team calendar IFrame, as well as mentions monthly team meetings. We haven't quite settled on a meeting format/agenda/etc, so treat this as a proposal that we can iterate on.

related to #109 