### PR TITLE
Add GHA to archive old cards

### DIFF
--- a/.github/ISSUE_TEMPLATE/meeting-deliverables.md
+++ b/.github/ISSUE_TEMPLATE/meeting-deliverables.md
@@ -18,6 +18,8 @@ Our goal is to synchronize the team on the most important things to work on, and
 
 _Follow the agenda below, checking boxes as we complete each step._
 
+- [ ] Activity Backlog Done items have been cleared. ([run action here](https://github.com/2i2c-org/team-compass/actions/workflows/archive-old-cards.yaml))
+
 ### Activity Backlog
 _(5m) Quick review of [Activity Backlog](https://github.com/orgs/2i2c-org/projects/5?fullscreen=true) to let team members signal-boost if needed._
 

--- a/.github/requirements.txt
+++ b/.github/requirements.txt
@@ -2,3 +2,4 @@
 ghapi
 ipython
 pyyaml
+pandas

--- a/.github/requirements.txt
+++ b/.github/requirements.txt
@@ -3,3 +3,4 @@ ghapi
 ipython
 pyyaml
 pandas
+rich

--- a/.github/workflows/archive-old-cards.yaml
+++ b/.github/workflows/archive-old-cards.yaml
@@ -4,10 +4,7 @@ description: |
   are moved to an "archive" column, and cards from two cycles ago are
   "Archived" entirely (so they are not visible)
 on:
-  schedule:
-  # Run every 1st and 15th day of the month
-  - cron: "0 0 1,15 * *"
-
+  # We'll only run this manually since cleaning the Activity Board is part of the deliverables meeting. 
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/archive-old-cards.yaml
+++ b/.github/workflows/archive-old-cards.yaml
@@ -1,0 +1,33 @@
+name: Update Activity Archive
+description: |
+  This action updates the activity archive so that cards finished in the last cycle
+  are moved to an "archive" column, and cards from two cycles ago are
+  "Archived" entirely (so they are not visible)
+on:
+  schedule:
+  # Run every 1st and 15th day of the month
+  - cron: "0 0 1,15 * *"
+
+  workflow_dispatch:
+
+jobs:
+  open-sync-issue:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    # Install dependencies
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+
+    - name: Install dependencies
+      run: |
+        pip install -r .github/requirements.txt
+
+    - name: Post sync md
+      env:
+        ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+      run: |
+        python scripts/archive-old-cards.py

--- a/scripts/archive-old-cards.py
+++ b/scripts/archive-old-cards.py
@@ -1,6 +1,12 @@
 from datetime import date
 from datetime import timedelta
 import pandas as pd
+from ghapi.all import GhApi
+from urllib.parse import quote
+from rich.console import Console
+
+console = Console()
+api = GhApi()
 
 project = "12135611"  # This is the Active board
 
@@ -10,19 +16,25 @@ archive_column = "14245354"  # Archive column on Activity Board
 today = pd.to_datetime(date.today())
 
 # Actually archive everything in the archive column so it's invisible
-four_weeks_ago = today.date() - timedelta(days=28)
+clear_archive_after_days = 28
+archive_clear_cutoff = today.date() - timedelta(days=clear_archive_after_days)
 archive_visible_cards = api.projects.list_cards(archive_column, archived_state="not_archived", per_page=100)
+console.log("Moving visible cards to archive...")
 for card in archive_visible_cards:
     # Archive entirely after 4 weeks since that is 2 cycles ago
-    older_than_four_weeks = four_weeks_ago > pd.to_datetime(card['updated_at']).date()
+    older_than_four_weeks = archive_clear_cutoff > pd.to_datetime(card['updated_at']).date()
     if older_than_four_weeks:
         api.projects.update_card(card['id'], archived=True)
 
 # Move cards in "Done" to "Archive"
-two_weeks_ago = today.date() - timedelta(days=14)
+archive_after_days = 14
+archive_cutoff = today.date() - timedelta(days=archive_after_days)
 finished_cards = api.projects.list_cards(done_column, per_page=100)[::-1]
+console.log("Clearning old cards in archive...")
 for card in finished_cards:
     # Move from Done to Archive after 2 weeks since it's now time for a new cycle
-    older_than_two_weeks = two_weeks_ago > pd.to_datetime(card['updated_at']).date()
+    older_than_two_weeks = archive_cutoff > pd.to_datetime(card['updated_at']).date()
     if older_than_two_weeks:
         api.projects.move_card(card['id'], "top", int(archive_column))
+
+console.log("Finished cleaning up activity board!")

--- a/scripts/archive-old-cards.py
+++ b/scripts/archive-old-cards.py
@@ -1,0 +1,28 @@
+from datetime import date
+from datetime import timedelta
+import pandas as pd
+
+project = "12135611"  # This is the Active board
+
+# Iterate through cards and move them to the new column so Done is clear
+done_column = "13714268"  # Done column on the Activity Board
+archive_column = "14245354"  # Archive column on Activity Board
+today = pd.to_datetime(date.today())
+
+# Actually archive everything in the archive column so it's invisible
+four_weeks_ago = today.date() - timedelta(days=28)
+archive_visible_cards = api.projects.list_cards(archive_column, archived_state="not_archived", per_page=100)
+for card in archive_visible_cards:
+    # Archive entirely after 4 weeks since that is 2 cycles ago
+    older_than_four_weeks = four_weeks_ago > pd.to_datetime(card['updated_at']).date()
+    if older_than_four_weeks:
+        api.projects.update_card(card['id'], archived=True)
+
+# Move cards in "Done" to "Archive"
+two_weeks_ago = today.date() - timedelta(days=14)
+finished_cards = api.projects.list_cards(done_column, per_page=100)[::-1]
+for card in finished_cards:
+    # Move from Done to Archive after 2 weeks since it's now time for a new cycle
+    older_than_two_weeks = two_weeks_ago > pd.to_datetime(card['updated_at']).date()
+    if older_than_two_weeks:
+        api.projects.move_card(card['id'], "top", int(archive_column))


### PR DESCRIPTION
This is a short script that uses `ghapi` to archive old cards in our Finished Card Archive. The goal of automating this is to ensure that:

1. The "Done" column reflects the work we've done in our most recent efforts (since it's useful to know what you've worked on over the last two weeks or so.
2. The "Archive" column has the cards from 4 weeks ago for reference, and afterwards those cards are cleaned from the board.

I wanted it to run every 2 weeks on Monday, but I couldn't figure out the CRON expression for this that wouldn't be super complicated 😬 

closes https://github.com/2i2c-org/team-compass/issues/190