### PR TITLE
Fix action timing for sprint planning

### DIFF
--- a/.github/workflows/create-sprint-planning-meeting.yaml
+++ b/.github/workflows/create-sprint-planning-meeting.yaml
@@ -1,8 +1,8 @@
 name: Open a sprint planning meeting issue
 on:
   schedule:
-  # Run every Wednesday at 07:00 AM UTC / 09:00AM Europe / 00:00AM California
-  - cron: "0 07 * * 3"
+  # Run every Tuesday at 07:00 AM UTC / 09:00AM Europe / 00:00AM California
+  - cron: "0 07 * * 2"
 
   workflow_dispatch:
 

--- a/.github/workflows/is-two-weeks.py
+++ b/.github/workflows/is-two-weeks.py
@@ -4,8 +4,8 @@ And use GitHub Actions outputs to store the result for use later on in the actio
 """
 from datetime import date
 
-# This is a Tuesday before a sprint meeting, so we'll calculate every-two-weeks relative to this
-start_date = date(2021,11,9)  
+# This is a Thursday after a sprint meeting, so we'll calculate every-two-weeks relative to this
+start_date = date(2021,11,11)  
 difference_days = abs(date.today() - start_date).days
 n_days_since_last_meeting = difference_days % 14  # Because we have a new meeting every 14 days.
 n_weeks_since_last_meeting = (n_days_since_last_meeting // 7) + 1


### PR DESCRIPTION
I think I figured out what was going wrong with our sprint planning action opener, so this PR:

- Calculates the number of days since the day *after* our last sprint planning meeting, that way we correctly detect whether we are nearing the end of week 1, or week 2 of a sprint
- Runs this every Tuesday instead of Wednesday, so that we have a day's notice reminder that the meeting is happening