### PR TITLE
Update sprint planning meeting template

### DIFF
--- a/.github/ISSUE_TEMPLATE/meeting-sprint-planning.md
+++ b/.github/ISSUE_TEMPLATE/meeting-sprint-planning.md
@@ -26,12 +26,12 @@ _Follow the agenda below, checking boxes as we complete each step._
 **Review the Sprint Board.** (10m)
 
 - [ ] Celebrate our accomplishments
-- [ ] Decide what to do with any incomplete deliverables
 - [ ] Archive deliverables we finished
 
 **Populate Sprint Board with new deliverables** (45m)
 
-- [ ] Review and clarify any deliverables we'd like to work on next
+- [ ] Review a few more urgent items in the [deliverables backlog](https://github.com/orgs/2i2c-org/projects/22/views/1)
+- [ ] Decide what to do with any incomplete deliverables from the last sprint
 - [ ] Add new deliverables to Sprint Board
 - [ ] Somebody is assigned to each deliverable
 - [ ] Everybody agrees the current cycle's plan is realistic and that the right items are on the board.


### PR DESCRIPTION
Minor updates to our sprint planning meeting after some helpful brainstorming with @GeorgianaElena 

The major thing is that we've moved the "decide what to do with incomplete deliverables" section into the "planning what's next" section. That way we can focus the first part of the meeting just on recognizing what we've done.