### PR TITLE
Updates to projects/strategy and links to proper pages

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -31,6 +31,7 @@ extensions = [
     "myst_parser",
     "sphinx_panels",
     "sphinx_copybutton",
+    "sphinx.ext.intersphinx",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/index.md
+++ b/index.md
@@ -50,16 +50,6 @@ meetings/eng/index
 reference/calendar
 ```
 
-## Major Projects
-
-Information about major efforts currently underway at 2i2c.
-
-```{toctree}
-:caption: 2i2c Projects
-projects/index
-projects/managed-hubs/index
-```
-
 ## About 2i2c
 
 Information about the broader 2i2c organization, as well as its mission and structure.
@@ -69,6 +59,7 @@ Information about the broader 2i2c organization, as well as its mission and stru
 :caption: About 2i2c
 
 about
+projects/index
 about/structure
 about/strategy
 positions

--- a/projects/index.md
+++ b/projects/index.md
@@ -9,32 +9,29 @@ In general, projects should have:
 1. A name / description
 2. A location where deliverables and tasks are being tracked.
 
-:::{seealso}
-The Managed JupyterHub Service is a special ongoing project of 2i2c.
-See [](managed-hubs/index.md) for information about it.
-:::
-
 ## 2i2c organizational launch
 
 As 2i2c is quite young, it must first build an organizational foundation for itself.
 This is an ongoing effort to define structure, process, and governance of 2i2c so that it can grow and execute on its mission.
 
-**Tracking deliverables**
+:::{admonition} Tracking deliverables
+The [organizational foundation project](https://github.com/orgs/2i2c-org/projects/11) contains a list of deliverables we are currently working towards.
+:::
 
-There are a few places to track this project:
+- **Strategy** - We must define a long-term vision for 2i2c, and high-level strategy for executing on that vision.
+- **Governance** - We must define how decision get made within 2i2c at all levels of the organization.
+- **Organizational policy** - We must define our early organizational policy, culture, and core documents like a Code of Conduct.
+- **Administration** - We need an administrative infrastructure to carry out 2i2c's organizational needs. This includes its legal status, hiring/contracting, and invoicing. 
+- **Public materials** - In order to gain recognition, we need to build public-facing materials and documentation. This includes websites and social media handles, early branding, and documentation.
 
-- [Issues in the 2i2c meta repository](https://github.com/2i2c-org/meta/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc) often contain actionable items towards this project.
-- The [organizational projects backlog](https://github.com/orgs/2i2c-org/projects/11) contains a list of deliverables we are currently working towards.
+## Managed Hub Service launch
 
-## Launch of the Managed JupyterHub Service
+The Managed JupyterHub Service is a special project of 2i2c that is [developed and described at this website](managed-hubs/index.md).
 
-The Managed JupyterHub Service is an ongoing special project, with the goal of sustaining itself and providing JupyterHub infrastructure to others in research and education.
-
-**Tracking deliverables**
-
-Since most of the [hubs we run](https://pilot-hubs.2i2c.org/en/latest/reference/hubs.html) are
-managed out of the [2i2c-org/pilot-hubs](https://github.com/2i2c-org/pilot-hubs) repository,
-deliverables are tracked in that repository as well.
+:::{admonition} Tracking deliverables
+- [the high level goals and strategy are described here](https://pilot.2i2c.org/en/latest/about/strategy.html)
+- [the roadmap for the service is described here](https://pilot.2i2c.org/en/latest/about/roadmap.html)
+:::
 
 (projects:jmte-pangeo)=
 ## Pangeo Hub Infrastructure development
@@ -42,26 +39,26 @@ deliverables are tracked in that repository as well.
 The Pangeo project has considerable needs in both operating and developing hub infrastructure for their community.
 We are collaborating with them to provide both daily operations of their hubs, as well as help them in evolvin and improving their infrastructure to better-suit their scientific mission.
 
-**Tracking deliverables**
+:::{admonition} Tracking deliverables
 
-This project is just beginning, and currently does not have a location to track its deliverables.
-However, you can find discussion of general Pangeo activity in [the Pangeo repository](https://github.com/pangeo-data/pangeo).
+**Note that this initiative is WIP and may change in scope and focus**
 
-## Jupyter Meets the Earth
-
-Jupyter Meets the Earth is an NSF EarthCube project to develop Jupyter infrastructure in service of the earth sciences.
-
-**Tracking deliverables**
-
-The [`pangeo-data/jupyter-earth` repository](https://github.com/pangeo-data/jupyter-earth) contains deliverables for this project. Look for [the {guilabel}`🏷 JupyterHub` label](https://github.com/pangeo-data/jupyter-earth/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22%3Alabel%3A+JupyterHub%22).
+We are tracking deliverables for this project [in this GitHub project board](https://github.com/orgs/2i2c-org/projects/16).
+:::
 
 ## Jupyter Book development
 
 The Executable Books Project is an international collaboration to build open source tools that facilitate publishing computational narratives using the Jupyter ecosystem.
 Its activities are split across a variety of repositories in the [`executablebooks/` organization](https://github.com/executablebooks).
 
-**Tracking deliverables**
+:::{admonition} Tracking deliverables
 
 - The [`meta/` repository](https://github.com/executablebooks/meta) contains high-level conversation and strategy in the project. Most project planning and execution is carried out in the issues in `executablebooks/` repositories.
 - The [`jupyter-book` repository](https://github.com/executablebooks) contains many issues that are the best place to get started finding things of interest to work on.
 - The [`executablebooks` feature voting board](https://executablebooks.org/en/latest/feature-vote.html) contains a table of issues users have "voted" for. It is a good guide for prioritizing work.
+
+:::
+
+```{toctree}
+managed-hubs/index
+```

--- a/projects/index.md
+++ b/projects/index.md
@@ -19,7 +19,7 @@ The [organizational foundation project](https://github.com/orgs/2i2c-org/project
 :::
 
 - **Strategy** - We must define a long-term vision for 2i2c, and high-level strategy for executing on that vision.
-- **Governance** - We must define how decision get made within 2i2c at all levels of the organization.
+- **Governance** - We must define how decisions get made within 2i2c at all levels of the organization.
 - **Organizational policy** - We must define our early organizational policy, culture, and core documents like a Code of Conduct.
 - **Administration** - We need an administrative infrastructure to carry out 2i2c's organizational needs. This includes its legal status, hiring/contracting, and invoicing. 
 - **Public materials** - In order to gain recognition, we need to build public-facing materials and documentation. This includes websites and social media handles, early branding, and documentation.

--- a/projects/index.md
+++ b/projects/index.md
@@ -9,6 +9,12 @@ In general, projects should have:
 1. A name / description
 2. A location where deliverables and tasks are being tracked.
 
+:::{admonition} Prototyping project boards
+We are currently prototyping the use of Project Boards for _initiatives_ for our medium-term planning.
+Initiatives are collections of work with a particular theme or focus.
+You may see them in use below - but they may evolve and be used differently as we learn more!
+:::
+
 ## 2i2c organizational launch
 
 As 2i2c is quite young, it must first build an organizational foundation for itself.

--- a/projects/index.md
+++ b/projects/index.md
@@ -39,6 +39,12 @@ The Managed JupyterHub Service is a special project of 2i2c that is [developed a
 - [the roadmap for the service is described here](https://pilot.2i2c.org/en/latest/about/roadmap.html)
 :::
 
+More information about the Managed JupyterHub Service can be found in these sections:
+
+```{toctree}
+managed-hubs/index
+```
+
 (projects:jmte-pangeo)=
 ## Pangeo Hub Infrastructure development
 
@@ -64,7 +70,3 @@ Its activities are split across a variety of repositories in the [`executableboo
 - The [`executablebooks` feature voting board](https://executablebooks.org/en/latest/feature-vote.html) contains a table of issues users have "voted" for. It is a good guide for prioritizing work.
 
 :::
-
-```{toctree}
-managed-hubs/index
-```

--- a/projects/managed-hubs/index.md
+++ b/projects/managed-hubs/index.md
@@ -13,7 +13,7 @@ We are also building a sales and support pipeline around this infrasturcture.
 **Infrastructure and development** happens in [the `pilot-hubs/` repository](https://github.com/2i2c-org/pilot-hubs).
 This is both the deployment infrastructure for the 2i2c JupyterHubs, as well as documentation and team coordination around developing and running them.
 
-**THe Hub Engineer's Guide** describes how to develop and operate the 2i2c `pilot-hubs/` infrastructure.
+**The Hub Engineer's Guide** describes how to develop and operate the 2i2c `pilot-hubs/` infrastructure.
 It is generally designed for 2i2c engineers to follow and learn.
 You can find it at [pilot-hubs.2i2c.org](https://pilot-hubs.2i2c.org).
 

--- a/projects/managed-hubs/index.md
+++ b/projects/managed-hubs/index.md
@@ -13,9 +13,18 @@ We are also building a sales and support pipeline around this infrasturcture.
 **Infrastructure and development** happens in [the `pilot-hubs/` repository](https://github.com/2i2c-org/pilot-hubs).
 This is both the deployment infrastructure for the 2i2c JupyterHubs, as well as documentation and team coordination around developing and running them.
 
-**User Documentation** is located in [the `pilot/` repository](https://github.com/2i2c-org/pilot). This contains user-facing information about the Pilot Hubs, such as how they can add/remove users, update their environment, get support, etc.
+**THe Hub Engineer's Guide** describes how to develop and operate the 2i2c `pilot-hubs/` infrastructure.
+It is generally designed for 2i2c engineers to follow and learn.
+You can find it at [pilot-hubs.2i2c.org](https://pilot-hubs.2i2c.org).
 
-**Information about the Managed Hubs Pilot** is located within sub-sections below.
+**The Hub Administrator's Guide** provides for Hub Administrators to customize and control their hub.
+It is community-facing, and meant as a more external view on the 2i2c Hubs Pilot.
+It also describes high-level information about the pilot in general.
+It is located at [pilot.2i2c.org](https://pilot.2i2c.org) (or [the `pilot/` repository](https://github.com/2i2c-org/pilot))
+
+**Strategy and roadmaps** for the Managed Hubs Pilot are located in the Hub Administrator's guide. 
+
+For other information about the Managed Hubs Pilot, see the sections below.
 
 ## A list of running JupyterHubs
 


### PR DESCRIPTION
This update has two main things:

- Fix some broken links and rearrange some content to be easier to find
- Updates our projects page to have less repeated information, and to have more details for the initiatives that are there

In tandem with https://github.com/2i2c-org/pilot/pull/94