### PR TITLE
Update pilot links to docs

### DIFF
--- a/projects/index.md
+++ b/projects/index.md
@@ -35,8 +35,8 @@ The [organizational foundation project](https://github.com/orgs/2i2c-org/project
 The Managed JupyterHub Service is a special project of 2i2c that is [developed and described at this website](managed-hubs/index.md).
 
 :::{admonition} Tracking deliverables
-- [the high level goals and strategy are described here](https://pilot.2i2c.org/en/latest/about/strategy.html)
-- [the roadmap for the service is described here](https://pilot.2i2c.org/en/latest/about/roadmap.html)
+- [the high level goals and strategy are described here](https://docs.2i2c.org/en/latest/about/strategy.html)
+- [the roadmap for the service is described here](https://docs.2i2c.org/en/latest/about/roadmap.html)
 :::
 
 More information about the Managed JupyterHub Service can be found in these sections:

--- a/projects/managed-hubs/index.md
+++ b/projects/managed-hubs/index.md
@@ -20,7 +20,7 @@ You can find it at [infrastructure.2i2c.org](https://infrastructure.2i2c.org).
 **The Hub Administrator's Guide** provides for Hub Administrators to customize and control their hub.
 It is community-facing, and meant as a more external view on the 2i2c Hubs Pilot.
 It also describes high-level information about the pilot in general.
-It is located at [pilot.2i2c.org](https://pilot.2i2c.org) (or [the `pilot/` repository](https://github.com/2i2c-org/pilot))
+It is located at [docs.2i2c.org](https://docs.2i2c.org) (or [the `docs/` repository](https://github.com/2i2c-org/docs))
 
 **Strategy and roadmaps** for the Managed Hubs Pilot are located in the Hub Administrator's guide. 
 


### PR DESCRIPTION
Minor updates to rename `pilot.2i2c.org` to `docs.2i2c.org`

ref: https://github.com/2i2c-org/docs/pull/127