### PR TITLE
Add impact issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ _build
 */.ipynb_checkpoints/*
 tmp/
 .DS_Store
+.nox
+__pycache__

--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# 2i2c Team Compass
+
+This repository contains the source files for the [2i2c Team Compass](https://team-compass.2i2c.org).
+For more information, see [our Team Compass landing page](https://team-compass.2i2c.org).
+
+## Build the team compass locally
+
+The Team Compass is built with [the Sphinx documentation engine](https://sphinx-doc.org).
+The easiest way to build the documentation in this repository is to use [the `nox` automation tool](https://nox.thea.codes/), a tool for quickly building environments and running commands within them.
+This ensures that your environment has all the dependencies needed to build the documentation.
+
+To do so, follow these steps:
+
+1. Install `nox`
+
+   ```console
+   $ pip install nox
+   ```
+2. Build the documentation:
+
+   ```console
+   $ nox -s docs_build
+   ```
+
+This should create a local environment in a `.nox` folder, build the documentation (as specified in the `noxfile.py` configuration), and the output will be in `_build/html`.
+
+To build live documentation that updates when you update local files, run the following command:
+
+```console
+$ nox -s docs_live
+```

--- a/conf.py
+++ b/conf.py
@@ -29,7 +29,7 @@ author = "2i2c"
 # ones.
 extensions = [
     "myst_parser",
-    "sphinx_panels",
+    "sphinx_design",
     "sphinx_copybutton",
     "sphinx.ext.intersphinx",
 ]
@@ -40,7 +40,7 @@ templates_path = ["_templates"]
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", ".github"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", ".github", ".nox", "README.md"]
 
 # -- Options for HTML output -------------------------------------------------
 
@@ -49,7 +49,7 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", ".github"]
 #
 html_theme = "sphinx_book_theme"
 html_sidebars = {
-    "**": ["2i2c-logo.html", "sbt-sidebar-nav.html", "sbt-sidebar-footer"]
+    "**": ["2i2c-logo.html", "search-field.html", "sbt-sidebar-nav.html", "sbt-sidebar-footer"]
 }
 html_static_path = ["_static"]
 
@@ -75,8 +75,6 @@ intersphinx_mapping = {
     "pi": ("https://pilot.2i2c.org/en/latest/", None),
     "ph": ("https://pilot-hubs.2i2c.org/en/latest/", None),
 }
-
-panels_add_bootstrap_css = False
 
 # Disable linkcheck for anchors because it throws false errors for any JS anchors
 linkcheck_anchors = False

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,24 @@
+import nox
+
+nox.options.reuse_existing_virtualenvs = True
+
+build_command = ["-b", "html", ".", "_build/html"]
+
+@nox.session
+def docs(session):
+    session.install("-r", "requirements.txt")
+    session.run("sphinx-build", *build_command)
+
+@nox.session
+def docs_live(session):
+    session.install("-r", "requirements.txt")
+
+    AUTOBUILD_IGNORE = [
+        "_build",
+        "build_assets",
+    ]
+    cmd = ["sphinx-autobuild"]
+    for folder in AUTOBUILD_IGNORE:
+        cmd.extend(["--ignore", f"*/{folder}/*"])
+    cmd.extend(build_command)
+    session.run(*cmd)

--- a/practices/github-conventions.md
+++ b/practices/github-conventions.md
@@ -21,23 +21,46 @@ Issue types are mutually-exclusive - there may only be one issue type per issue.
 
 There are a few issue types that are defined for all repositories:
 
-- {badge}`type: deliverable, badge-info`: an incremental improvement to something. See [](coordination:deliverables) for more information.
-- {badge}`type: bug, badge-info`: something that is not working or incorrect in the repository.
+- {bdg-info}`type: enhancement`: an incremental improvement to something. See [](coordination:deliverables) for more information.
+- {bdg-info}`type: bug`: something that is not working or incorrect in the repository.
+- {bdg-info}`type: task`: an action to take.
 
 In addition, other repositories may use repository-specific types, with the caveat that **all issues must still only have one `type` label**.
 
-### Issue priority
+### Issue impact
 
 **OPTIONAL**
 
-Issue priority is used to classify some issues as requiring action before others.
-Any issue without a priority tag should be assumed as lower priority than {badge}`prio: low,badge-danger`.
- 
-Here are the priority labels for our issues:
+Issue impact is used to signal how much of an impact resolving an issue will have.
+The meaning of this depends on the issue type (e.g., enhancement, bug, etc), but our general guidelines are the following:
 
-- {badge}`prio: high, badge-danger`
-- {badge}`prio: medium, badge-danger`
-- {badge}`prio: low, badge-danger`
+:::{epigraph}
+The impact should be proportional to a combination of:
+
+- The number of users that will be impacted by an issue's resolution,
+- The extent of the impact our users will feel (e.g., major change in experience vs. minor improvement)
+- The importance of communities or stakeholders that are impacted by the issue.
+:::
+
+Here are the impact labels for our issues:
+
+- {bdg-danger}`impact: high`
+- {bdg-danger}`impact: medium`
+- {bdg-danger}`impact: low`
+
+#### Categorizing impact
+
+Here are a few guidelines for how to categorize impact across a few major types of issues.
+
+Features / Enhancements
+: - `impact: high`: Will be seen and commonly used by nearly all users. Has been requested by an abnormally large number of users. Is of particular importance to a key community.
+  - `impact: med`: Useful to many users but not an overwhelming amount. Will be a less-obvious improvement. Most issues should be in this category.
+  - `impact: low`: Useful but not a critical part of workflows. Is a niche use-case that only a few users may need.
+
+Bugs
+: - `impact: high`: Disruptive to nearly all users, or critically disruptive to many users or key communities (e.g., sessions won't work at all).
+  - `impact: med`: Disruptive to some users, but not in a critical way. Only noticeable under circumstances that aren't very common. Most issues should be in this category.
+  - `impact: low`: Minimally disruptive or cosmetic, or only affects a small number of users or niche use-cases.
 
 ### Issue tag
 
@@ -48,7 +71,7 @@ They are highly repository-specific, optional, and non-exclusive (so issues may 
 
 Here are some example tags:
 
-- {badge}`🏷: documentation,badge-warning`: related to documentation in a repository
-- {badge}`🏷: CI/CD,badge-warning`: related to continuous integration/deployment
-- {badge}`🏷: data access,badge-warning`: related to data access functionality
-- {badge}`🏷: hub admin,badge-warning`: related to hub administrator functionality
+- {bdg-warning}`🏷: documentation`: related to documentation in a repository
+- {bdg-warning}`🏷: CI/CD`: related to continuous integration/deployment
+- {bdg-warning}`🏷: data access`: related to data access functionality
+- {bdg-warning}`🏷: hub admin`: related to hub administrator functionality

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
-sphinx
-sphinx-book-theme
 myst-parser[linkify]
-sphinx-copybutton
-sphinx-panels
 pandas
+sphinx
+sphinx-autobuild
+sphinx-book-theme
+sphinx-copybutton
+sphinx-design


### PR DESCRIPTION
Updates our documentation to include our use of `impact` labels. Also adds a noxfile to make it a bit easier to build the docs locally (I was running into a bunch of build errors because I have a bunch of dev versions installed in my global environment) 

Also updates `sphinx-panels` to `sphinx-design` since that's where the new development will be

I'll leave this open for a day or two, and if there are no suggested edits or objections I'll merge, since we've already discussed this a bit in the #227 

closes https://github.com/2i2c-org/team-compass/issues/227