### PR TITLE
Open sprint issue every two weeks

### DIFF
--- a/.github/workflows/create-sprint-planning-meeting.yaml
+++ b/.github/workflows/create-sprint-planning-meeting.yaml
@@ -15,8 +15,10 @@ jobs:
     - name: Calculate if we're on a 2-week cycle
       run: python datetime.py
       id: is-two-weeks
+    - name: Echo the weeks thus far 
+      run: echo "Is-two-weeks is ${{ steps.is-two-weeks.outputs.IS_TWO_WEEKS }}"
     - name: Open a new issue
-      if: ${{ steps.is-two-weeks.IS_TWO_WEEKS }} == 'True'
+      if: ${{ steps.is-two-weeks.outputs.IS_TWO_WEEKS }} == 'True'
       uses: JasonEtco/create-an-issue@v2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/create-sprint-planning-meeting.yaml
+++ b/.github/workflows/create-sprint-planning-meeting.yaml
@@ -16,7 +16,7 @@ jobs:
       run: python datetime.py
       id: is-two-weeks
     - name: Open a new issue
-      if: ${{ steps.is-two-weeks.IS_TWO_WEEKS == 'True' }}
+      if: steps.is-two-weeks.IS_TWO_WEEKS == 'True'
       uses: JasonEtco/create-an-issue@v2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/create-sprint-planning-meeting.yaml
+++ b/.github/workflows/create-sprint-planning-meeting.yaml
@@ -16,7 +16,7 @@ jobs:
       run: python datetime.py
       id: is-two-weeks
     - name: Open a new issue
-      if: steps.is-two-weeks.IS_TWO_WEEKS == 'True'
+      if: ${{ steps.is-two-weeks.IS_TWO_WEEKS }} == 'True'
       uses: JasonEtco/create-an-issue@v2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/create-sprint-planning-meeting.yaml
+++ b/.github/workflows/create-sprint-planning-meeting.yaml
@@ -15,7 +15,7 @@ jobs:
     - name: Calculate if we're on a 2-week cycle
       run: python datetime.py
       id: is-two-weeks
-    - name: Echo the weeks thus far 
+    - name: Print IS_TWO_WEEKS for reference
       run: echo "Is-two-weeks is ${{ steps.is-two-weeks.outputs.IS_TWO_WEEKS }}"
     - name: Open a new issue
       if: ${{ steps.is-two-weeks.outputs.IS_TWO_WEEKS }} == 'True'

--- a/.github/workflows/create-sprint-planning-meeting.yaml
+++ b/.github/workflows/create-sprint-planning-meeting.yaml
@@ -11,7 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: JasonEtco/create-an-issue@v2
+    - uses: actions/setup-python@v2
+    - name: Calculate if we're on a 2-week cycle
+      run: python datetime.py
+      id: is-two-weeks
+    - name: Open a new issue
+      if: ${{ steps.is-two-weeks.IS_TWO_WEEKS == 'True' }}
+      uses: JasonEtco/create-an-issue@v2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/.github/workflows/datetime.py
+++ b/.github/workflows/datetime.py
@@ -1,0 +1,17 @@
+#import date function from datetime module
+from datetime import date
+import os
+
+#provide the 1st date in YYYY,MM,DD format
+start_date = date(2021,11,1)
+
+#getting the result, abs = absolute value
+#(date1-date2).days gives an integer number of dates
+days = abs(date.today() - start_date).days
+
+# // makes result an integer (and rounds down)
+weeks = days // 7
+is_two_weeks = (weeks % 2) == 0
+
+# Store the variable value for use later
+print(f'::set-output name=IS_TWO_WEEKS::{is_two_weeks}'

--- a/.github/workflows/datetime.py
+++ b/.github/workflows/datetime.py
@@ -14,4 +14,4 @@ weeks = days // 7
 is_two_weeks = (weeks % 2) == 0
 
 # Store the variable value for use later
-print(f'::set-output name=IS_TWO_WEEKS::{is_two_weeks}'
+print(f'::set-output name=IS_TWO_WEEKS::{is_two_weeks}')

--- a/.github/workflows/datetime.py
+++ b/.github/workflows/datetime.py
@@ -1,6 +1,8 @@
-#import date function from datetime module
+"""
+Calculate whether the number of weeks since a reference date is divisible by 2.
+And use GitHub Actions outputs to store the result for use later on in the action.
+"""
 from datetime import date
-import os
 
 # This is a Tuesday before a sprint meeting, so we'll calculate every-two-weeks relative to this
 start_date = date(2021,11,9)  
@@ -10,5 +12,7 @@ difference_days = abs(date.today() - start_date).days
 weeks = difference_days // 7
 is_two_weeks = (weeks % 2) == 0
 
-# Store the variable value for use later
+# Store the output value for use later
+# See https://docs.github.com/en/actions/learn-github-actions/workflow-commands-for-github-actions#using-workflow-commands-to-access-toolkit-functions
+# for more information
 print(f'::set-output name=IS_TWO_WEEKS::{is_two_weeks}')

--- a/.github/workflows/datetime.py
+++ b/.github/workflows/datetime.py
@@ -2,15 +2,12 @@
 from datetime import date
 import os
 
-#provide the 1st date in YYYY,MM,DD format
-start_date = date(2021,11,1)
-
-#getting the result, abs = absolute value
-#(date1-date2).days gives an integer number of dates
-days = abs(date.today() - start_date).days
+# This is a Tuesday before a sprint meeting, so we'll calculate every-two-weeks relative to this
+start_date = date(2021,11,9)  
+difference_days = abs(date.today() - start_date).days
 
 # // makes result an integer (and rounds down)
-weeks = days // 7
+weeks = difference_days // 7
 is_two_weeks = (weeks % 2) == 0
 
 # Store the variable value for use later


### PR DESCRIPTION
The goal of this PR is to make our "open a sprint planning meeting" issue to open an issue every **two weeks** instead of every week. It uses the following logic:

- The action runs at the same time each week.
- It defines a `start_date` that is the reference date that we'll use to define "every two weeks"
- It takes the current date, and figures out the number of weeks since the `start_date`.
- It takes the modulo 2 of that difference.
- It checks if the modulo is 0, and stores this as a `bool` as an environment variable.
- The "open issue" step then checks the value of that environment variable before deciding whether to move forward.

I'm not positive that this PR as it stands actually works, so would love any comments on whether this looks correct to you :-)