### PR TITLE
Adding roles to Managed JupyterHub Service

### DIFF
--- a/projects/managed-hubs/index.md
+++ b/projects/managed-hubs/index.md
@@ -1,4 +1,4 @@
-# The Managed JupyterHub Service
+# Managed JupyterHub Service
 
 The Managed JupyterHub Service is a special project that is run by 2i2c.
 It is an ongoing service, and thus is less development-oriented than projects that are funded by grants and collaborations.

--- a/projects/managed-hubs/index.md
+++ b/projects/managed-hubs/index.md
@@ -15,6 +15,8 @@ This is both the deployment infrastructure for the 2i2c JupyterHubs, as well as 
 
 **User Documentation** is located in [the `pilot/` repository](https://github.com/2i2c-org/pilot). This contains user-facing information about the Pilot Hubs, such as how they can add/remove users, update their environment, get support, etc.
 
+**Information about the Managed Hubs Pilot** is located within sub-sections below.
+
 ## A list of running JupyterHubs
 
 We keep a table with all of our currently-running JupyterHubs at this location: [List of Running JupyterHubs](https://pilot-hubs.2i2c.org/en/latest/reference/hubs.html).
@@ -27,4 +29,5 @@ We keep a table with all of our currently-running JupyterHubs at this location: 
 ```{toctree}
 pricing.md
 sales.md
+roles.md
 ```

--- a/projects/managed-hubs/roles.md
+++ b/projects/managed-hubs/roles.md
@@ -1,0 +1,26 @@
+# Roles for the Managed JupyterHub Service
+
+There are a few major roles that we define for the Managed JupyterHub Service.
+These are outlined below.
+
+:::{seealso}
+They are also described in [the Hub Services diagrams slideshow](https://docs.google.com/presentation/d/1kqrviwVOoZfey_rujhIasdkKZmlYgxV-1J2AG-nr3VY/edit#slide=id.ge3f2127292_0_573) as well as in the [Managed Service Plan](https://docs.google.com/document/d/1Ka7tgJe7HR8EmS_MMakrYztgfkJT_iFksPsWHdQBqhM/edit?usp=sharing).
+:::
+
+Hub Community
+: The community of practice that a Managed JupyterHub serves.
+  This includes leadership of the community as well as users of the hub.
+Community Representative
+: The Community Representative is the main point of contact between the hub engineer and the users on a hub.
+  They are the primary escalation pathway when issues arise that can not be debugged on their own, or for customization requests that require an engineer.
+  This person is usually part of the community that uses the hub.
+Hub Administrators
+: Hub Administrators have special status and permissions on a hub.
+  They are able to add users, start/stop servers, and generally have more control over operations on the hub.
+  When a new hub is deployed, the Community Representative is added as a Hub Administrator, along with 2i2c Engineers.
+  The Community Representative may then add other users as administrators if they wish.
+Hub Engineer
+: Keeps a hub running from day to day.
+  The hub engineer is the first wave of defense when a Community Representative has determined that something is technically wrong on the hub infrastructure.
+  They also perform development and upgrades on hub infrastructure.
+  This person is generally employed by 2i2c.

--- a/projects/managed-hubs/roles.md
+++ b/projects/managed-hubs/roles.md
@@ -1,4 +1,4 @@
-# Roles for the Managed JupyterHub Service
+# Roles for the service
 
 There are a few major roles that we define for the Managed JupyterHub Service.
 These are outlined below.
@@ -10,15 +10,18 @@ They are also described in [the Hub Services diagrams slideshow](https://docs.go
 Hub Community
 : The community of practice that a Managed JupyterHub serves.
   This includes leadership of the community as well as users of the hub.
+
 Community Representative
 : The Community Representative is the main point of contact between the hub engineer and the users on a hub.
   They are the primary escalation pathway when issues arise that can not be debugged on their own, or for customization requests that require an engineer.
   This person is usually part of the community that uses the hub.
+
 Hub Administrators
 : Hub Administrators have special status and permissions on a hub.
   They are able to add users, start/stop servers, and generally have more control over operations on the hub.
   When a new hub is deployed, the Community Representative is added as a Hub Administrator, along with 2i2c Engineers.
   The Community Representative may then add other users as administrators if they wish.
+
 Hub Engineer
 : Keeps a hub running from day to day.
   The hub engineer is the first wave of defense when a Community Representative has determined that something is technically wrong on the hub infrastructure.


### PR DESCRIPTION
This adds a page with definitions for "Roles in a Managed JupyterHub". It defines these roles:

- Hub Community
- Community Representative
- Hub Administrators
- Hub Engineer
