### PR TITLE
Add information about team zoom

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -66,8 +66,8 @@ myst_enable_extensions = [
 ]
 myst_url_schemes = ["https", "http", "ftp", "mailto"]
 intersphinx_mapping = {
-    "pi": ("https://pilot.2i2c.org", None),
-    "ph": ("https://pilot-hubs.2i2c.org", None),
+    "pi": ("https://pilot.2i2c.org/en/latest", None),
+    "ph": ("https://pilot-hubs.2i2c.org/en/latest", None),
 }
 
 panels_add_bootstrap_css = False

--- a/practices/communication.md
+++ b/practices/communication.md
@@ -69,7 +69,7 @@ This Slack has both 2i2c staff and Steering Conucil members, as well as several 
 Our team has a dedicated Zoom room that anybody on the 2i2c team may use.
 We try not to publicly post this link to avoid the likelihood of abuse.
 The room is password-protected but accessible to anybody that joins via the link.
-Ask any team member what the URL is (it is easy to remember).
+Ask any team member what the URL is (it is easy to remember) if you wish to join.
 
 In addition, the Zoom account that is connected to this room is also available for any 2i2c team member to use.
 The username for this account is `hello@2i2c.org` and you should ask a team member for the password if you wish to use it.

--- a/practices/communication.md
+++ b/practices/communication.md
@@ -1,4 +1,4 @@
-
+(practices:communication)=
 # Team communication
 
 There are a few different communication channels with 2i2c, depending on your team and what kind of communication you'd like to have.
@@ -63,7 +63,18 @@ It is not used for official records or planning.
 Informal communication happens in the 2i2c Slack channel ([http://2i2c.slack.com/](http://2i2c.slack.com/)).
 This Slack has both 2i2c staff and Steering Conucil members, as well as several other interested parties.
 
+(communication:zoom)=
+## Zoom
 
+Our team has a dedicated Zoom room that anybody on the 2i2c team may use.
+We try not to publicly post this link to avoid the likelihood of abuse.
+The room is password-protected but accessible to anybody that joins via the link.
+Ask any team member what the URL is (it is easy to remember).
+
+In addition, the Zoom account that is connected to this room is also available for any 2i2c team member to use.
+The username for this account is `hello@2i2c.org` and you should ask a team member for the password if you wish to use it.
+
+For public-facing zoom meetings that are hosted with this account, create a zoom link that is unique to the meeting, rather than using the general team room.
 
 ## Slack
 

--- a/practices/development.md
+++ b/practices/development.md
@@ -185,7 +185,7 @@ Not all of them are followed strictly, though some are more important than other
 
 Changing active infrastructure is a bit different from developing technology that is not immediately in production.
 As such, we follow some more specific guidelines for these kinds of changes.
-See [](ph:infrastructure:review).
+See {ref}`ph:infrastructure:review`.
 
 ### Policy for team compass changes
 

--- a/practices/meetings.md
+++ b/practices/meetings.md
@@ -5,7 +5,8 @@ There are a few kinds of synchronous meetings that we create space for.
 This section describes the kinds of meetings we use and why they exist.
 
 :::{seealso}
-See the [Team Calendar page](team/calendar) for specific dates and information about each of these meetings.
+- See the [Team Calendar page](team/calendar) for specific dates and information about each of these meetings.
+- See [the communication page](practices:communication) for information about how to access zoom meetings and other communication channels.
 :::
 
 ## Guidelines for all team meetings


### PR DESCRIPTION
This adds some information about our team Zoom room. It doesn't go into detail about the password etc, and we should update this once we have a better policy for sharing passwords.

closes https://github.com/2i2c-org/pilot-hubs/issues/663