### PR TITLE
Update sops and secrets docs

### DIFF
--- a/practices/secrets.md
+++ b/practices/secrets.md
@@ -1,4 +1,4 @@
-# Secrets, credientials, and passwords
+# Secrets, credentials, and passwords
 
 This section describes how 2i2c team members share and access sensitive credentials that allow permissions on our infrastructure and services.
 
@@ -56,6 +56,10 @@ To use `sops` with a 2i2c configuration file, follow these steps:
 3. **Set up the Google Cloud Key Management Service (KMS)**. This allows you to use your Google Cloud login to provide authentication for `sops`.
    [Follow the `sops` instructions to use KMS](https://github.com/mozilla/sops/#encrypting-using-gcp-kms).
 
+```{note}
+Step 3 is only required when setting up `sops` for the first time.
+```
+
 To confirm that `sops` has been set up properly, try encrypting or decrypting a configuration file per the sections below.
 
 ### Decrypt secrets with `sops`
@@ -64,13 +68,13 @@ In order to decrypt an encrypted configuration file, you should first follow the
 Once you've completed those steps, do the following:
 
 1. **Navigate to the root of the repository**.
-   There are a set of rules stored in [`.sops.yaml`](https://github.com/2i2c-org/infrastructure/blob/master/.sops.yaml) that use regex to match a file to be encrypted with the encryption key location.
+   There are a set of rules stored in [`.sops.yaml`](https://github.com/2i2c-org/infrastructure/blob/HEAD/.sops.yaml) that use regex to match a file to be encrypted with the encryption key location.
    You will receive an error from `sops` if you are not in the root folder and it cannot see this file.
 2. **Run the `sops` command**.
-   The following command will decrypt a configuration file (in this case, the configuration file in the `infrastructure` repository):
+   The following command will decrypt a configuration file:
 
    ```bash
-   sops --decrypt config/secrets.yaml
+   sops --decrypt example/path/to/a/sops-file.yaml
    ```
 
    :::{tip}
@@ -79,9 +83,13 @@ Once you've completed those steps, do the following:
 
    You should see the **decrypted configuration file** printed to `stdout`.
 
-   :::{admonition} Decrypt the file in-place
-   If you'd like to decrypt a configuration file in-place, use the `--in-place` or `-i` flag.
-   This will **overwrite** the configuration file with a decrypted version.
+   :::{admonition} Secret file naming conventions
+   We have naming conventions in place for our secret files that allow us to:
+
+   1. Identify when a file is encrypted or not, and
+   2. Use `.gitignore` rules to assist us in not committing unencrypted secrets to the repository
+
+   See our [infrastructure docs](https://infrastructure.2i2c.org/en/latest/topic/secrets.html) for more information on this.
    :::
 
 ### Learn more about `sops`

--- a/practices/secrets.md
+++ b/practices/secrets.md
@@ -51,9 +51,9 @@ To use `sops` with a 2i2c configuration file, follow these steps:
 3. **Set up the Google Cloud Key Management Service (KMS)**. This allows you to use your Google Cloud login to provide authentication for `sops`.
    [Follow the `sops` instructions to use KMS](https://github.com/mozilla/sops/#encrypting-using-gcp-kms).
 
-```{note}
-Step 3 is only required when setting up `sops` for the first time.
-```
+   ```{note}
+   This step is only required when setting up `sops` for the first time.
+   ```
 
 To confirm that `sops` has been set up properly, try encrypting or decrypting a configuration file per the sections below.
 

--- a/practices/secrets.md
+++ b/practices/secrets.md
@@ -16,28 +16,23 @@ See below for information about how to use `sops`.
 [`sops`](https://github.com/mozilla/sops) is a command-line tool for encrypting and decrypting secrets that are on disk.
 It is similar to [`git-crypt`](https://github.com/AGWA/git-crypt) (which is what is used by the Binder SRE team), but gives a bit more visibility into the encrypted fields by only encrypting the *values* rather than the *keys*.
 
-Here's an example of a file that has been encrypted with `sops` (from [our `infrastructure` configuration](https://github.com/2i2c-org/infrastructure/blob/master/config/secrets.yaml)):
+Here's an example of a file that has been encrypted with `sops` (from [our `infrastructure` configuration](https://github.com/2i2c-org/infrastructure/blob/HEAD/config/clusters/2i2c/enc-grafana-token.secret.yaml)):
 
 ```yaml
-auth0:
-    domain: ENC[AES256_GCM,data:aEi/GvnxpyGsvinhZ5sXXto=,iv:SR6sgQronhovtuUpQnSuIO2KFo9eTSP9tgFqg+QBJ8I=,tag:6yzNIPmFEWilI1qajTH1WQ==,type:str]
-    client_id: ENC[AES256_GCM,data:aHw7KJCg4Hn2RiLIiONQXnc48/JFsCCnW0WFVLtCFgM=,iv:FFxe1kNtBh5ljroqCTW3wicQzyDszSCSyYx4Boe2Dns=,tag:a/m2QDTrcKpurKq0IZPjOw==,type:str]
-    client_secret: ENC[AES256_GCM,data:B+fw9jZUc2b0Mb9CD/Pas+aZLPd3Rp1GI6Wrq0wXYcE5HvMEOXhXOqzl9nEKhbR/cVAh5YZt+xlI8G2zOraWbQ==,iv:nDIxzcuQ5Noxp7HyYsL02hBRDLi9An5MN8IEdLnLffA=,tag:T4GgBUkzfSV5UC8RX8yT2g==,type:str]
-secret_key: ENC[AES256_GCM,data:ZT5kb64zUJIEKhUQSKgCRF8HcEnvK59KCtVs6TEO+O3S5qWBJIJY9kivlYU8a93XRN9cxIi9YlG4EfLoFR5JUw==,iv:V5OKGcKfG6s4EKdonrosvFJPltujSp5z4SZ8th9SkYs=,tag:jqQcK4+HO+i8SLerABYxeQ==,type:str]
+grafana_token: ENC[AES256_GCM,data:o337Q5SSoBxk5bwSbbM12OO06LfLGsyWhh/SHccH4uOllMPSt4lN9EoRThfhDasrKaXyDmCNBdX+VBPrvBl1S61d7FG1Dfc/Cou3UODe99pZ53N1anooF5Oz38I=,iv:kai3CpHRtx1k9E5iZIcOOXFg0iElr7z+Q1+sZm6TNyI=,tag:1DfUibZUUIjaEMzpf0xkSw==,type:str]
 sops:
-    kms: []
-    gcp_kms:
-        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
-          created_at: "2021-04-20T11:50:21Z"
-          enc: CiQA4OM7eLU3yaaPc6QnzaG3oPhN+OtaG+JCEd57CTIQcOSi+RUSSQBy9hCYh5zsV6u1djsUJPdj+2rwIb3aj0ZWkmZC+XtgXRrGTcI9BuUnnk25yyzi0HWr3CBZxARltajdQHydZCXlY+O28vsySkg=
-    azure_kv: []
-    hc_vault: []
-    age: []
-    lastmodified: "2021-06-11T06:36:56Z"
-    mac: ENC[AES256_GCM,data:oW0k09Gd65XK0OxRcX9jPaDMatFPrE42A6rdIHvKNQBmM2MY+VECKLbDzci1Ob9VZsp91ss0psn0im28z9G/Fjf6adRwXjtnI7k5KkEwkwivxpnk9RX+ZyPkFn4ccnhbHEciRU4NVS1upFJLCGDs9EBZ6FTXzMEx5aL2jUlLXYA=,iv:oaIR4rwUgcLpEFo19kziEuNJwf407NHPQVsM2pPRvxY=,tag:zozw57Qc1CYVj6TLkiyPlQ==,type:str]
-    pgp: []
-    unencrypted_suffix: _unencrypted
-    version: 3.7.1
+  kms: []
+  gcp_kms:
+    - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+      created_at: "2021-10-18T17:21:01Z"
+      enc: CiQA4OM7eCwqoRc3NEE62VoPH0gA0Po3esF12tQCnZPYegT5EeQSSQC9ZQbL4hYbnpjbvR0/ye+TTgW6I/0h4Ltv5uU2m5s+EQ4jLWLW/5oqpKIRyisqxQJaU42cFb6CeiII/117BEwXaGx0K+e+NDA=
+  azure_kv: []
+  hc_vault: []
+  lastmodified: "2021-10-27T10:10:54Z"
+  mac: ENC[AES256_GCM,data:rT4AaoBrRR9Ok4oB+ptLzMqdMecQxzIZqs2wXiPO5qazj20QyYlz2GCk5Szc8xw8itvjRh2G4SnbdWmNbtVvns3zTT1/OXtTTOiwAfVSYtMwF7hIxLYlMb1T/0RoYEmnxy8joa50+ClnHJk+cStcx0EF5ll1B++dpCMGP5oH/G4=,iv:r+TXdJZiPYP2kpSeiz2l1szvPXOZxSnns9GtTmHx1Xk=,tag:eaNOhcBdXYiBXdhrsqlW2g==,type:str]
+  pgp: []
+  unencrypted_suffix: _unencrypted
+  version: 3.6.1
 ```
 
 As you can see, we have access to the **key names** but the **values are encrypted**.


### PR DESCRIPTION
Refresh of the docs around secrets and sops in our team-compass. Links back to infrastructure docs for details including naming conventions.