### PR TITLE
Update support team process

### DIFF
--- a/.github/ISSUE_TEMPLATE/support-steward.md
+++ b/.github/ISSUE_TEMPLATE/support-steward.md
@@ -1,11 +1,11 @@
 ---
 name: "➡️ Support Steward transfer"
-about: Transition the support steward role between team members.
+about: Transition a support steward role between team members.
 labels: "type: support-steward"
 title: "Support Steward: <name>"
 ---
 
-This issue transitions the support steward role to a new team member!
+This issue transitions a support steward role to a new team member!
 We transition support steward roles every two weeks.
 The support steward rotates alphabetically through the 2i2c Engineering Team. Here's a [list of team members for support steward rotation](https://team-compass.2i2c.org/en/latest/about/team.html#open-infrastructure-team).
 
@@ -16,13 +16,13 @@ The support steward rotates alphabetically through the 2i2c Engineering Team. He
 
 ### Useful info
 
+- [Support Team membership issue](https://github.com/2i2c-org/team-compass/issues/294)
+- [Support Team process](https://team-compass.2i2c.org/en/latest/projects/managed-hubs/support.html)
 - [FreshDesk dashboard](https://2i2c.freshdesk.com/a/)
-- [Support Slack channel](https://2i2c.slack.com/archives/C028WU9PFBN)
 - [Open support issues and PRs](https://github.com/search?q=org%3A2i2c-org+label%3Asupport+is%3Aopen)
 
 ### Tasks to transition the support steward!
 
 - [ ] New support steward is named
 - [ ] New support steward has discussed open support issues with outgoing support steward
-- [ ] Previous support steward transfer issue is closed. Support steward now in steady-state.
-- [ ] Support steward's tenure is over. Time to [transfer the support steward role to a new team member](https://github.com/2i2c-org/team-compass/issues/new?assignees=&labels=type%3A+support-steward&template=support-steward.md&title=Support+Steward%3A+%3Cname%3E)
+- [ ] New support team member is added [to the Support Team issue](https://github.com/2i2c-org/team-compass/issues/294)

--- a/projects/managed-hubs/support.md
+++ b/projects/managed-hubs/support.md
@@ -1,6 +1,105 @@
-# Support process
+# Support team process
 
-:::{admonition} In Progress!
+:::{admonition} In Beta!
 :class: warning
-We are currently working out our support process. Check [this Google Doc for our current process](https://docs.google.com/document/d/17Kj_FbtVMl32TEcfvCp18fF1SEiBjVOhCswdidUytgM/edit).
+We are currently working out our support process.
+The content on this page might change over time, and we welcome suggested changes and pull requests!
 :::
+
+This is a team process to track **support requests** from users on the hubs that we run.
+
+## Overview
+
+The **support team** is a two-person team of Support Stewards that oversees all support requests for users of 2i2c hubs.
+The Support Stewards work together to regularly **communicate** with users that open FreshDesk tickets throughout the process, route support-related to work to engineering team members, and keep track of this work to ensure it is completed.
+
+For most support requests, we use [a FreshDesk service](https://2i2c.freshdesk.com/a/) to handle communcation with the community.
+
+## Support team structure
+
+The Support Team is a **two-person team** of Support Stewards that work together.
+Tenure on the support team is **for four weeks**.
+Every **two weeks** (generally at the sprint meeting), a Support Steward cycles off the support team, and a new team member joins the team.
+The support team rotates through [the “Open Infrastructure Engineering Team” on this page](https://team-compass.2i2c.org/en/latest/about/team.html), in alphabetical order.
+
+The current support team is listed in an [ongoing GitHub issue](https://github.com/2i2c-org/team-compass/issues/294).
+In the sprint meeting, we should edit this issue to add/remove Support Stewards as necessary.
+
+```{button-link} https://github.com/2i2c-org/team-compass/issues/294
+Support team issue
+```
+
+## Responsibilities and expectations
+
+These are some major responsibilities and goals of the support team:
+
+- Be the main point of contact for all support tickets regardless of the community
+- Communicate with the person opening a support ticket, to keep them in the loop
+- Create backlog issues as-needed
+- Route support issues to the engineering team in order to make the changes necessary to resolve the issue.
+- During events, be extra attentive to support channels in case a change is needed.
+
+:::{note}
+We should try to respond to all support-related communications **within one working day**.
+Even if the support request is not resolved, others appreciate when we keep them in-the-loop about what we're doing.
+:::
+
+## Tracking support items
+
+### FreshDesk requests
+
+For bugs, hub changes, improvements, and general questions, we use the [e-mail address `support@2i2c.org`](mailto:support@2i2c.org).
+This is connected with [the 2i2c FreshDesk account](https://2i2c.freshdesk.com/), and is a central place for all support-related requests.
+
+Many requests may be immediately resolved via a quick action or response to the community representative.
+However, if a request requires consultation with the team, open a backlog issue.
+
+(support:issues)=
+### Support issues
+
+If resolving a support issue requiries ongoing or concerted owrk, open a backlog issue tagged with the {guilabel}`support` label.
+
+Support backlog items should:
+
+- Be placed in our [Sprint Board](coordination:sprint-board).
+- Include a reference to any FreshDesk tickets if they exist.
+- Be prioritized over other backlog items for that sprint.
+
+## Communication channels
+
+We use two Slack channels to discuss support-related questions on the 2i2c hub:
+
+- The [#support-freshdesk](https://2i2c.slack.com/archives/C028WU9PFBN) is for discussing support tickets on Freshdesk.
+  Open a Slack thread for each support ticket, to have conversation around it amongst the team.
+  This channel is private because there’s an assumption of privacy when we discuss community-specific support matters.
+- The [#hub-support](https://2i2c.slack.com/archives/C01DB2JRP8W) channel is for discussing more general support-related issues relating to operating the 2i2c Hubs, and not not related to a specific FreshDesk ticket.
+  This channel is public, so can be useful if we wish to invite conversation from non 2i2c team members.
+
+## Lifecycle of a support request
+
+- When you receive a ticket, communicate that you have received it and note the next steps you’ll follow to resolve it (even if this just means investigating because you're not sure what is wrong).
+- If needed, open a [support issue and add it to the backlog](support:issues).
+- Identify an engineering team member that can pick up this work.
+- Give the user updates every day or two as we work to resolve the issue.
+- When it is resolved, tell the user what you’ve done to resolve the issue.
+- Close any FreshDesk tickets and support issues that are related to this request.
+
+## How to prioritize support requests
+
+- Ask whether an issue is "critical" (AKA does the hub not work at all) and prioritize these if so
+- Events should be prioritized (or in general, moments with a large influx of users)
+- In general, "how much does this incident impact the users of a given hub?" is a good guideline for deciding what to prioritize
+
+
+## Asking for help from others
+
+The support team is primarily a **communicator** and a **router** - they are not necessarily the ones who carry out the changes needed to resolve a support issue.
+Instead, the support team is empowered to ask engineering team members to pick up backlog items that are related to support requests.
+
+When a support request is made that requires an action from a 2i2c engineer, a Support Steward should describe this change in a GitHub issue, and add it to the [Sprint Board](coordination:sprint-board).
+Think about an engineering team member that likely has the skills and capacity needed, and ask them if they are willing to take on resolving this issue.
+Try not to ask the same person for support help many times in a row - we should spread the work needed to address support issues across the team.
+
+## Who can make support requests?
+
+See the [2i2c documentation support page](support:email) for information about how users can open support requests.

--- a/projects/managed-hubs/support.md
+++ b/projects/managed-hubs/support.md
@@ -11,9 +11,9 @@ This is a team process to track **support requests** from users on the hubs that
 ## Overview
 
 The **support team** is a two-person team of Support Stewards that oversees all support requests for users of 2i2c hubs.
-The Support Stewards work together to regularly **communicate** with users that open FreshDesk tickets throughout the process, route support-related to work to engineering team members, and keep track of this work to ensure it is completed.
+The Support Stewards work together to regularly **communicate** with users that open FreshDesk tickets, route support-related to engineering team members, and keep track of this work to ensure it is completed.
 
-For most support requests, we use [a FreshDesk service](https://2i2c.freshdesk.com/a/) to handle communcation with the community.
+For most support requests, we use [a FreshDesk service](https://2i2c.freshdesk.com/a/) to handle communication with the communities.
 
 ## Support team structure
 
@@ -52,12 +52,12 @@ For bugs, hub changes, improvements, and general questions, we use the [e-mail a
 This is connected with [the 2i2c FreshDesk account](https://2i2c.freshdesk.com/), and is a central place for all support-related requests.
 
 Many requests may be immediately resolved via a quick action or response to the community representative.
-However, if a request requires consultation with the team, open a backlog issue.
+However, if a request requires consultation with the team, first open a thread in the {guilabel}`#support-freshdesk` Slack channel, and if necessary open a backlog issue or a .
 
 (support:issues)=
 ### Support issues
 
-If resolving a support issue requiries ongoing or concerted owrk, open a backlog issue tagged with the {guilabel}`support` label.
+If resolving a support issue requires ongoing or concerted work, open a backlog issue tagged with the {guilabel}`support` label.
 
 Support backlog items should:
 
@@ -76,6 +76,13 @@ We use two Slack channels to discuss support-related questions on the 2i2c hub:
   This channel is public, so can be useful if we wish to invite conversation from non 2i2c team members.
 
 ## Lifecycle of a support request
+
+
+Below is a summary of the major steps that make up the support process, from beginning to end of a ticket.
+
+:::{note}
+We should try to respond to all support-related communications within one working day.
+:::
 
 - When you receive a ticket, communicate that you have received it and note the next steps you’ll follow to resolve it (even if this just means investigating because you're not sure what is wrong).
 - If needed, open a [support issue and add it to the backlog](support:issues).

--- a/projects/managed-hubs/support.md
+++ b/projects/managed-hubs/support.md
@@ -52,7 +52,10 @@ For bugs, hub changes, improvements, and general questions, we use the [e-mail a
 This is connected with [the 2i2c FreshDesk account](https://2i2c.freshdesk.com/), and is a central place for all support-related requests.
 
 Many requests may be immediately resolved via a quick action or response to the community representative.
-However, if a request requires consultation with the team, first open a thread in the {guilabel}`#support-freshdesk` Slack channel, and if necessary open a backlog issue or a .
+If a request requires consultation with the team, then:
+
+- Open a Slack thread in the {guilabel}`#support-freshdesk` channel to discuss with others. If we need to track a work item to resolve the ticket over time, then:
+- Open a GitHub issue with the {guilabel}`support` label, and add it to our Sprint backlog.
 
 (support:issues)=
 ### Support issues
@@ -86,6 +89,7 @@ We should try to respond to all support-related communications within one workin
 
 - When you receive a ticket, communicate that you have received it and note the next steps you’ll follow to resolve it (even if this just means investigating because you're not sure what is wrong).
 - If needed, open a [support issue and add it to the backlog](support:issues).
+  Note that we should still use Freshdesk for support communication on this request, the GitHub issue is just for 2i2c team members to coordinate.
 - Identify an engineering team member that can pick up this work.
 - Give the user updates every day or two as we work to resolve the issue.
 - When it is resolved, tell the user what you’ve done to resolve the issue.
@@ -93,7 +97,7 @@ We should try to respond to all support-related communications within one workin
 
 ## How to prioritize support requests
 
-- Ask whether an issue is "critical" (AKA does the hub not work at all) and prioritize these if so
+- Ask questions that will help us understand whether an issue is "critical". For example, "Does this effect many users on the hub, or just a subset?", "Does this problem always happen, or intermittently?", "Is the hub accessible at all or is it totally down?".
 - Events should be prioritized (or in general, moments with a large influx of users)
 - In general, "how much does this incident impact the users of a given hub?" is a good guideline for deciding what to prioritize
 


### PR DESCRIPTION
This provides a number of updates to our team support process, pulling in [content from our support draft document](https://docs.google.com/document/d/17Kj_FbtVMl32TEcfvCp18fF1SEiBjVOhCswdidUytgM/edit#heading=h.2o7un34fgv7m) as well as conversations with @damianavila and @consideRatio after their latest support steward experiences.

It makes a few changes to the support process itself:

- adds the notion of a Support Team, and suggests that 2 people should be on this team at once.
- increases the Support Steward tenure to 4 weeks instead of 2 weeks (so every 2 weeks we transition one Support Steward on the 2-person team)
- suggests that we use a persistent GitHub issue that lists the current Support Team, and we can just update this over time as team membership changes

### Feedback

I'd love feedback in particular from @damianavila and @consideRatio since many of these ideas came from conversations with them. I also haven't had a chance to debrief with @GeorgianaElena yet but would love her thoughts on whether there's anything we should add or change here!

closes https://github.com/2i2c-org/team-compass/issues/291