### PR TITLE
Add a rationale to our compensation page

### DIFF
--- a/hr/compensation.md
+++ b/hr/compensation.md
@@ -29,3 +29,12 @@ We generally use the following criteria when defining the salary for a given pos
 
 Benefits are offered by {term}`Code for Science and Society`.
 They are offered via [TriNet](https://www.trinet.com/) as described in [the CS&S employee handbook](https://drive.google.com/file/d/1anHo8P09gjGLnUfGj2ceSDxvJTYwMeS1/view?usp=sharing).
+
+## Rationale
+
+Below is a brief rationale for a few major aspects of our compensation strategy. We believe that these practices allow 2i2c to hire competitively, equitably, and successfully.
+
+- We want to set salaries that are very competitive for tech-focused non-profits of a similar size.
+- We also want to hire competitively for the tech industry, while recognizing that we do not have the same access to capital because we are a non-profit.
+- We believe in equal pay for equal work. We don’t believe that a team member's ability to support the mission of 2i2c is impacted by their ability to negotiate a better salary. We also don’t think it is impacted by external factors like geographical location or cost of living.
+- We believe in transparency and openness when it comes to our salaries, in order to balance the amount of information on both sides of the hiring equation. 

--- a/practices/secrets.md
+++ b/practices/secrets.md
@@ -10,13 +10,17 @@ This means we try to use services where team members have their own account with
 **When we must share secrets**: If we must share secrets for an account (for example, credentails for deployment to cloud infrastructure), then we use [the command-line tool `sops`](https://github.com/mozilla/sops) to encrypt our secrets.
 See below for information about how to use `sops`.
 
+We try to keep encrypted secrets files near their configuration files.
+For example, we'll keep a Kubernetes configuration file in the same folder as the secrets that are needed to make changes to that cluster.
+See [the 2i2c GKE cluster folder](https://github.com/2i2c-org/infrastructure/tree/master/config/clusters/2i2c) for an example.
+
 (secrets:sops)=
 ## `sops` overview
 
 [`sops`](https://github.com/mozilla/sops) is a command-line tool for encrypting and decrypting secrets that are on disk.
 It is similar to [`git-crypt`](https://github.com/AGWA/git-crypt) (which is what is used by the Binder SRE team), but gives a bit more visibility into the encrypted fields by only encrypting the *values* rather than the *keys*.
 
-Here's an example of a file that has been encrypted with `sops` (from [our `infrastructure` configuration](https://github.com/2i2c-org/infrastructure/blob/master/config/secrets.yaml)):
+Here's an example of a file that has been encrypted with `sops` (from [our `infrastructure` configuration](https://github.com/2i2c-org/infrastructure/blob/master/config/clusters/2i2c/enc-grafana-token.secret.yaml)):
 
 ```yaml
 auth0:

--- a/practices/secrets.md
+++ b/practices/secrets.md
@@ -20,7 +20,7 @@ See [the 2i2c GKE cluster folder](https://github.com/2i2c-org/infrastructure/tre
 [`sops`](https://github.com/mozilla/sops) is a command-line tool for encrypting and decrypting secrets that are on disk.
 It is similar to [`git-crypt`](https://github.com/AGWA/git-crypt) (which is what is used by the Binder SRE team), but gives a bit more visibility into the encrypted fields by only encrypting the *values* rather than the *keys*.
 
-Here's an example of a file that has been encrypted with `sops` (from [our `infrastructure` configuration](https://github.com/2i2c-org/infrastructure/blob/master/config/clusters/2i2c/enc-grafana-token.secret.yaml)):
+Here's an example of a file that has been encrypted with `sops` (from [our `infrastructure` configuration](https://github.com/2i2c-org/infrastructure/blob/HEAD/config/clusters/2i2c/enc-grafana-token.secret.yaml)):
 
 ```yaml
 auth0:

--- a/practices/secrets.md
+++ b/practices/secrets.md
@@ -12,7 +12,7 @@ See below for information about how to use `sops`.
 
 We try to keep encrypted secrets files near their configuration files.
 For example, we'll keep a Kubernetes configuration file in the same folder as the secrets that are needed to make changes to that cluster.
-See [the 2i2c GKE cluster folder](https://github.com/2i2c-org/infrastructure/tree/master/config/clusters/2i2c) for an example.
+See [the 2i2c GKE cluster folder](https://github.com/2i2c-org/infrastructure/tree/HEAD/config/clusters/2i2c) for an example.
 
 (secrets:sops)=
 ## `sops` overview


### PR DESCRIPTION
As a part of https://github.com/2i2c-org/2i2c-org.github.io/pull/93 I'm updating our compensation page a bit. We had a long paragraph about our rationale there, but I think this makes more sense as a part of our compensation strategy documents, and we can cross-link it from our 2i2c.org site.