### PR TITLE
Add PTO and benefits information

### DIFF
--- a/hr/compensation.md
+++ b/hr/compensation.md
@@ -1,0 +1,13 @@
+# Compensation and Benefits
+
+## Compensation philosophy
+
+See [the 2i2c Careers page](https://2i2c.org/careers/) for a short description of our compensation philosophy.
+
+Salaries at 2i2c are determined solely by job title as well as several steps within that job (corresponding to experience in a particular job).
+We have [internal salary documents for the specific positions and levels](https://docs.google.com/spreadsheets/d/1FJM5pAbc0EWhu4CpPjlbWTMOsZAnivEd2ZBIZIdwpE8/edit?usp=sharing).
+
+## Benefits
+
+Benefits are offered by {term}`Code for Science and Society`.
+They are offered via [TriNet](https://www.trinet.com/) as described in [the CS&S employee handbook](https://drive.google.com/file/d/1anHo8P09gjGLnUfGj2ceSDxvJTYwMeS1/view?usp=sharing).

--- a/hr/index.md
+++ b/hr/index.md
@@ -1,0 +1,10 @@
+# Human resources
+
+These sections contain information about **Human Resources at 2i2c**.
+This includes employment information, salary information, benefits, etc.
+
+```{toctree}
+compensation.md
+job-titles.md
+time-off.md
+```

--- a/hr/job-titles.md
+++ b/hr/job-titles.md
@@ -1,4 +1,4 @@
-# Positions and Salaries
+# Job Titles
 
 This document represents the positions and salary levels that 2i2c uses. They are inspired by the hiring/salary structure of several tech companies[^job-refs].
 
@@ -59,10 +59,5 @@ This role focuses their efforts on our infrastructure, but spends a lot of their
 ### Director of 2i2c
 
 This role is the director of 2i2c. They oversee strategy, execution, and fundraising at 2i2c. They also ensure that 2i2c engineers are empowered to execute on their responsibilities, and thrive in their positions.
-
-
-## Salaries
-
-Salaries at 2i2c are determined solely by job title as well as several steps within that job (corresponding to experience in a particular job). Currently, the salary policy of 2i2c is [listed on the careers page of our website](https://2i2c.org/careers/). We additionally have [internal salary documents for the specific positions and levels](https://docs.google.com/spreadsheets/d/1FJM5pAbc0EWhu4CpPjlbWTMOsZAnivEd2ZBIZIdwpE8/edit?usp=sharing).
 
 [^job-refs]: In particular, [Buffer](https://buffer.com/resources/salary-formula-changes-2019/) and [Basecamp](https://m.signalvnoise.com/how-we-pay-people-at-basecamp/)

--- a/hr/time-off.md
+++ b/hr/time-off.md
@@ -46,7 +46,7 @@ Just do the best you can, and try to balance your own constraints with respect f
 
 ## Inspiration
 
-2i2c's PTO policy is inspired by several other remote organizations. In particular, [Buffer](https://buffer.com/resources/employees-take-vacation/), [GitLab](https://about.gitlab.com/handbook/paid-time-off/), and [BaseCamp](https://basecamp.com/handbook/08-benefits-and-perks#paid-time-off).
+2i2c's PTO policy is inspired by several other remote organizations. In particular, [Buffer](https://buffer.com/resources/employees-take-vacation/), [GitLab](https://about.gitlab.com/handbook/paid-time-off/), and [BaseCamp](https://basecamp.com/handbook/07-benefits-and-perks#paid-time-off).
 
 [^time-off]: 40 days a year is based off of the [list of paid holidays by country](https://en.wikipedia.org/wiki/List_of_minimum_annual_leave_by_country) from Wikipedia.
   A rough calculation of the **90th percentile** of days off by country yielded **40 days** each year. Here’s [a notebook that describes this analysis](https://notebooksharing.space/view/a94504e5a06b437d20e1b9488ad1241a48d5ff3e80c8181f95294c765e23c42e#displayOptions=).

--- a/hr/time-off.md
+++ b/hr/time-off.md
@@ -1,0 +1,51 @@
+# Taking time Off
+
+In general, 2i2c inherits its benefits and paid time off policy from {term}`Code for Science and Society`.
+These policies are detailed in the [CS&S Employee Handbook](https://drive.google.com/file/d/1anHo8P09gjGLnUfGj2ceSDxvJTYwMeS1/view?usp=sharing). This page describes some 2i2c-specific practices that are applied in addition to the CS&S policies.
+
+## Goals
+
+- Normalize our PTO policies across countries, so that team members don’t get different PTO depending on their country of residence.
+- Choose PTO policies that minimize the chance that a team member will take *fewer- days off per year than the minimum in their country.
+- Do not apply hard limits and restrictions, but instead encourage soft minimums and coordination amongst team members.
+- Encourage a focus on contributions to the team and organization over number of days worked.
+- Base our numbers off of objective data where possible.
+
+## Policy
+
+- 2i2c does not have a limit on the number of days you may take off each year.
+- We recommend that all 2i2c team members take **at least 40 days** (8 weeks) annually (pro-rated if you started work mid-way through the year).[^time-off]
+- We do not treat holidays differently from vacation days.
+- You must open an issue to tell others about your intention to take time off, and you must add your intended time off to the [Team Leave Calendar](https://calendar.google.com/calendar/u/2?cid=Y19pNTJqZGNhbTZ0M3FsaDF1NTNqdG42MjNwY0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t).
+
+### Guidelines for taking time off
+
+- **Don’t ask, do tell.** Tell team members as early as possible before you take time off. A good rule of thumb is to tell others in advance twice as long as you’ll be off (so for 2 days, let people know 4 days in advance; for 1 week, let others know 2 weeks in advance, etc).
+- **Be mindful of the team.** We strive to build team processes that give us the capacity for team members to regularly take time off, but please consider the team’s obligations around the time you’re taking off. For example, during important team meetings, particularly high-stress events, etc.
+- **Discuss with others if there are objections.** If a team member believes that your time off would be unfairly harmful to the team, they may object via commenting in the github issue for your time off. In general, team members should only object if a person’s time off would significantly harm 2i2c’s ability to accomplish its mission. If there are objections, we should aim to resolve these via discussion amongst the team. However, ultimately it is the decision of the person requesting time off.
+- **Weekends and holiday seasons are exceptional.** We do not expect team members to work during weekends, and we also expect that many team members may be off simultaneously during heavy holiday seasons (in particular, the end of the year). This may create tension, as we are running services that run 24/7. We signal our intent to protect holidays and weekends by advertising reduced responsiveness with no promises during these times. If we feel obligated to engage with a community “outside work hours”, we should recognize this and ensure the people doing this work feel valued and fairly treated.
+
+## Process for taking time off
+
+Open a GitHub Issue in the `2i2c-org/meta` repository using [the “Time off” template](https://github.com/2i2c-org/meta/issues/new?assignees=&labels=time-off&template=time-off.md).
+Follow the steps in that template.
+
+## Sick and personal leave
+
+2i2c team members should always prioritize their own well-being and health.
+If for any reason you must take a leave for personal reasons, you are encouraged to do so.
+Follow the process described above in this case - you are welcome to describe your intention however you wish.
+In this case, our guidelines around letting others know ahead of time are somewhat relaxed, as sick leave may happen unexpectedly.
+Just do the best you can, and try to balance your own constraints with respect for the team’s bandwidth and planning.
+
+## Unknowns to resolve
+
+- This process is likely too informal if our team significantly scales in size and complexity.
+- Our process for having group discussion if there’s an objection to time off may be under-specified, and we may need to make it more formal if this creates tension.
+
+## Inspiration
+
+2i2c's PTO policy is inspired by several other remote organizations. In particular, [Buffer](https://buffer.com/resources/employees-take-vacation/), [GitLab](https://about.gitlab.com/handbook/paid-time-off/), and [BaseCamp](https://basecamp.com/handbook/08-benefits-and-perks#paid-time-off).
+
+[^time-off]: 40 days a year is based off of the [list of paid holidays by country](https://en.wikipedia.org/wiki/List_of_minimum_annual_leave_by_country) from Wikipedia.
+  A rough calculation of the **90th percentile** of days off by country yielded **40 days** each year. Here’s [a notebook that describes this analysis](https://notebooksharing.space/view/a94504e5a06b437d20e1b9488ad1241a48d5ff3e80c8181f95294c765e23c42e#displayOptions=).

--- a/hr/time-off.md
+++ b/hr/time-off.md
@@ -1,12 +1,12 @@
 # Taking time Off
 
-In general, 2i2c inherits its benefits and paid time off policy from {term}`Code for Science and Society`.
+In general, 2i2c inherits its benefits and paid time off (PTO) policy from {term}`Code for Science and Society`.
 These policies are detailed in the [CS&S Employee Handbook](https://drive.google.com/file/d/1anHo8P09gjGLnUfGj2ceSDxvJTYwMeS1/view?usp=sharing). This page describes some 2i2c-specific practices that are applied in addition to the CS&S policies.
 
 ## Goals
 
 - Normalize our PTO policies across countries, so that team members don’t get different PTO depending on their country of residence.
-- Choose PTO policies that minimize the chance that a team member will take *fewer- days off per year than the minimum in their country.
+- Choose PTO policies that minimize the chance that a team member will take *fewer* days off per year than the minimum in their country.
 - Do not apply hard limits and restrictions, but instead encourage soft minimums and coordination amongst team members.
 - Encourage a focus on contributions to the team and organization over number of days worked.
 - Base our numbers off of objective data where possible.
@@ -15,7 +15,7 @@ These policies are detailed in the [CS&S Employee Handbook](https://drive.google
 
 - 2i2c does not have a limit on the number of days you may take off each year.
 - We recommend that all 2i2c team members take **at least 40 days** (8 weeks) annually (pro-rated if you started work mid-way through the year).[^time-off]
-- We do not treat holidays differently from vacation days.
+- We do not treat national holidays differently from vacation days.
 - You must open an issue to tell others about your intention to take time off, and you must add your intended time off to the [Team Leave Calendar](https://calendar.google.com/calendar/u/2?cid=Y19pNTJqZGNhbTZ0M3FsaDF1NTNqdG42MjNwY0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t).
 
 ### Guidelines for taking time off
@@ -23,7 +23,7 @@ These policies are detailed in the [CS&S Employee Handbook](https://drive.google
 - **Don’t ask, do tell.** Tell team members as early as possible before you take time off. A good rule of thumb is to tell others in advance twice as long as you’ll be off (so for 2 days, let people know 4 days in advance; for 1 week, let others know 2 weeks in advance, etc).
 - **Be mindful of the team.** We strive to build team processes that give us the capacity for team members to regularly take time off, but please consider the team’s obligations around the time you’re taking off. For example, during important team meetings, particularly high-stress events, etc.
 - **Discuss with others if there are objections.** If a team member believes that your time off would be unfairly harmful to the team, they may object via commenting in the github issue for your time off. In general, team members should only object if a person’s time off would significantly harm 2i2c’s ability to accomplish its mission. If there are objections, we should aim to resolve these via discussion amongst the team. However, ultimately it is the decision of the person requesting time off.
-- **Weekends and holiday seasons are exceptional.** We do not expect team members to work during weekends, and we also expect that many team members may be off simultaneously during heavy holiday seasons (in particular, the end of the year). This may create tension, as we are running services that run 24/7. We signal our intent to protect holidays and weekends by advertising reduced responsiveness with no promises during these times. If we feel obligated to engage with a community “outside work hours”, we should recognize this and ensure the people doing this work feel valued and fairly treated.
+- **Weekends and holiday seasons are exceptional.** We do not expect team members to work during weekends, and we also expect that many team members may be off simultaneously during heavy holiday seasons (in particular, the end of the calendar year). This may create tension, as we are running services that run 24/7. We signal our intent to protect holidays and weekends by advertising reduced responsiveness with no promises during these times. If we feel obligated to engage with a community “outside work hours”, we should recognize this and ensure the people doing this work feel valued and fairly treated.
 
 ## Process for taking time off
 

--- a/hr/time-off.md
+++ b/hr/time-off.md
@@ -1,3 +1,4 @@
+(hr/time-off)=
 # Taking time Off
 
 In general, 2i2c inherits its benefits and paid time off (PTO) policy from {term}`Code for Science and Society`.

--- a/index.md
+++ b/index.md
@@ -50,6 +50,17 @@ meetings/eng/index
 reference/calendar
 ```
 
+## Projects and Services
+
+These sections cover major active projects and services that 2i2c is currently working on or offering.
+They go into more detail about the plans, structure, and strategy of each project.
+
+```{toctree}
+:caption: Projects and Services
+projects/index
+projects/managed-hubs/index
+```
+
 ## About 2i2c
 
 Information about the broader 2i2c organization, as well as its mission and structure.
@@ -59,10 +70,8 @@ Information about the broader 2i2c organization, as well as its mission and stru
 :caption: About 2i2c
 
 about
-projects/index
-projects/managed-hubs/index
+hr/index
 about/structure
 about/strategy
-positions
 reference/index
 ```

--- a/practices/communication.md
+++ b/practices/communication.md
@@ -96,34 +96,6 @@ In addition, we may create private rooms on a short-term basis for specific even
 
 ## Taking time off
 
-First and foremost, 2i2c fosters a culture of healthy balance between work and life. All 2i2c team members should take the time they need to thrive - this will both make you happier and help us accomplish our mission most effectively.
-
-The 2i2c team uses [a shared Google Calendar](https://calendar.google.com/calendar/u/2?cid=Y19pNTJqZGNhbTZ0M3FsaDF1NTNqdG42MjNwY0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t) to keep track of when team members will be away.
-Everyone at 2i2c has access to it, and has the ability to add events to this calendar.
-
-**Use the Calendar to let the team know you're taking time off**.
-Here are the reasons that you might do so:
-
-**Personal Time Off**: If you're taking personal time off (e.g., vacation, holidays, personal leave, etc), add an event to this calendar with a title to let others know you'll be away.
-
-For example:
-
-```
-AWAY: <your name> - <optional reason>
-```
-
-**Reduced time**: If you expect to be on **reduced time** for an extended period, please use the calendar for this as well.
-
-For example:
-
-```
-REDUCED: <your name> - <optional reason>
-```
-
-**Holidays**: Please add any national holidays for your location of residence if you expect that you (or others in your location) may take time off for this as well.
-
-For example:
-
-```
-HOLIDAY: <holiday name>
-```
+It's critical that you communicate with team members when you intend to take time off.
+This helps the team plan for your absence, and ensures that we are spreading work equitably and intentionally.
+See [](hr/time-off) for our practices and policies for taking time off.


### PR DESCRIPTION
This adds a few pieces of information around benefits and PTO, as part of https://github.com/2i2c-org/meta/issues/257.

- Adds our time off policy
- Adds some CSS-specific links to our benefits etc
- Re-arranges our pages a little bit so we have a dedicated HR section that we can expand. Also creates a separate "Services and Projects" section so that it is not conflated with the "about 2i2c" section.
