### PR TITLE
[merge on 09-27] Update sprint meeting cadence to bi-weekly

### DIFF
--- a/.github/ISSUE_TEMPLATE/meeting-sprint-planning.md
+++ b/.github/ISSUE_TEMPLATE/meeting-sprint-planning.md
@@ -7,15 +7,11 @@ title: "Sprint Planning Meeting: {{ date | date('dddd, MMMM Do') }}"
 
 # 2i2c Sprint Planning meeting
 
-This is a **60 minute** recurring meeting every **Tuesday at 8:00AM Pacific time** (here's [**a timezone converter**](https://arewemeetingyet.com/Los%20Angeles/2000-01-01/08:00/2i2c%20Team%20Meeting#eyJ1cmwiOiJodHRwczovL2hhY2ttZC5pby9ZNVNCTXhWN1I2Q01xemVUWGdtNWtBIn0=), ignore the date!).
+This is a **60 minute** recurring meeting **every other Wednesday at 7:30AM Pacific time** (here's [**a timezone converter**](https://arewemeetingyet.com/Los%20Angeles/2000-01-01/07:30/2i2c%20Team%20Meeting#eyJ1cmwiOiJodHRwczovL2hhY2ttZC5pby9ZNVNCTXhWN1I2Q01xemVUWGdtNWtBIn0=), ignore the date!).
 
 Our goal is to synchronize the team on the most important things to work on, and to divide work between one another so we know what to work on next.
 
-## Links
-
-- [**Video conference link**](https://bit.ly/zoom-holdgraf)
-- [**Calendar for future meetings**](https://calendar.google.com/calendar/embed?src=c_4hjjouojd8psql9i1a8nd1uff4%40group.calendar.google.com&ctz=America%2FLos_Angeles)
-- [**List of 2i2c projects**](https://github.com/orgs/2i2c-org/projects)
+- [**Sprint Board**]([https://](https://github.com/orgs/2i2c-org/projects/14))
 - [**Deliverables backlog**](https://github.com/orgs/2i2c-org/projects/7?fullscreen=true)
 
 **Meeting facilitator**: <INSERT FACILITATOR HERE>
@@ -24,28 +20,18 @@ Our goal is to synchronize the team on the most important things to work on, and
 
 _Follow the agenda below, checking boxes as we complete each step._
 
-## Before the meeting
 
-- [ ] Create this week's sprint board
-- [ ] Choose a sprint meeting facilitator
-
-## Review of last week's Sprint Board. (5m)
-
-- [ ] Team members have all filled out last week's team sync
-- [ ] Decide what to do with any incomplete deliverables
-- [ ] Archive last week's board
-
-## Populate this week's Sprint Board (45m)
-
-- [ ] Archive and celebrate closed deliverables 🎉
-- [ ] Team members note any reduced availability
-- [ ] Add new deliverables to Sprint Board
-- [ ] Somebody is assigned to each deliverable
-- [ ] Everybody agrees the current cycle's plan is realistic and that the right items are on the board.
-
-## Support ticket overview. (10m)
-
-- [ ] Support steward asks for assistance on issues that need it.
-- [ ] (_once a month_) Transition support steward roles to the next team member
-  - [ ] Open issue for next Support Steward.
-  - [ ] Close previous issue for Support Steward.
+- [ ] Review of last week's Sprint Board. (10m)
+  - [ ] Celebrate our accomplishments
+  - [ ] Decide what to do with any incomplete deliverables
+  - [ ] Archive deliverables we finished
+- [ ] Populate this week's Sprint Board (45m)
+  - [ ] Review and clarify any deliverables we'd like to work on next
+  - [ ] Add new deliverables to Sprint Board
+  - [ ] Somebody is assigned to each deliverable
+  - [ ] Everybody agrees the current cycle's plan is realistic and that the right items are on the board.
+- [ ] Support ticket overview. (5m)
+  - [ ] Support steward asks for assistance on issues that need it.
+  - [ ] (_once a month_) Transition support steward roles to the next team member
+    - [ ] Open issue for next Support Steward.
+    - [ ] Close previous issue for Support Steward.

--- a/.github/workflows/create-sprint-planning-meeting.yaml
+++ b/.github/workflows/create-sprint-planning-meeting.yaml
@@ -1,8 +1,8 @@
 name: Open a sprint planning meeting issue
 on:
   schedule:
-  # Run every Tuesday at 07:00 AM UTC / 09:00AM Europe / 00:00AM California
-  - cron: "0 07 * * 2"
+  # Run every Wednesday at 07:00 AM UTC / 09:00AM Europe / 00:00AM California
+  - cron: "0 07 * * 3"
 
   workflow_dispatch:
 

--- a/conf.py
+++ b/conf.py
@@ -31,6 +31,7 @@ extensions = [
     "myst_parser",
     "sphinx_panels",
     "sphinx_copybutton",
+    "sphinx.ext.intersphinx",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -66,8 +67,8 @@ myst_enable_extensions = [
 ]
 myst_url_schemes = ["https", "http", "ftp", "mailto"]
 intersphinx_mapping = {
-    "pi": ("https://pilot.2i2c.org", None),
-    "ph": ("https://pilot-hubs.2i2c.org", None),
+    "pi": ("https://pilot.2i2c.org/en/latest/", None),
+    "ph": ("https://pilot-hubs.2i2c.org/en/latest/", None),
 }
 
 panels_add_bootstrap_css = False

--- a/practices/communication.md
+++ b/practices/communication.md
@@ -1,5 +1,5 @@
 (practices:communication)=
-# Team communication
+# Communication channels
 
 There are a few different communication channels with 2i2c, depending on your team and what kind of communication you'd like to have.
 See below for details.

--- a/practices/development.md
+++ b/practices/development.md
@@ -18,34 +18,31 @@ However, our work within a sprint is a **team commitment**, and we are all respo
 
 ### Sprint cadence
 
-:::{admonition} Temporarily weekly!
-We are still working out the best structure for the Sprint Planning meeting and how it fits in with our team coordination.
-See [this GitHub issue](https://github.com/2i2c-org/team-compass/issues/182) for the latest information.
-:::
-
-Our team works in one week sprints.
+Our team works in **two-week sprints**.
 Here is a brief overview of each sprint.
 
-Tuesday
+Wednesday (beginning of sprint)
 : Sprint begins with our [sprint planning meeting](meetings:sprint-planning).
 
-  In this meeting we prioritize and assign the items that each team member will work on for this week, and review items that require discussion and planning.
+  In this meeting we discuss major accomplishments in the previous sprint. We then prioritize and assign the items that each team member will work on for the next sprint, and review items that require discussion and planning.
 
-Wed-Friday
+During the sprint
 : Team members work on the deliverables assigned to them at the sprint planning meeting.
+  We use [the Sprint Board](coordination:sprint-board) to coordinate our activities during the sprint.
+  On Mondays, each team member fills out a **team sync update** to share the major things they worked on, and note any unexpected challenges or blockers.
 
-Monday
-: By the end of the day, team members should have completed all of their deliverables for that week.
-  Each team member fills out a **team sync update** to share the major things they worked on, and note any unexpected challenges or blockers.
-
+Tuesday of week 2 (end of sprint)
+: By the end of the day, team members should have completed all of their deliverables for that sprint.
+  
 ### Sprint planning meeting
 
-The 2i2c team meets **every Tuesday** for 60 minutes.
+The team conducts a Sprint Planning meeting for 60 minutes at the beginning of each sprint.
 The goal of this meeting is to review our major work deliverables, synchronize with one another, and prioritize work across team members.
 It is also a chance to hand off the Support Steward role to the next person.
 
-Sprint Planning Meetings roughly follow a two-step process:
+Sprint Planning Meetings roughly follow a three-step process:
 
+1. Review what we've accomplished in the previous sprint, and decide what to do with remaining deliverables that we did not complete.
 1. Scan and discuss the [deliverables backlog](coordination:deliverables-backlog) in order to understand our WIP deliverables and their prioritization relative to one another.
 2. Add deliverables, or their tasks, to the week's Sprint Board, and work on them throughout the week.
    It's up to the team whether a deliverable or one of its tasks should be added to the board.

--- a/practices/development.md
+++ b/practices/development.md
@@ -1,10 +1,11 @@
 (coordination:development)=
-# Team development workflow
+# Development workflow
 
 This section describes how our development team carries out its planning and day-to-day work.
 
 :::{admonition} Helpful links
 👉 [Here is a link to all 2i2c GitHub Issues that have been assigned to you](https://github.com/issues?q=is%3Aissue+is%3Aopen+archived%3Afalse+sort%3Aupdated-desc+assignee%3A%40me+user%3A2i2c-org)
+
 👉 [Here's a link to see all Pull Requests for which your review is requested](https://github.com/issues?q=is%3Aopen+archived%3Afalse+sort%3Aupdated-desc+user%3A2i2c-org+type%3Apr+review-requested%3A%40me)
 :::
 
@@ -43,8 +44,8 @@ It is also a chance to hand off the Support Steward role to the next person.
 Sprint Planning Meetings roughly follow a three-step process:
 
 1. Review what we've accomplished in the previous sprint, and decide what to do with remaining deliverables that we did not complete.
-1. Scan and discuss the [deliverables backlog](coordination:deliverables-backlog) in order to understand our WIP deliverables and their prioritization relative to one another.
-2. Add deliverables, or their tasks, to the week's Sprint Board, and work on them throughout the week.
+2. Scan and discuss the [deliverables backlog](coordination:deliverables-backlog) in order to understand our WIP deliverables and their prioritization relative to one another.
+3. Add deliverables, or their tasks, to the week's Sprint Board, and work on them throughout the week.
    It's up to the team whether a deliverable or one of its tasks should be added to the board.
 
 You can find the meeting format/agenda {download}`in the Sprint Planning meeting template <../.github/ISSUE_TEMPLATE/meeting-sprint-planning.md>`.

--- a/practices/meetings.md
+++ b/practices/meetings.md
@@ -1,5 +1,5 @@
 (meetings:intro)=
-# Team meetings
+# Meetings guidelines
 
 There are a few kinds of synchronous meetings that we create space for.
 This section describes the kinds of meetings we use and why they exist.

--- a/practices/meetings.md
+++ b/practices/meetings.md
@@ -62,7 +62,9 @@ The following are meetings that we regularly hold.
 
 ### Monthly team meetings
 
-The 2i2c Team meets the **first Monday of each month** for 90 minutes.
+The 2i2c Team meets **monthly on Tuesdays** for 90 minutes.
+
+See the [Team Calendar page](team/calendar) for information about when and where the meetings are held.
 
 Monthly team meetings are an opportunity to all meet face to face in order to discuss topics that benefit from synchronous conversation.
 For example, these are some goals we might have:
@@ -72,11 +74,10 @@ For example, these are some goals we might have:
 - Zoom out and make sure we are on the right track
 - Discuss team process issues to make sure we are all supported
 
-It is **not a status update meeting** - this should be done via our GitHub issues and project boards!
+It is **not a status update meeting** - this should be done via our GitHub issues and sprint planning!
 
 We use [this HackMD for our team meeting notes and agenda](https://hackmd.io/Y5SBMxV7R6CMqzeTXgm5kA).
 
-See the [Team Calendar page](team/calendar) for information about when and where the meetings are held.
 
 (meetings:sprint-planning)=
 ### Sprint Planning meetings


### PR DESCRIPTION
This updates our sprint meeting cadence to bi-weekly, and updates our team practices documentation accordingly.

We will start this practice on the week of the 27th, so let's hold off on merging this until then. I've already updated the calendars to switch to the new schedule that week as well!

closes #237 