### PR TITLE
Add section on sops and secrets

### DIFF
--- a/practices/index.md
+++ b/practices/index.md
@@ -37,6 +37,7 @@ The syncs are just to get everyone on the same page.
 ```{toctree}
 communication
 development
+secrets
 cloud-access
 meetings
 github-conventions

--- a/practices/secrets.md
+++ b/practices/secrets.md
@@ -2,7 +2,7 @@
 
 This section describes how 2i2c team members share and access sensitive credentials that allow permissions on our infrastructure and services.
 
-## Location of information
+## Where are secrets located?
 
 **For more services**: Our team tries to use services that allow for multi-user authorization.
 This means we try to use services where team members have their own account with permissions on the service, so no secrets need be shared (for example, GitHub organizations).
@@ -10,6 +10,7 @@ This means we try to use services where team members have their own account with
 **When we must share secrets**: If we must share secrets for an account (for example, credentails for deployment to cloud infrastructure), then we use [the command-line tool `sops`](https://github.com/mozilla/sops) to encrypt our secrets.
 See below for information about how to use `sops`.
 
+(secrets:sops)=
 ## `sops` overview
 
 [`sops`](https://github.com/mozilla/sops) is a command-line tool for encrypting and decrypting secrets that are on disk.
@@ -43,8 +44,8 @@ As you can see, we have access to the **key names** but the **values are encrypt
 Some information about which encryption key `sops` uses to encrypt/decrypt the secret is also stored under the top-level `sops` JSON key.
 In the next section we'll cover how to unencrypt this file.
 
-(secrets:sops)=
-### Use `sops` to decrypt secrets
+(secrets:sops:setup)=
+### Set up `sops`
 
 To use `sops` with a 2i2c configuration file, follow these steps:
 
@@ -54,15 +55,38 @@ To use `sops` with a 2i2c configuration file, follow these steps:
    [Follow the Google Cloud instructions](https://cloud.google.com/sdk/docs/install) to do so.
 3. **Set up the Google Cloud Key Management Service (KMS)**. This allows you to use your Google Cloud login to provide authentication for `sops`.
    [Follow the `sops` instructions to use KMS](https://github.com/mozilla/sops/#encrypting-using-gcp-kms).
-4. **Decrypt the secrets file**. Once you've set up KMS, you should be able to decrypt the file with `sops`.
-   Run the following command, and you should see the secret values printed on your screen:
+
+To confirm that `sops` has been set up properly, try encrypting or decrypting a configuration file per the sections below.
+
+### Decrypt secrets with `sops`
+
+In order to decrypt an encrypted configuration file, you should first follow the instructions in [](secrets:sops:setup).
+Once you've completed those steps, do the following:
+
+1. **Navigate to the root of the repository**.
+   There are a set of rules stored in [`.sops.yaml`](https://github.com/2i2c-org/pilot-hubs/blob/master/.sops.yaml) that use regex to match a file to be encrypted with the encryption key location.
+   You will receive an error from `sops` if you are not in the root folder and it cannot see this file.
+2. **Run the `sops` command**.
+   The following command will decrypt a configuration file (in this case, the configuration file in the `pilot-hubs` repository):
 
    ```bash
-   sops --decrypt --in-place path/to/config/secrets.yaml
+   sops --decrypt config/secrets.yaml
    ```
 
-```{note}
-Make sure to run `sops` from the root of the repository.
-There are a set of rules stored in [`.sops.yaml`](https://github.com/2i2c-org/pilot-hubs/blob/master/.sops.yaml) that use regex to match a file to be encrypted with the encryption key location.
-You will receive an error from `sops` if you are not in the root folder and it cannot see this file.
-```
+   :::{margin}
+   You can also use the `-d` flag instead of `--decrypt`.
+   :::
+
+   You should see the **decrypted configuration file** printed to `stdout`.
+
+   :::{admonition} Decrypt the file in-place
+   If you'd like to decrypt a configuration file in-place, use the `--in-place` or `-i` flag.
+   This will **overwrite** the configuration file with a decrypted version.
+   :::
+
+### Learn more about `sops`
+
+For more information about using `sops`, here are a few links to `sops` documentation:
+- [Basic usage of `sops`](https://github.com/mozilla/sops#usage)
+- [Encrypting files with GCP KMS](https://github.com/mozilla/sops#encrypting-using-gcp-kms)
+- [Common examples with `sops`](https://github.com/mozilla/sops#examples).a

--- a/practices/secrets.md
+++ b/practices/secrets.md
@@ -40,6 +40,7 @@ sops:
 ```
 
 As you can see, we have access to the **key names** but the **values are encrypted**.
+Some information about which encryption key `sops` uses to encrypt/decrypt the secret is also stored under the top-level `sops` JSON key.
 In the next section we'll cover how to unencrypt this file.
 
 (secrets:sops)=
@@ -49,6 +50,7 @@ To use `sops` with a 2i2c configuration file, follow these steps:
 
 1. **Set up `sops`**. To do so, [follow the `sops` download and install instructions here](https://github.com/mozilla/sops/#1download).
 2. **Set up the Google Cloud SDK**. We use Google Cloud to provide the authentication for `sops`, and this is managed by the `gcloud` command-line tool.
+   You will need access to the `two-eye-two-see` Google project in order to access the `sops` encryption keys.
    [Follow the Google Cloud instructions](https://cloud.google.com/sdk/docs/install) to do so.
 3. **Set up the Google Cloud Key Management Service (KMS)**. This allows you to use your Google Cloud login to provide authentication for `sops`.
    [Follow the `sops` instructions to use KMS](https://github.com/mozilla/sops/#encrypting-using-gcp-kms).
@@ -56,7 +58,10 @@ To use `sops` with a 2i2c configuration file, follow these steps:
    Run the following command, and you should see the secret values printed on your screen:
 
    ```bash
-   sops --decrypt path/to/config/secrets.yaml
+   sops --decrypt --in-place path/to/config/secrets.yaml
    ```
 
-
+```{note}
+Make sure to run `sops` from the root of the repository.
+There are a set of rules stored in [`.sops.yaml`](https://github.com/2i2c-org/pilot-hubs/blob/master/.sops.yaml) that use regex to match a file to be encrypted with the encryption key location.
+You will receive an error from `sops` if you are not in the root folder and it cannot see this file.

--- a/practices/secrets.md
+++ b/practices/secrets.md
@@ -65,3 +65,4 @@ To use `sops` with a 2i2c configuration file, follow these steps:
 Make sure to run `sops` from the root of the repository.
 There are a set of rules stored in [`.sops.yaml`](https://github.com/2i2c-org/pilot-hubs/blob/master/.sops.yaml) that use regex to match a file to be encrypted with the encryption key location.
 You will receive an error from `sops` if you are not in the root folder and it cannot see this file.
+```


### PR DESCRIPTION
I was trying to debug the COESSING Grafana and realized I didn't have the password. I needed to get `sops` set up locally, and so used the opportunity to document the process a bit more thoroughly with some extra explanation.

This slightly duplicates content [in the pilot hubs docs](https://pilot-hubs.2i2c.org/en/latest/reference/tools.html?highlight=sops#sops) - perhaps we should cross link that one to here?

# Tasks

- [x] Consolidate and cross-link from other docs as well