### PR TITLE
Pilot Hubs to infrastructure in docs

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -67,7 +67,7 @@ myst_enable_extensions = [
 myst_url_schemes = ["https", "http", "ftp", "mailto"]
 intersphinx_mapping = {
     "pi": ("https://pilot.2i2c.org/en/latest/", None),
-    "ph": ("https://pilot-hubs.2i2c.org/en/latest/", None),
+    "ph": ("https://infrastructure.2i2c.org/en/latest/", None),
 }
 
 # Disable linkcheck for anchors because it throws false errors for any JS anchors

--- a/meetings/eng/2021.md
+++ b/meetings/eng/2021.md
@@ -135,15 +135,15 @@ Start: 5:56pm (30-45m)
   - How do we use this workflow to work on projects with different focus areas? E.g. Pilot hub infra vs. Executable Books vs. Upstream improvements
 - How do we encode new work items that pop up (e.g. support requests that we must prioritize)?
     - Do support-related issues get treated in a special way?
-    - Example: OceanHackWeek PR to pilot-hubs: https://github.com/2i2c-org/pilot-hubs/pull/564
-    - Example: Outage reports such as https://github.com/2i2c-org/pilot-hubs/issues/524
+    - Example: OceanHackWeek PR to pilot-hubs: https://github.com/2i2c-org/infrastructure/pull/564
+    - Example: Outage reports such as https://github.com/2i2c-org/infrastructure/issues/524
     - If we add a support-related issue, do we remove another issue from the activity board? 
 - Proposal: Agile process around the boards
   - Roughly follow an "agile" approach to these boards, and use our deliverables sync meeting to plan out the next two weeks of things to follow?
   - Should we roughly tie the language of agile to our workflows? E.g. "things on the deliverables boards are 'epics', things on the activity board are 'stories'"?
 - How do we encode questions, discussions, and decisions with team members?
   - Via Issues, GitHub Discussions?
-  - Example: Yuvi's `pilot-hubs` renaming question: https://github.com/2i2c-org/pilot-hubs/issues/570
+  - Example: Yuvi's `infrastructure` renaming question: https://github.com/2i2c-org/infrastructure/issues/570
   - How do we signal-boost them? (e.g. put in "needs review", put in "needs discussion"?)
 - Where to store "ongoing information that requires attention over time"?
   - Things like "pinned issues", but for a board?
@@ -174,7 +174,7 @@ After our meeting, we should move items here that we didn't discuss or decided t
 - [Relevant issue](https://github.com/2i2c-org/team-compass/issues/167)
 - Is the Support Steward the **only** one expected to check and respond to FreshDesk questions?
   - Is it OK that this is creating a bottleneck? (e.g., if the Support Steward is asleep is there no support responses expected at all?)
-  - Example of an issue that benefited from multiple perspectives: https://github.com/2i2c-org/pilot-hubs/issues/549
+  - Example of an issue that benefited from multiple perspectives: https://github.com/2i2c-org/infrastructure/issues/549
 - When we create a ticket after a support request, do we still expect Community Representatives to communicate via FreshDesk, or is it OK for them to start responding in the GitHub issue?
   - Is it OK that this is creating a bottleneck? (if multiple people from a community cannot see the same ticket?)
   
@@ -216,7 +216,7 @@ After our meeting, we should move items here that we didn't discuss or decided t
 
 - Support Steward proposal (10-20m) (07:35)
     - any feedback / suggested changes / etc? Shall we plan to begin the support steward role soon?
-    - https://github.com/2i2c-org/pilot-hubs/issues/
+    - https://github.com/2i2c-org/infrastructure/issues/
     - https://docs.google.com/document/d/17Kj_FbtVMl32TEcfvCp18fF1SEiBjVOhCswdidUytgM/edit
     - Feedback?
         - ES: two weeks sounds good to him

--- a/practices/communication.md
+++ b/practices/communication.md
@@ -16,7 +16,7 @@ For those who are doing daily work with 2i2c, we use [GitHub Discussions](https:
 There are a few different discussion forums depending on the kind of conversation you'd like to have:
 
 - General team discussion: [2i2c-org/team-compass/discussions](https://github.com/2i2c-org/team-compass/discussions)
-- Discussion specifically about the pilot hubs: [2i2c-org/pilot-hubs/discussions](https://github.com/2i2c-org/pilot-hubs/discussions)
+- Discussion specifically about the pilot hubs: [2i2c-org/infrastructure/discussions](https://github.com/2i2c-org/infrastructure/discussions)
 - Team discussion that needs to be private (this should be low-volume): [2i2c-org/meta/discussions](https://github.com/2i2c-org/meta/discussions)
 
 ### To-do items and deliverables

--- a/practices/secrets.md
+++ b/practices/secrets.md
@@ -16,7 +16,7 @@ See below for information about how to use `sops`.
 [`sops`](https://github.com/mozilla/sops) is a command-line tool for encrypting and decrypting secrets that are on disk.
 It is similar to [`git-crypt`](https://github.com/AGWA/git-crypt) (which is what is used by the Binder SRE team), but gives a bit more visibility into the encrypted fields by only encrypting the *values* rather than the *keys*.
 
-Here's an example of a file that has been encrypted with `sops` (from [our `pilot-hubs` configuration](https://github.com/2i2c-org/pilot-hubs/blob/master/config/secrets.yaml)):
+Here's an example of a file that has been encrypted with `sops` (from [our `infrastructure` configuration](https://github.com/2i2c-org/infrastructure/blob/master/config/secrets.yaml)):
 
 ```yaml
 auth0:
@@ -64,10 +64,10 @@ In order to decrypt an encrypted configuration file, you should first follow the
 Once you've completed those steps, do the following:
 
 1. **Navigate to the root of the repository**.
-   There are a set of rules stored in [`.sops.yaml`](https://github.com/2i2c-org/pilot-hubs/blob/master/.sops.yaml) that use regex to match a file to be encrypted with the encryption key location.
+   There are a set of rules stored in [`.sops.yaml`](https://github.com/2i2c-org/infrastructure/blob/master/.sops.yaml) that use regex to match a file to be encrypted with the encryption key location.
    You will receive an error from `sops` if you are not in the root folder and it cannot see this file.
 2. **Run the `sops` command**.
-   The following command will decrypt a configuration file (in this case, the configuration file in the `pilot-hubs` repository):
+   The following command will decrypt a configuration file (in this case, the configuration file in the `infrastructure` repository):
 
    ```bash
    sops --decrypt config/secrets.yaml

--- a/projects/managed-hubs/index.md
+++ b/projects/managed-hubs/index.md
@@ -10,12 +10,12 @@ We are also building a sales and support pipeline around this infrasturcture.
 
 ## Where is information located?
 
-**Infrastructure and development** happens in [the `pilot-hubs/` repository](https://github.com/2i2c-org/pilot-hubs).
+**Infrastructure and development** happens in [the `infrastructure/` repository](https://github.com/2i2c-org/infrastructure).
 This is both the deployment infrastructure for the 2i2c JupyterHubs, as well as documentation and team coordination around developing and running them.
 
-**The Hub Engineer's Guide** describes how to develop and operate the 2i2c `pilot-hubs/` infrastructure.
+**The Hub Engineer's Guide** describes how to develop and operate the 2i2c `infrastructure/` infrastructure.
 It is generally designed for 2i2c engineers to follow and learn.
-You can find it at [pilot-hubs.2i2c.org](https://pilot-hubs.2i2c.org).
+You can find it at [infrastructure.2i2c.org](https://infrastructure.2i2c.org).
 
 **The Hub Administrator's Guide** provides for Hub Administrators to customize and control their hub.
 It is community-facing, and meant as a more external view on the 2i2c Hubs Pilot.
@@ -28,7 +28,7 @@ For other information about the Managed Hubs Pilot, see the sections below.
 
 ## A list of running JupyterHubs
 
-We keep a table with all of our currently-running JupyterHubs at this location: [List of Running JupyterHubs](https://pilot-hubs.2i2c.org/en/latest/reference/hubs.html).
+We keep a table with all of our currently-running JupyterHubs at this location: [List of Running JupyterHubs](https://infrastructure.2i2c.org/en/latest/reference/hubs.html).
 
 ## Other project information
 

--- a/projects/managed-hubs/roles.md
+++ b/projects/managed-hubs/roles.md
@@ -29,7 +29,7 @@ The job of hub administrators is to support users and to perform common administ
 They are able to add users, start/stop servers, and generally have more control over operations on the hub.
 
 :::{seealso}
-See the [Pilot Hubs Administrator documentation](https://pilot.2i2c.org) for helpful information for Hub Administrators.
+See the [Community Hub Administrator documentation](https://docs.2i2c.org) for helpful information for Hub Administrators.
 :::
 
 :::{warning}

--- a/projects/managed-hubs/sales.md
+++ b/projects/managed-hubs/sales.md
@@ -83,10 +83,10 @@ Send an invoice and get to work 🚀
 The final step of the Leads and Sales process is to set up a managed JupyterHub for the lead (now, the "client"). To do so, follow the process below:
 
 Create an issue for the client
-: We use [issues in the `pilot-hubs/` repository](https://github.com/2i2c-org/pilot-hubs/issues) with the [{guilabel}`Hub` label](https://github.com/2i2c-org/pilot-hubs/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3AHub) to track the progress of each hub we are running.
+: We use [issues in the `infrastructure/` repository](https://github.com/2i2c-org/infrastructure/issues) with the [{guilabel}`Hub` label](https://github.com/2i2c-org/infrastructure/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3AHub) to track the progress of each hub we are running.
 
 The New Hub generation process
-: Follow the [process defined in the `pilot-hubs` repo](https://pilot-hubs.2i2c.org) in creating a new hub for a lead. This will then track the operation and maintenance of the hub.
+: Follow the [process defined in the `infrastructure` repo](https://infrastructure.2i2c.org) in creating a new hub for a lead. This will then track the operation and maintenance of the hub.
 
 :::{admonition} To Do: Create a Customer Management system
 In addition to tracking our sales / leads, we need to track running hubs and active customers in order to quickly understand their status and respond to their needs.


### PR DESCRIPTION
This renames references of `pilot hubs` to `infrastructure` or `community hubs` when we refer to specific hubs.