### PR TITLE
Add compensation reference docs

### DIFF
--- a/hr/compensation.md
+++ b/hr/compensation.md
@@ -7,6 +7,24 @@ See [the 2i2c Careers page](https://2i2c.org/careers/) for a short description o
 Salaries at 2i2c are determined solely by job title as well as several steps within that job (corresponding to experience in a particular job).
 We have [internal salary documents for the specific positions and levels](https://docs.google.com/spreadsheets/d/1FJM5pAbc0EWhu4CpPjlbWTMOsZAnivEd2ZBIZIdwpE8/edit?usp=sharing).
 
+### GuideStar compensation comparisons
+
+We define our salary levels relative to non-profit organizations with a similar size and scope as 2i2c.
+In order to have a more objective definition of competitive salaries, we use [the GuideStar compensation report](https://www.guidestar.org/) to compare common numbers across non-profits.
+This is provided by CS&S, and we have a PDF in our drive here:
+
+- [GuideStar Report for non-profits similar to us(2020)](https://drive.google.com/file/d/1qb6qSTBqvrgQeTywjHfMlAqhUDau-x31/view?usp=sharing) - - [Full report here](https://drive.google.com/file/d/1i6cO-FjwN0nZfTfBUf7Vd9hdVILNeCQw/view?usp=sharing)
+
+We generally use the following criteria when defining the salary for a given position / level with the GuideStar report:
+
+- Use the “Science and Technology Research Institutes, Services” category
+- Use the $1m-$5m budget category
+- Choose an appropriate job category that most closely matches this position.
+- Define “compensation” as base salary + 30% benefits
+- Aim for the median compensation in a category 
+- The numbers there are for the **top-paid position**  
+  - Reduce accordingly depending on the level we're hiring for. A good rule of thumb for defining new roles is to expect a 10% salary bump between levels, and a 2% salary bump for steps within a level.
+
 ## Benefits
 
 Benefits are offered by {term}`Code for Science and Society`.


### PR DESCRIPTION
In designing the new role for https://github.com/2i2c-org/meta/issues/256 , we used the GuideStar report (provided by CS&S) to have a more data-driven definition of salaries for similar organizations. I wrote up a short set of guidelines for the process that we followed to define the salary for this role, so that we are transparent about where our salaries come from and so we can re-use it in the future.