### PR TITLE
Rename remote to distributed

### DIFF
--- a/get-started.md
+++ b/get-started.md
@@ -67,13 +67,13 @@ You can use this to begin participating in our daily activities and find out wha
 
 Check out the [projects page](reference/projects.md) for more information about the projects that 2i2c is working on.
 
-## Tips for working remotely
+## Tips for distributed working
 
-2i2c is a remote-first organization, and believes strongly in following practices that are inclusive, participatory, and collaborative. It has team members spread out over many time zones working on a variety of projects. There are many guides and tips for working remotely[^remote-work1], and we've tried to distill a few key components for our workflows:
+2i2c is a distributed organization, and believes strongly in following practices that are inclusive, participatory, and collaborative. It has team members spread out over many time zones working on a variety of projects. There are many guides and tips for distributed working[^distributed-work1], and we've tried to distill a few key components for our workflows:
 
 1. **Have a single source of truth**. For any information or projects in 2i2c, there should be one source of truth. Any conflicting information will defer to this source of truth, and it should be updated first and often. The default source of truth is this team compass, unless otherwise specified.
 
-2. **Document everything**. Documentation is the most important tool for coordinating and distributing information across remote teams. It is crucial that 2i2c team members document all relevant information about their projects, what they are working on, etc.
+2. **Document everything**. Documentation is the most important tool for coordinating and distributing information across distributed teams. It is crucial that 2i2c team members document all relevant information about their projects, what they are working on, etc.
 
 3. **Broadcast updates in multiple places**. Different people have different preferred methods of engagement and communication on 2i2c projects. For this reason, don't assume that posting an update or question in a single location will reach everybody that you wish to reach. Do not hesitate to post questions or ask for feedback in multiple places (e.g., GitHub, Slack, or even email). However, try to keep information in a single place to have a single source of truth.
 

--- a/practices/expectations.md
+++ b/practices/expectations.md
@@ -13,13 +13,13 @@ We are currently working on a Code of Conduct for 2i2c, but until it is complete
 ### Be communicative
 
 First and foremost, be communicative to other team members.
-2i2c is a remote-first organization, and it is crucial that we are open and up-front with one another.
+2i2c is a distributed organization, and it is crucial that we are open and up-front with one another.
 If there's any doubt, don't hesitate to ask someone, ideally in a public channel.
 If you are wondering whether somebody else needs to know something, assume that they do and tell them.
 
-### Be proactive 
+### Be proactive
 
-We are a remote-first organization, and this means that it is crucial that we work together to identify how to make the most impact.
+We are a distributed organization, and this means that it is crucial that we work together to identify how to make the most impact.
 2i2c generally do a combination of development, operations, and support for the infrastructure and projects that we work on.
 
 What you work on will depend on your role and potentially your funding source, but the important thing is that you are proactive in working with other team members to identify what you should work on next.

--- a/practices/info-location.md
+++ b/practices/info-location.md
@@ -68,4 +68,4 @@ We use the [GitHub bots](https://slack.github.com/) to track github issues that 
 
 [^sst1]: **References for Single Source of Truth**: For a few examples, see [this Bitergia post](https://blog.bitergia.com/2020/08/25/why-ospo-teams-need-a-single-source-of-truth/) and [the GitLab SSOT section](https://about.gitlab.com/handbook/values/#single-source-of-truth).
 
-[^remote-work1]: **References for Remote Work**: [The GitLab remote work guide](https://about.gitlab.com/company/culture/all-remote/guide/), [the future of work is written](https://increment.com/remote/future-of-work-is-written/), [RFCs as a management tool](https://buriti.ca/6-lessons-i-learned-while-implementing-technical-rfcs-as-a-management-tool-34687dbf46cb)
+[^distributed-work1]: **References for Distributed Work**: [The GitLab remote work guide](https://about.gitlab.com/company/culture/all-remote/guide/), [the future of work is written](https://increment.com/remote/future-of-work-is-written/), [RFCs as a management tool](https://buriti.ca/6-lessons-i-learned-while-implementing-technical-rfcs-as-a-management-tool-34687dbf46cb)

--- a/reference/terminology.md
+++ b/reference/terminology.md
@@ -5,5 +5,5 @@ Here are some helpful terms that we use at 2i2c.
 ```{glossary}
 Source of Truth
 Single Source of Truth
-  Remote teams and open communities need to balance information across team members, and ensure that everyone is on the same page. For this reason, it is recommended to adopt a "single source of truth" for anything important. This is an authoritative source that everyone can look to in order to know the current status and plan for anything we do at 2i2c.
+  Distributed teams and open communities need to balance information across team members, and ensure that everyone is on the same page. For this reason, it is recommended to adopt a "single source of truth" for anything important. This is an authoritative source that everyone can look to in order to know the current status and plan for anything we do at 2i2c.
 ```


### PR DESCRIPTION
This PR generally updates our team language to use the term "distributed" rather than "remote". As in, **2i2c is a distributed organization**, rather than **2i2c is a remote organization**.

Here are a few reasons for doing this:

- "remote" implies that there is a central home base from which others are remote
- "distributed" is more like an organizational strategy/philosophy ("our team is distributed"), whereas "remote" is often more about logistics ("I am working remotely today").

And [here is a nice post that discusses some of this](https://medium.com/walmartglobaltech/we-are-distributed-4c64ec6109f4).

What do folks think? Does this sound like a correct description of our team practices?