### PR TITLE
NEW: Team roles calendar

### DIFF
--- a/.github/ISSUE_TEMPLATE/meeting-team.md
+++ b/.github/ISSUE_TEMPLATE/meeting-team.md
@@ -13,9 +13,10 @@ _Information about when and where the meeting will take place_
 
 - **Date:** <YYYY-MM-DD>
 - **Time:** 7:30AM US/Pacific time (or [**your timezone**](https://arewemeetingyet.com/Los%20Angeles/<YYYY-MM-DD>/07:30/2i2c%20Team%20Meeting#eyJ1cmwiOiJodHRwczovL2hhY2ttZC5pby9ZNVNCTXhWN1I2Q01xemVUWGdtNWtBIn0=))
-- **Video conference link:** https://zoom.2i2c.org
-- **HackMD for meeting:** https://hackmd.io/Y5SBMxV7R6CMqzeTXgm5kA
-- **Calendar for future meetings:** [this Google Calendar](https://calendar.google.com/calendar/embed?src=c_4hjjouojd8psql9i1a8nd1uff4%40group.calendar.google.com&ctz=America%2FLos_Angeles)
+- [**Video conference link**](https://zoom.2i2c.org)
+- [**HackMD for meeting**](https://hackmd.io/Y5SBMxV7R6CMqzeTXgm5kA)
+- [**Calendar for future meetings**](https://calendar.google.com/calendar/embed?src=c_4hjjouojd8psql9i1a8nd1uff4%40group.calendar.google.com&ctz=America%2FLos_Angeles)
+- [**Calendar for Team Roles**](https://calendar.google.com/calendar/embed?src=c_nq8hl7qsm484g1p7mfkm29jpo8%40group.calendar.google.com&ctz=America%2FLos_Angeles)
 
 # Follow up issues
 
@@ -35,7 +36,7 @@ _Steps to take to have the meeting._
 
 ### Team roles
 
-_List the current and next meeting facilitator using the list from [our team page](https://team-compass.2i2c.org/en/latest/about/team.html)_
+_List the current and next meeting facilitator using the list from our team roles calendar (see link above)_
 
 - Facilitator for this month: {{ NAME }}
 - Facilitator for next month: {{ NAME }}

--- a/.github/ISSUE_TEMPLATE/support-steward.md
+++ b/.github/ISSUE_TEMPLATE/support-steward.md
@@ -7,7 +7,6 @@ title: "Support Steward: <name>"
 
 This issue transitions a support steward role to a new team member!
 We transition support steward roles every two weeks.
-The support steward rotates alphabetically through the 2i2c Engineering Team. Here's a [list of team members for support steward rotation](https://team-compass.2i2c.org/en/latest/about/team.html#open-infrastructure-team).
 
 ### Support steward
 
@@ -16,12 +15,12 @@ The support steward rotates alphabetically through the 2i2c Engineering Team. He
 
 ### Useful info
 
-- [Team Roles membership issue](https://github.com/2i2c-org/team-compass/issues/294)
+- [Here's a calendar of support steward roles](https://calendar.google.com/calendar/embed?src=c_nq8hl7qsm484g1p7mfkm29jpo8%40group.calendar.google.com&ctz=America%2FLos_Angeles)
 - [Support Team process](https://team-compass.2i2c.org/en/latest/projects/managed-hubs/support.html)
 - [FreshDesk dashboard](https://2i2c.freshdesk.com/a/)
 - [Open support issues and PRs](https://github.com/search?q=org%3A2i2c-org+label%3Asupport+is%3Aopen)
 
 ### Tasks to transition the support steward!
 
-- [ ] The [Team Roles membership issue](https://github.com/2i2c-org/team-compass/issues/294) is updated with new support steward
+- [ ] This issue has been updated with the next support steward (see Team Roles calendar)
 - [ ] New support steward has discussed open support issues with outgoing support steward

--- a/practices/meetings.md
+++ b/practices/meetings.md
@@ -30,12 +30,10 @@ These are major roles that should be filled by someone explicitly for any team m
 ### Facilitator
 
 The role of meeting facilitator is to structure the meeting so that it is well-scoped, and to guide conversation to be productive and inclusive.
-We use [this GitHub issue to track which team members are currently serving in this role](https://github.com/2i2c-org/team-compass/issues/294).
 
-```{button-link} https://github.com/2i2c-org/team-compass/issues/294
-:color: primary
-Team Roles membership issue
-```
+:::{seealso}
+See [our Team Roles calendar](team-roles-calendar) to know when each team member serves in this role.
+:::
 
 #### Responsibilities of the Facilitator
 

--- a/projects/managed-hubs/roles.md
+++ b/projects/managed-hubs/roles.md
@@ -3,10 +3,6 @@
 There are a few major roles that we define for the Managed JupyterHub Service.
 These are outlined below.
 
-:::{seealso}
-They are also described in [the Hub Services diagrams slideshow](https://docs.google.com/presentation/d/1kqrviwVOoZfey_rujhIasdkKZmlYgxV-1J2AG-nr3VY/edit#slide=id.ge3f2127292_0_573) as well as in the [Managed Service Plan](https://docs.google.com/document/d/1Ka7tgJe7HR8EmS_MMakrYztgfkJT_iFksPsWHdQBqhM/edit?usp=sharing).
-:::
-
 (roles:community-representative)=
 ## Community Representative
 
@@ -56,32 +52,11 @@ People in these roles are generally affiliated with 2i2c.
 - Debug and resolve major issues with a hub that require intervention from a Hub Engineer
 - Perform open source development on technologies that are in use by the hubs
 
-## Support Steward
+(roles:support-steward)=
+## Support Stewards
 
-:::{warning}
-This is an experimental role and the details may change!
-:::
-
-The Support Steward is tasked with keeping track of ongoing support requests to `support@2i2c.org`.
-They do not necessarily complete the request themselves, and should work with other engineers to ensure they are resolved.
-We use [this GitHub issue to track which team members are currently serving in each role](https://github.com/2i2c-org/team-compass/issues/294).
-
-The Support Steward rotates throughout the engineering team each sprint, in order to ensure that all team members share the load of supporting our communities.
-
-See [the Support Process proposal](https://docs.google.com/document/d/17Kj_FbtVMl32TEcfvCp18fF1SEiBjVOhCswdidUytgM/edit?usp=sharing) for the latest version of our support process.
-
-```{button-link} https://github.com/2i2c-org/team-compass/issues/294
-:color: primary
-Team Roles membership issue
-```
-
-### Responsibilities
-
-- Check the communication channels for support that we are using
-- Respond to new support requests
-- Communicate with community representatives throughout the support process
-- Coordinate with engineering team members to ensure support requests are completed
-- Pay attention to ongoing support efforts to ensure they are resolved in a timely manner
+Support Stewards are the first point of contact for all support-related issues.
+See [](support:process) for more information.
 
 ## Diagram of roles
 

--- a/projects/managed-hubs/support.md
+++ b/projects/managed-hubs/support.md
@@ -1,3 +1,5 @@
+
+(support:process)=
 # Support team process
 
 :::{admonition} In Beta!
@@ -22,12 +24,9 @@ Tenure on the support team is **for four weeks**.
 Every **two weeks** (generally at the sprint meeting), a Support Steward cycles off the support team, and a new team member joins the team.
 The support team rotates through [the “Open Infrastructure Engineering Team” on this page](https://team-compass.2i2c.org/en/latest/about/team.html), in alphabetical order.
 
-The current support team is listed in an [ongoing GitHub issue](https://github.com/2i2c-org/team-compass/issues/294).
-In the sprint meeting, we should edit this issue to add/remove Support Stewards as necessary.
-
-```{button-link} https://github.com/2i2c-org/team-compass/issues/294
-Support team issue
-```
+:::{seealso}
+See [our Team Roles calendar](team-roles-calendar) to know when each team member serves in this role.
+:::
 
 ## Responsibilities and expectations
 

--- a/reference/calendar.md
+++ b/reference/calendar.md
@@ -1,7 +1,27 @@
 (team/calendar)=
-# 2i2c Team Calendar
+# Team Calendars
+
+## 2i2c Events
 
 Below is a calendar with some relevant events for the 2i2c Team and Community.
 You can find a [link to the team calendar here](https://calendar.google.com/calendar/embed?src=c_4hjjouojd8psql9i1a8nd1uff4%40group.calendar.google.com&ctz=America%2FLos_Angeles).
 
 <iframe src="https://calendar.google.com/calendar/embed?height=600&amp;wkst=1&amp;bgcolor=%23ffffff&amp;ctz=America%2FLos_Angeles&amp;src=Y180aGpqb3VvamQ4cHNxbDlpMWE4bmQxdWZmNEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t&amp;src=Y19pNTJqZGNhbTZ0M3FsaDF1NTNqdG42MjNwY0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t&amp;src=Y184ZmhrOXBtZmxocWM3OWI2bWY0dnEwYjlwc0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t&amp;color=%23009688&amp;color=%23616161&amp;color=%234285F4&amp;showTitle=0&amp;showPrint=0&amp;showTabs=0&amp;showCalendars=1" style="border:solid 1px #777" width="800" height="600" frameborder="0" scrolling="no"></iframe>
+
+(team-roles-calendar)=
+## Team Roles Calendar
+
+We use a Team Roles calendar to keep track of when each team member is serving in a given role.
+You can find [the Team Roles calendar here](https://calendar.google.com/calendar/embed?src=c_nq8hl7qsm484g1p7mfkm29jpo8%40group.calendar.google.com&ctz=America%2FLos_Angeles).
+
+Here's a short description of our Team Roles:
+
+Support Stewards
+: Are the first point of contact for all support requests at `support@2i2c.org`.
+  See [](roles:support-steward) for more information.
+
+Meeting Facilitator
+: Leads our monthly team meetings.
+  See [](meetings:roles) for more information.
+
+<iframe src="https://calendar.google.com/calendar/embed?src=c_nq8hl7qsm484g1p7mfkm29jpo8%40group.calendar.google.com&ctz=America%2FLos_Angeles" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>


### PR DESCRIPTION
This adds a team roles calendar to keep track of when team members are in each role, rather than documenting this via #294 . I've created that calendar and populated it for the next 3 months with the team members that are serving in each role.

closes #294    
closes #334 