### PR TITLE
Update roles and backlog practices from last meeting

### DIFF
--- a/.github/ISSUE_TEMPLATE/meeting-sprint-planning.md
+++ b/.github/ISSUE_TEMPLATE/meeting-sprint-planning.md
@@ -17,7 +17,6 @@ Our goal is to synchronize the team on the most important things to work on, and
 ### Meeting roles
 
 - **Meeting facilitator**: {{ NAME }}
-- **Next Support Steward**: {{ NAME }}
 
 ### Meeting agenda
 

--- a/.github/ISSUE_TEMPLATE/support-steward.md
+++ b/.github/ISSUE_TEMPLATE/support-steward.md
@@ -11,18 +11,17 @@ The support steward rotates alphabetically through the 2i2c Engineering Team. He
 
 ### Support steward
 
-- Incoming Support Steward:`@<INSERT HANDLE>`
-- _Outgoing Support Steward: `@<INSERT HANDLE>`_
+- **Incoming Support Steward**:`@<INSERT HANDLE>`
+- **Outgoing Support Steward**: `@<INSERT HANDLE>`
 
 ### Useful info
 
-- [Support Team membership issue](https://github.com/2i2c-org/team-compass/issues/294)
+- [Team Roles membership issue](https://github.com/2i2c-org/team-compass/issues/294)
 - [Support Team process](https://team-compass.2i2c.org/en/latest/projects/managed-hubs/support.html)
 - [FreshDesk dashboard](https://2i2c.freshdesk.com/a/)
 - [Open support issues and PRs](https://github.com/search?q=org%3A2i2c-org+label%3Asupport+is%3Aopen)
 
 ### Tasks to transition the support steward!
 
-- [ ] New support steward is named
+- [ ] The [Team Roles membership issue](https://github.com/2i2c-org/team-compass/issues/294) is updated with new support steward
 - [ ] New support steward has discussed open support issues with outgoing support steward
-- [ ] New support team member is added [to the Support Team issue](https://github.com/2i2c-org/team-compass/issues/294)

--- a/practices/development.md
+++ b/practices/development.md
@@ -123,8 +123,18 @@ This represents the work that the team is planning to do in the near future.
 These items adhere to the following principles:
 
 - The order of items should be roughly according to priority, with higher priority items at the top of lists.
-- Items on the board should have a **status** that signals whether they are being actively worked on, ready to work, or need more refinement before working.
+- Items on the board should have a **status** that signals whether they are ready to work or need more refinement before working.
 - If an item has multiple components or would otherwise take longer than a sprint to complete, create new issues as sub-tasks, and add *them* to the Sprint Board.
+
+### Assigning to an issue
+
+Only assign a backlog issue to somebody if it is **actively being worked on**.
+We assume that once somebody is assigned to an issue, it is part of an active sprint.
+Note that **all** issues on our Sprint Backlog should have somebody assigned to them.
+
+:::{admonition} Our definition of "Work in Progress"
+Because issues that are actively being worked on must have somebody assigned to them, we use "the issues that have somebody assigned to them" as our definition of Work in Progress.
+:::
 
 ### Backlog item limits
 

--- a/practices/meetings.md
+++ b/practices/meetings.md
@@ -30,8 +30,15 @@ These are major roles that should be filled by someone explicitly for any team m
 ### Facilitator
 
 The role of meeting facilitator is to structure the meeting so that it is well-scoped, and to guide conversation to be productive and inclusive.
+We use [this GitHub issue to track which team members are currently serving in this role](https://github.com/2i2c-org/team-compass/issues/294).
 
-:::{admonition} Responsibilities of the Facilitator
+```{button-link} https://github.com/2i2c-org/team-compass/issues/294
+:color: primary
+Team Roles membership issue
+```
+
+#### Responsibilities of the Facilitator
+
 Before the meeting
 :  - Collect rough agenda items from team members
    - Set the agenda
@@ -43,7 +50,7 @@ After the meeting
 : - Convert actionable items into issues
   - Clean up the notes after the meeting and archive them in the appropriate location (e.g., the Team Compass)
   - Close-out the meeting issue
-:::
+
 
 #### Who serves as the facilitator?
 

--- a/projects/managed-hubs/roles.md
+++ b/projects/managed-hubs/roles.md
@@ -64,10 +64,16 @@ This is an experimental role and the details may change!
 
 The Support Steward is tasked with keeping track of ongoing support requests to `support@2i2c.org`.
 They do not necessarily complete the request themselves, and should work with other engineers to ensure they are resolved.
+We use [this GitHub issue to track which team members are currently serving in each role](https://github.com/2i2c-org/team-compass/issues/294).
 
 The Support Steward rotates throughout the engineering team each sprint, in order to ensure that all team members share the load of supporting our communities.
 
 See [the Support Process proposal](https://docs.google.com/document/d/17Kj_FbtVMl32TEcfvCp18fF1SEiBjVOhCswdidUytgM/edit?usp=sharing) for the latest version of our support process.
+
+```{button-link} https://github.com/2i2c-org/team-compass/issues/294
+:color: primary
+Team Roles membership issue
+```
 
 ### Responsibilities
 


### PR DESCRIPTION
This makes a few minor team process updates after our last meeting:

- Adds some references to [our team roles meta issue](https://github.com/2i2c-org/team-compass/issues/294) which is the issue we can use to track who is in what role at each moment in time.
- Simplifies our support steward transition issue a bit, and reduces some of the redundant information
- Documents our practice of assigning people to an issue once it's actively being worked on, and defines our team's current "Work in Progress" as "the issues that have somebody assigned to them"
  - This is the biggest change in this PR, it means that we should take a strict approach to issue assignment, so that we *only* assign somebody when they're actively working on it, and if somebody is no longer actively working on an issue then we should remove their assignment from it.

red #312 and some conversations in there and after