### PR TITLE
ENH: Convert team syncs from issues to slack only

### DIFF
--- a/.github/ISSUE_TEMPLATE/team-update.ARCHIVEDmd
+++ b/.github/ISSUE_TEMPLATE/team-update.ARCHIVEDmd
@@ -1,3 +1,11 @@
+"""
+NOTE: This markdown file is archived, as we have moved our team updates to
+use the Slack Geekbot. However, we're keeping it in the repository for now in
+case we'd like to revisit this practice.
+
+If we haven't touched this file or needed it by March 2022, we should
+delete it and the GitHub actions associated with it!
+"""
 ---
 name: "♻ Team sync"
 about: Syncronize the team's goals and actions

--- a/.github/workflows/close-team-sync.ARCHIVEDyaml
+++ b/.github/workflows/close-team-sync.ARCHIVEDyaml
@@ -1,3 +1,6 @@
+# **
+# Archived: delete this in March 2022 if we don't decide to re-use it by then.
+# **
 # From https://github.com/marketplace/actions/close-matching-issues
 name: Close a weekly team sync issue
 on:

--- a/.github/workflows/create-team-sync.ARCHIVEDyaml
+++ b/.github/workflows/create-team-sync.ARCHIVEDyaml
@@ -1,3 +1,6 @@
+# **
+# Archived: delete this in March 2022 if we don't decide to re-use it by then.
+# **
 name: Open a weekly team sync issue
 on:
   schedule:

--- a/conf.py
+++ b/conf.py
@@ -66,6 +66,7 @@ linkcheck_ignore = [
     "https://drive.google.com*",  # Because it's almost always private
     "https://icsi.berkeley.edu*",  # Because it's broken often
     "https://sociocracyforall.org*",  # Because it raises a 403 but still works
+    "https://airtable.com*",  # Because it has some kind of security that returns a 403
 ]
 
 

--- a/meetings/eng/2021.md
+++ b/meetings/eng/2021.md
@@ -12,7 +12,6 @@ All of the discussions here were already encoded as issues and google docs (link
 
 ### Paid Time Off / Holiday plans (25m)
 
-- [Proposal language](https://docs.google.com/document/d/1uvfcQUJYZXK0RTLOQ6lx3Lc7JzSbm_p0sieWK6OQ1bQ/edit)
 - High-level policy
   - don't ask for permission, but do be transparent and do coordinate with the team
   - Unlimited PTO, target of 40 days, don't distinguish between personal and national holiday

--- a/practices/development.md
+++ b/practices/development.md
@@ -30,7 +30,7 @@ Wednesday (beginning of sprint)
 During the sprint
 : Team members work on the items assigned to them at the sprint planning meeting.
   We use [the Sprint Board](coordination:sprint-board) to coordinate our activities during the sprint.
-  On Mondays, each team member fills out a **team sync update** to share the major things they worked on, and note any unexpected challenges or blockers.
+  We provide updates about what we've been up to, what we're doing next, and where we need help via regular **asynchronous Slack stand-ups**.
 
 Tuesday of week 2 (end of sprint)
 : By the end of the day, team members should have completed all of their items for that sprint.
@@ -73,6 +73,32 @@ The Sprint Board is broken down into these columns:
 - {guilabel}`Done` Items that are complete! These should be celebrated archived in the next Sprint Planning meeting.
 
 In addition, we have a few other pieces of metadata to signal different kind of actions that would be needed 
+
+
+(coordination:team-syncs)=
+## Daily team syncs
+
+Throughout the week we have a lightweight asynchronous team sync process so that we can get on the same page.
+The primary goals of this process are:
+
+- To ensure that nobody is stuck on something
+- To signal-boost requests for review and help
+- To provide accountability of what we've been up to
+- To help us coordinate what to do next
+
+We use [the Geekbot](https://geekbot.com/) to manage this process.
+During a sync, each team member gets a message in their morning time with a few questions.
+Answer each question, and at the end the answers will be posted to our `#team-updates` channel.
+
+:::{seealso}
+You can customize the way that Geekbot standups work for you.
+See [the Geekbot workflow guides](https://help.geekbot.com/en/articles/4283332-commands-how-to-streamline-your-workflow) for some helpful information.
+:::
+
+:::{admonition} TODO: Share this publicly
+We are exploring ways to aggregate and share our team sync activity publicly, to be more transparent with others about what we are up to.
+We will update this section once we better-understand this process.
+:::
 
 (coordination:deliverables)=
 ## Deliverables and work issues

--- a/practices/development.md
+++ b/practices/development.md
@@ -79,6 +79,7 @@ In addition, we have a few other pieces of metadata to signal different kind of 
 ## Daily team syncs
 
 Throughout the week we have a lightweight asynchronous team sync process so that we can get on the same page.
+These currently happen on Monday, Wednesday, and Friday in the morning time of each team member.
 The primary goals of this process are:
 
 - To ensure that nobody is stuck on something

--- a/practices/index.md
+++ b/practices/index.md
@@ -13,26 +13,6 @@ Here are the goals we optimize for in organizing our team coordination practices
 
 We want to do this with high efficiency so that people can quickly get on the same page and focus efforts around decision-making and collaboration. We also wish to do it in a 💯 remote-friendly way since we are split across many different time-zones.
 
-
-(coordination:team-syncs)=
-## Weekly team syncs
-
-Every Monday, the 2i2c Hub Operations team conducts a team sync to get on the same page and coordinate their tasks for the week.
-
-A GitHub Action will automatically create a new Team Sync issue at the beginning of each Monday.
-This action uses [this issue template](https://github.com/2i2c-org/team-compass/blob/main/.github/ISSUE_TEMPLATE/team-update.md) and inserts currently open/actionable issues before creating the sync issue.
-
-Here is the process for our team syncs.
-
-1. **On Mondays a new issue is created automatically**. This issue is our space to discuss, update, and sync.
-2. **Team members give their responses**. You can copy/paste the template, and then give your responses in comments to the issue. You shouldn't feel forced to add content if you can't think of anything, use it as much as is useful.
-3. **Discuss and agree on next steps throughout the day**. The goal is to ensure that important issues have somebody paying attention to them, and that team members are supported in the tasks they work towards. At the end of the day the issue is automatically closed.
-
-```{note}
-While these syncs happen once a week, the process of communicating with team members and working on tasks / deliverables can be dynamic and constantly updating.
-The syncs are just to get everyone on the same page.
-```
-
 ```{toctree}
 communication
 development


### PR DESCRIPTION
This converts our team sync process to use the Slack Geekbot instead of GitHub issues each week. Here are major changes:

- Archives our actions and issue template around creating a weekly team sync. I've decided to archive them rather than delete them for now, in case we want to re-visit this practice. But I've added notes to delete them in a few months if we don't change things up.
- Moves our weekly sync process into the development coordination guide, since I think that's a more natural place for it.

ref https://github.com/2i2c-org/team-compass/issues/259