### PR TITLE
Team meeting follow-ups

### DIFF
--- a/.github/ISSUE_TEMPLATE/meeting-sprint-planning.md
+++ b/.github/ISSUE_TEMPLATE/meeting-sprint-planning.md
@@ -11,8 +11,8 @@ This is a **60 minute** recurring meeting **every other Wednesday at 7:30AM Paci
 
 Our goal is to synchronize the team on the most important things to work on, and to divide work between one another so we know what to work on next.
 
-- [**Sprint Board**]([https://](https://github.com/orgs/2i2c-org/projects/14))
-- [**Deliverables backlog**](https://github.com/orgs/2i2c-org/projects/7?fullscreen=true)
+- [**Sprint Board**](https://github.com/orgs/2i2c-org/projects/21)
+- [**Deliverables backlog**](https://github.com/orgs/2i2c-org/projects/22)
 
 **Meeting facilitator**: <INSERT FACILITATOR HERE>
 
@@ -21,17 +21,15 @@ Our goal is to synchronize the team on the most important things to work on, and
 _Follow the agenda below, checking boxes as we complete each step._
 
 
-- [ ] Review of last week's Sprint Board. (10m)
+- [ ] Review the Sprint Board. (10m)
   - [ ] Celebrate our accomplishments
   - [ ] Decide what to do with any incomplete deliverables
   - [ ] Archive deliverables we finished
-- [ ] Populate this week's Sprint Board (45m)
+- [ ] Populate Sprint Board with new deliverables (45m)
   - [ ] Review and clarify any deliverables we'd like to work on next
   - [ ] Add new deliverables to Sprint Board
   - [ ] Somebody is assigned to each deliverable
   - [ ] Everybody agrees the current cycle's plan is realistic and that the right items are on the board.
 - [ ] Support ticket overview. (5m)
-  - [ ] Support steward asks for assistance on issues that need it.
-  - [ ] (_once a month_) Transition support steward roles to the next team member
-    - [ ] Open issue for next Support Steward.
-    - [ ] Close previous issue for Support Steward.
+  - [ ] Support steward describes any open support issues.
+  - [ ] Next support steward is: <INSERT NAME HERE>

--- a/.github/ISSUE_TEMPLATE/meeting-team.md
+++ b/.github/ISSUE_TEMPLATE/meeting-team.md
@@ -2,7 +2,7 @@
 name: "📅 Team Meeting"
 about: Plan a team meeting.
 labels: "type: team-sync"
-title: "Team Meeting: <MONTH YYYY>"
+title: "Team Meeting: {{ date | date('MMMM') }}"
 ---
 
 This is a planning issue for our next team meeting! See below for information about the meeting and next steps.
@@ -12,13 +12,10 @@ This is a planning issue for our next team meeting! See below for information ab
 _Information about when and where the meeting will take place_
 
 - **Date:** <YYYY-MM-DD>
-- **Time:** 8AM US/Pacific time (or [**your timezone**](https://arewemeetingyet.com/Los%20Angeles/<YYYY-MM-DD>/08:00/2i2c%20Team%20Meeting#eyJ1cmwiOiJodHRwczovL2hhY2ttZC5pby9ZNVNCTXhWN1I2Q01xemVUWGdtNWtBIn0=))
-- **Video conference link:** https://bit.ly/zoom-holdgraf
+- **Time:** 7:30AM US/Pacific time (or [**your timezone**](https://arewemeetingyet.com/Los%20Angeles/<YYYY-MM-DD>/07:30/2i2c%20Team%20Meeting#eyJ1cmwiOiJodHRwczovL2hhY2ttZC5pby9ZNVNCTXhWN1I2Q01xemVUWGdtNWtBIn0=))
+- **Video conference link:** https://zoom.2i2c.org
 - **HackMD for meeting:** https://hackmd.io/Y5SBMxV7R6CMqzeTXgm5kA
 - **Calendar for future meetings:** [this Google Calendar](https://calendar.google.com/calendar/embed?src=c_4hjjouojd8psql9i1a8nd1uff4%40group.calendar.google.com&ctz=America%2FLos_Angeles)
-- **Meeting facilitator**: <INSERT FACILITATOR HERE>
-- **Meeting recorder**: <INSERT RECORDER HERE>
-- **Meeting timekeeper**: <INSERT TIMEKEEPER HERE>
 
 # Follow up issues
 
@@ -26,16 +23,13 @@ _Links to follow up issues below_
 
 - ...
 
-# Actions
+# Tasks for the facilitator
 
 _Steps to take to have the meeting._
 
-- **At least 1 day prior to meeting**
-  - [ ] Agenda items added to the meeting
-  - [ ] Meeting roles identified in meeting issue
+- [ ] Agenda items added to the meeting
 - [ ] Have the meeting
 - [ ] Open up any follow-up issues or discussions and link above
-- [ ] Cut notes out of HackMD and add to the Team Compass: <PR link here>
-- [ ] Update HackMD information for next month's meeting
-- [ ] Create a GitHub issue for next month's meeting
+- [ ] Cut notes out of HackMD and add to the Team Compass
+- [ ] Next team facilitator is notified: {{ INSERT HANDLE HERE }}
 - [ ] Meeting complete! 🎉

--- a/.github/workflows/create-team-meeting.yaml
+++ b/.github/workflows/create-team-meeting.yaml
@@ -1,0 +1,18 @@
+name: Open a weekly team sync issue
+on:
+  schedule:
+  # Run on the first day of the month so there's time to update the issue w/ info
+  - cron: "0 1 1 * *"
+
+  workflow_dispatch:
+
+jobs:
+  create-sync-issue:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: JasonEtco/create-an-issue@v2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        filename: .github/ISSUE_TEMPLATE/meeting-team.md

--- a/meetings/eng/2021.md
+++ b/meetings/eng/2021.md
@@ -1,5 +1,65 @@
 # 2021 Meetings
 
+## 2021-10-12
+
+- **Meeting facilitator**: @choldgraf
+
+### Focus for these meetings
+
+- Can we remove some of the high-level "check-in" stuff? General agreement is "yes"
+- What improvements can we make?
+  - Structure the meetings from a high-level a bit more closely to make it easier to choose things to talk about
+
+#### Follow-ups
+
+- [x] Re-work the meeting structure to focus on the agenda and less about reporting / updating.
+
+### Cycling through team roles
+
+- what's a good process for doing this? (examples of roles below)
+- How can we facilitate the changing of roles?
+  - If it's just a generic sign-up sheet, people tend not to sign up
+  - Instead, fix an order ahead of time
+  - Term limits are roughly quarterly
+- Roles to use?
+  - Support Steward
+  - Meeting facilitator
+    - The meetings we have: sprint meetings every 2 weeks, team meeting each. That's 3 meetings a month.
+- Division of labor or everybody does every role?
+  - We are a small team, so may not have the ability to divide labor
+- How can people be supported in this role?
+  - Create a team culture of supporting the person who serves in this role
+  - Encourage practices of skill-sharing and providing guidance to one another
+  - The skills that come from this kind of role are general enough to be useful to all
+  - In the future, we may want dedicated people in this role if we grow
+
+#### Follow ups
+
+- [x] Chris writes up descriptions of the support steward and meeting facilitator role
+- [x] Create a google sheet with an alphabetical list of team names, and use this to track dates for the roles
+  - Meeting facilitator: switch each month
+  - Support steward: switch each sprint
+
+### New GitHub Issues Beta
+
+- Any objections to using them for ourselves?
+  - Let's do it!
+
+#### Follow ups
+
+- [x] Convert our project boards to new project boards and create new links.
+
+### Overview of Q3 update post
+
+- General structure looks good
+- How do we highlight open source stuff?
+  - Metrics of activity on github stuff
+  - Collect public-facing stories that we can re-tell
+
+#### Follow ups
+
+- [ ] Chris writes a paragraph about our major open source contributions, and collects a few simple metrics to report.
+
 ## 2021-09-06
 
 ### Meeting roles

--- a/practices/development.md
+++ b/practices/development.md
@@ -108,7 +108,7 @@ Tasks to complete
 (coordination:deliverables-backlog)=
 ### The Deliverables Backlog
 
-[Click here to go to the Deliverables Backlog](https://github.com/orgs/2i2c-org/projects/7?fullscreen=true).
+[Click here to go to the Deliverables Backlog](https://github.com/orgs/2i2c-org/projects/22).
 
 The Deliverables Backlog is a GitHub Projects Board with a list of [Deliverables](coordination:deliverables) across all of our active projects.
 These deliverables adhere to the following principles:

--- a/practices/meetings.md
+++ b/practices/meetings.md
@@ -32,21 +32,28 @@ These are major roles that should be filled by someone explicitly for any team m
 The role of meeting facilitator is to structure the meeting so that it is well-scoped, and to guide conversation to be productive and inclusive.
 
 :::{admonition} Responsibilities of the Facilitator
-- Set the agenda before the meeting (either creating it themselves, or asking for agenda items from others)
-- Run the meeting, ensuring that we stay on-time with agenda items and discussion
-- Convert actionable items into issues and close-out the meeting issue if it exists
+Before the meeting
+:  - Collect rough agenda items from team members
+   - Set the agenda
+
+During the meeting
+: Run the meeting, ensuring that conversations are inclusive and productive
+
+After the meeting
+: - Convert actionable items into issues
+  - Clean up the notes after the meeting and archive them in the appropriate location (e.g., the Team Compass)
+  - Close-out the meeting issue
 :::
 
 ### Recorder
 
 The Meeting Recorder is responsible for encoding the discussion points and actionable items that came out of a meeting.
-Their primary goal is to make sure we don't miss something important after the meeting, and ensure that the content of the meeting is saved for reference from others.
+Their primary goal is to make sure that the content of the meeting is saved for reference from others.
 
 :::{admonition} Responsibilities of the Recorder
 - Write down major discussion points and ideas during the meeting
 - Write down action items / to-dos explicitly so that we know what to follow up on
-- Clean up the notes after the meeting
-- Archive the notes in the appropriate location (e.g., the Team Compass)
+
 :::
 
 ### Timekeeper

--- a/projects/index.md
+++ b/projects/index.md
@@ -21,7 +21,7 @@ As 2i2c is quite young, it must first build an organizational foundation for its
 This is an ongoing effort to define structure, process, and governance of 2i2c so that it can grow and execute on its mission.
 
 :::{admonition} Tracking deliverables
-The [organizational foundation project](https://github.com/orgs/2i2c-org/projects/11) contains a list of deliverables we are currently working towards.
+The [organizational foundation project](https://github.com/orgs/2i2c-org/projects/23) contains a list of deliverables we are currently working towards.
 :::
 
 - **Strategy** - We must define a long-term vision for 2i2c, and high-level strategy for executing on that vision.
@@ -55,7 +55,7 @@ We are collaborating with them to provide both daily operations of their hubs, a
 
 **Note that this initiative is WIP and may change in scope and focus**
 
-We are tracking deliverables for this project [in this GitHub project board](https://github.com/orgs/2i2c-org/projects/16).
+We are tracking deliverables for this project [in this GitHub project board](https://github.com/orgs/2i2c-org/projects/24).
 :::
 
 ## Jupyter Book development

--- a/projects/managed-hubs/roles.md
+++ b/projects/managed-hubs/roles.md
@@ -58,15 +58,16 @@ People in these roles are generally affiliated with 2i2c.
 
 ## Support Steward
 
-:::{admonition} Experimental!
-:class: warning
-This is an experimental role, [see this Google Doc](https://docs.google.com/document/d/17Kj_FbtVMl32TEcfvCp18fF1SEiBjVOhCswdidUytgM/edit?usp=sharing0) for running notes and thoughts about the role.
+:::{warning}
+This is an experimental role and the details may change!
 :::
 
 The Support Steward is tasked with keeping track of ongoing support requests to `support@2i2c.org`.
 They do not necessarily complete the request themselves, and should work with other engineers to ensure they are resolved.
 
-The Support Steward rotates throughout the engineering team on a regular basis, in order to ensure that all team members share the load of supporting our communities.
+The Support Steward rotates throughout the engineering team each sprint, in order to ensure that all team members share the load of supporting our communities.
+
+See [the Support Process proposal](https://docs.google.com/document/d/17Kj_FbtVMl32TEcfvCp18fF1SEiBjVOhCswdidUytgM/edit?usp=sharing) for the latest version of our support process.
 
 ### Responsibilities
 


### PR DESCRIPTION
This implements a few major follow-ups from our team meeting:

- Updates the language and links around the Support Steward and Facilitator Roles
- Updates project boards to use versions w/ the new github projects beta
- Cleans up some of our notes templates