### PR TITLE
Remove sprint concept and center the coordination in the backlog

### DIFF
--- a/.github/ISSUE_TEMPLATE/meeting-coordination-planning.md
+++ b/.github/ISSUE_TEMPLATE/meeting-coordination-planning.md
@@ -1,11 +1,11 @@
 ---
-name: "🚀 Cycle Planning Meeting"
-about: Conduct a Cycle Planning meeting.
+name: "🚀 Coordination Planning Meeting"
+about: Conduct a Coordination Planning meeting.
 labels: "type: team-sync, :label: meeting:cycle-planning"
-title: "Cycle Planning Meeting: {{ date | date('add', 1, 'days') | date('dddd, MMMM Do') }}"
+title: "Coordination Planning Meeting: {{ date | date('add', 1, 'days') | date('dddd, MMMM Do') }}"
 ---
 
-# 2i2c Cycle Planning meeting
+# 2i2c Coordination Planning meeting
 
 This is a **60 minute** recurring meeting **every other Wednesday at 7:30AM Pacific time** (here's [**a timezone converter**](https://arewemeetingyet.com/Los%20Angeles/2000-01-01/07:30/2i2c%20Team%20Meeting#eyJ1cmwiOiJodHRwczovL2hhY2ttZC5pby9ZNVNCTXhWN1I2Q01xemVUWGdtNWtBIn0=), ignore the date!).
 

--- a/.github/ISSUE_TEMPLATE/meeting-sprint-planning.md
+++ b/.github/ISSUE_TEMPLATE/meeting-sprint-planning.md
@@ -1,11 +1,11 @@
 ---
-name: "🚀 Sprint Planning Meeting"
-about: Conduct a Sprint Planning meeting.
-labels: "type: team-sync, :label: meeting:sprint-planning"
-title: "Sprint Planning Meeting: {{ date | date('add', 1, 'days') | date('dddd, MMMM Do') }}"
+name: "🚀 Cycle Planning Meeting"
+about: Conduct a Cycle Planning meeting.
+labels: "type: team-sync, :label: meeting:cycle-planning"
+title: "Cycle Planning Meeting: {{ date | date('add', 1, 'days') | date('dddd, MMMM Do') }}"
 ---
 
-# 2i2c Sprint Planning meeting
+# 2i2c Cycle Planning meeting
 
 This is a **60 minute** recurring meeting **every other Wednesday at 7:30AM Pacific time** (here's [**a timezone converter**](https://arewemeetingyet.com/Los%20Angeles/2000-01-01/07:30/2i2c%20Team%20Meeting#eyJ1cmwiOiJodHRwczovL2hhY2ttZC5pby9ZNVNCTXhWN1I2Q01xemVUWGdtNWtBIn0=), ignore the date!).
 
@@ -30,9 +30,9 @@ For each operations or support item, we should:
 
 For each project, its champion does the following:
 
-- Share accomplishments since the last sprint, demos, etc
+- Share accomplishments since the last cycle, demos, etc
 - Discuss any quick blockers or major questions to answer
-- Discuss the work plan for the next sprint for this project
+- Discuss the work plan for the next cycle for this project
 
 **Context share from admin and sustainability** (5 min, if time)
 

--- a/.github/workflows/create-team-coordination-issues.yaml
+++ b/.github/workflows/create-team-coordination-issues.yaml
@@ -12,7 +12,7 @@ on:
         default: false
 
 jobs:
-  create-cycle-planning-issue:
+  create-coordination-planning-issue:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -30,13 +30,13 @@ jobs:
       if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled }}
       uses: mxschmitt/action-tmate@v3
 
-    - name: Open a cycle planning issue
+    - name: Open a coordination planning issue
       if: ${{ steps.is-two-weeks.outputs.IS_TWO_WEEKS == 'True' }} 
       uses: JasonEtco/create-an-issue@v2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        filename: .github/ISSUE_TEMPLATE/meeting-cycle-planning.md
+        filename: .github/ISSUE_TEMPLATE/meeting-coordination-planning.md
 
     - name: Open a support steward transfer issue
       if: ${{ steps.is-two-weeks.outputs.IS_TWO_WEEKS == 'True' }} 

--- a/.github/workflows/create-team-coordination-issues.yaml
+++ b/.github/workflows/create-team-coordination-issues.yaml
@@ -12,7 +12,7 @@ on:
         default: false
 
 jobs:
-  create-sprint-planning-issue:
+  create-cycle-planning-issue:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -30,13 +30,13 @@ jobs:
       if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled }}
       uses: mxschmitt/action-tmate@v3
 
-    - name: Open a sprint planning issue
+    - name: Open a cycle planning issue
       if: ${{ steps.is-two-weeks.outputs.IS_TWO_WEEKS == 'True' }} 
       uses: JasonEtco/create-an-issue@v2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        filename: .github/ISSUE_TEMPLATE/meeting-sprint-planning.md
+        filename: .github/ISSUE_TEMPLATE/meeting-cycle-planning.md
 
     - name: Open a support steward transfer issue
       if: ${{ steps.is-two-weeks.outputs.IS_TWO_WEEKS == 'True' }} 

--- a/.github/workflows/is-two-weeks.py
+++ b/.github/workflows/is-two-weeks.py
@@ -4,7 +4,7 @@ And use GitHub Actions outputs to store the result for use later on in the actio
 """
 from datetime import date
 
-# This is a Thursday after a sprint meeting, so we'll calculate every-two-weeks relative to this
+# This is a Thursday after a cycle meeting, so we'll calculate every-two-weeks relative to this
 start_date = date(2021,11,11)  
 difference_days = abs(date.today() - start_date).days
 n_days_since_last_meeting = difference_days % 14  # Because we have a new meeting every 14 days.

--- a/.github/workflows/is-two-weeks.py
+++ b/.github/workflows/is-two-weeks.py
@@ -4,7 +4,7 @@ And use GitHub Actions outputs to store the result for use later on in the actio
 """
 from datetime import date
 
-# This is a Thursday after a cycle meeting, so we'll calculate every-two-weeks relative to this
+# This is a Thursday after a coordination meeting, so we'll calculate every-two-weeks relative to this
 start_date = date(2021,11,11)  
 difference_days = abs(date.today() - start_date).days
 n_days_since_last_meeting = difference_days % 14  # Because we have a new meeting every 14 days.

--- a/practices/development.md
+++ b/practices/development.md
@@ -9,50 +9,50 @@ This section describes how our development team carries out its planning and day
 👉 [Here's a link to see all Pull Requests for which your review is requested](https://github.com/issues?q=is%3Aopen+archived%3Afalse+sort%3Aupdated-desc+user%3A2i2c-org+type%3Apr+review-requested%3A%40me)
 :::
 
-(coordination:sprints)=
-## Team Sprints
+(coordination:cycles)=
+## Team Cycles
 
-The 2i2c team uses Sprints to coordinate with one another in focused cycles of work.
-To begin each sprint, we collectively choose items to work on in the next sprint.
+The 2i2c team uses Cycles to coordinate with one another in focused cycles of work.
+To begin each cycle, we collectively choose items to work on in the next cycle.
 Each item should have a person assigned to it, who will be responsible for ensuring that the work gets done.
-However, our work within a sprint is a **team commitment**, and we are all responsible for helping one another accomplish our tasks.
+However, our work within a cycle is a **team commitment**, and we are all responsible for helping one another accomplish our tasks.
 
-### Sprint cadence
+### Cycle cadence
 
-Our team works in **two-week sprints**.
-Here is a brief overview of each sprint.
+Our team works in **two-week cycles**.
+Here is a brief overview of each cycle.
 
-Wednesday (beginning of sprint)
-: Sprint begins with our [sprint planning meeting](meetings:sprint-planning).
+Wednesday (beginning of cycle)
+: Cycle begins with our [cycle planning meeting](meetings:cycle-planning).
 
-  In this meeting we discuss major accomplishments in the previous sprint. We then prioritize and assign the items that each team member will work on for the next sprint, and review items that require discussion and planning.
+  In this meeting we discuss major accomplishments in the previous cycle. We then prioritize and assign the items that each team member will work on for the next cycle, and review items that require discussion and planning.
 
-During the sprint
-: Team members work on the items assigned to them at the sprint planning meeting.
-  We use [the Sprint Board](coordination:sprint-board) to coordinate our activities during the sprint.
+During the cycle
+: Team members work on the items assigned to them at the cycle planning meeting.
+  We use [the Cycle Board](coordination:cycle-board) to coordinate our activities during the cycle.
   We provide updates about what we've been up to, what we're doing next, and where we need help via regular **asynchronous Slack stand-ups**.
 
-Tuesday of week 2 (end of sprint)
-: By the end of the day, team members should have completed all of their items for that sprint.
+Tuesday of week 2 (end of cycle)
+: By the end of the day, team members should have completed all of their items for that cycle.
   
-### Sprint planning meeting
+### Cycle planning meeting
 
-The team conducts a Sprint Planning meeting for 60 minutes at the beginning of each sprint.
+The team conducts a Cycle Planning meeting for 60 minutes at the beginning of each cycle.
 The goal of this meeting is to review our major work items, synchronize with one another, and prioritize work across team members.
 Our **Project Manager** role leads these meetings.
 It is also a chance to hand off the Support Steward role to the next person.
 
-See [the Sprint Planning issue template](https://github.com/2i2c-org/team-compass/blob/main/.github/ISSUE_TEMPLATE/meeting-sprint-planning.md) for the agenda / structure of these meetings.
+See [the Cycle Planning issue template](https://github.com/2i2c-org/team-compass/blob/main/.github/ISSUE_TEMPLATE/meeting-cycle-planning.md) for the agenda / structure of these meetings.
 
-(coordination:sprint-board)=
-### The Sprint Board
+(coordination:cycle-board)=
+### The Cycle Board
 
-The Sprint Board is a place to keep track of the [Deliverables and tasks](coordination:deliverables) our team intends to work on for the week.
+The Cycle Board is a place to keep track of the [Deliverables and tasks](coordination:deliverables) our team intends to work on for the week.
 It is a GitHub Projects board that is created for each week, and closed at the end of each week.
-The team's goal is to complete all items on the Sprint Board by the end of the Sprint.
+The team's goal is to complete all items on the Cycle Board by the end of the Cycle.
 This is a team commitment - while one person may be assigned to a deliverable, we all commit to working together to get the work done.
 
-:::{admonition} The Sprint Board should...
+:::{admonition} The Cycle Board should...
 :class: tip
 - Have enough items to keep the team occupied for the week
 - Not have so many items that a team member gets overwhelmed
@@ -60,11 +60,11 @@ This is a team commitment - while one person may be assigned to a deliverable, w
 - Have a team member assigned to each item on the board
 :::
 
-The Sprint Board is broken down into these columns:
+The Cycle Board is broken down into these columns:
 
 - {guilabel}`Up Next` Items that are ready to be worked on.
 - {guilabel}`In progress` An item that a team member is currently working towards.
-- {guilabel}`Done` Items that are complete! These should be celebrated archived in the next Sprint Planning meeting.
+- {guilabel}`Done` Items that are complete! These should be celebrated archived in the next Cycle Planning meeting.
 
 In addition, we have a few other pieces of metadata to signal different kind of actions that would be needed 
 
@@ -132,7 +132,7 @@ Tasks to complete
   All deliverables should have either a set of concrete steps to take to meet the deliverable, or at least one task with the **acceptance criteria** for when the deliverable will be complete.
   Task lists should be in the top comment of the deliverable, and are encoded as markdown tasks lists (e.g. with `- [ ]`).
   Task lists should be updated over time as we learn the steps needed to close the deliverable.
-  For more complex deliverables, these tasks may be what goes onto the Sprint Board, rather than the deliverable itself.
+  For more complex deliverables, these tasks may be what goes onto the Cycle Board, rather than the deliverable itself.
 
 (coordination:deliverables-backlog)=
 ## The Team Backlog
@@ -145,13 +145,13 @@ These items adhere to the following principles:
 
 - The order of items should be roughly according to priority, with higher priority items at the top of lists.
 - Items on the board should have a **status** that signals whether they are ready to work or need more refinement before working.
-- If an item has multiple components or would otherwise take longer than a sprint to complete, create new issues as sub-tasks, and add *them* to the Sprint Board.
+- If an item has multiple components or would otherwise take longer than a cycle to complete, create new issues as sub-tasks, and add *them* to the Cycle Board.
 
 ### Assigning to an issue
 
 Only assign a backlog issue to somebody if it is **actively being worked on**.
-We assume that once somebody is assigned to an issue, it is part of an active sprint.
-Note that **all** issues on our Sprint Backlog should have somebody assigned to them.
+We assume that once somebody is assigned to an issue, it is part of an active cycle.
+Note that **all** issues on our Cycle Backlog should have somebody assigned to them.
 
 :::{admonition} Our definition of "Work in Progress"
 Because issues that are actively being worked on must have somebody assigned to them, we use "the issues that have somebody assigned to them" as our definition of Work in Progress.
@@ -159,21 +159,21 @@ Because issues that are actively being worked on must have somebody assigned to 
 
 ### Backlog item limits
 
-Our goal is to have backlog items that roughly cover the next 3 [sprint cycles](coordination:sprints).
+Our goal is to have backlog items that roughly cover the next 3 [cycle cycles](coordination:cycles).
 We **should not have more backlog items than this amount**.
 
-You can estimate the number of items on the board at any one time by assuming that **each team member (at 100% FTE) can accomplish about 2 items per sprint**.
+You can estimate the number of items on the board at any one time by assuming that **each team member (at 100% FTE) can accomplish about 2 items per cycle**.
 You can then calculate the rough number of items on this board with the equation:
 
 ```
-n_team_members * 2 (items per sprint) * 3 (sprints on the board)
+n_team_members * 2 (items per cycle) * 3 (cycles on the board)
 ```
 
 So if we have 5.5 team members available (if one of them is at 50% FTE), then the team backlog should have around `5.5 * 2 * 3 = 33 deliverables` on it.
 
 ### Adding backlog items
 
-We should add items to our team backlog when we have capacity to do the work in the next 3 sprints, and when those items are ready to be prioritized over all the other work that we *could* do (e.g., all issues in our repositories and encoded in project backlogs).
+We should add items to our team backlog when we have capacity to do the work in the next 3 cycles, and when those items are ready to be prioritized over all the other work that we *could* do (e.g., all issues in our repositories and encoded in project backlogs).
 
 :::{tip}
 
@@ -211,11 +211,11 @@ This doesn't mean that we know **all** of the tasks needed to complete the item,
 
 [^invest]: A good resource for considering what kinds of information makes a deliverable "ready" is [the INVEST methodology](https://agileforall.com/new-to-agile-invest-in-good-user-stories).
 
-The team picks up work associated with a backlog item via our Sprint Planning meeting.
+The team picks up work associated with a backlog item via our Cycle Planning meeting.
 In this case, there are two options:
 
-1. **Add the item to the Sprint Board**. If an item is scoped tightly enough that it can be completed within one sprint, then add it to the [Sprint Board](coordination:sprint-board) and complete it in a sprint.
-2. **Generate issues from tasks and add them to the Sprint Board**. For items that are more complex and require tasks that would take more than one sprint, use the **Task List** in the issue to generate new issues for use on the Sprint Board.
+1. **Add the item to the Cycle Board**. If an item is scoped tightly enough that it can be completed within one cycle, then add it to the [Cycle Board](coordination:cycle-board) and complete it in a cycle.
+2. **Generate issues from tasks and add them to the Cycle Board**. For items that are more complex and require tasks that would take more than one cycle, use the **Task List** in the issue to generate new issues for use on the Cycle Board.
 
    :::{tip}
    You can [use GitHub's task issue tracking features](https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists) to keep track of tasks associated with an issue.
@@ -252,8 +252,8 @@ Not all of them are followed strictly, though some are more important than other
 - **Be explicit about what feedback you want**.
   When you open a PR, include some language about specific things you'd like feedback with, if applicable.
   This helps others focus their attention.
-- **Use the review column on sprint boards**.
-  When a PR needs review, move any relevant issues to the {kbd}`Review` column of the active [Sprint Board](coordination:sprint-board) so others notice it.
+- **Use the review column on cycle boards**.
+  When a PR needs review, move any relevant issues to the {kbd}`Review` column of the active [Cycle Board](coordination:cycle-board) so others notice it.
 - **Merge after one approval**.
   If there is at least one approval on a PR, then anybody, including the PR author, may merge the PR.
   PR authors should not hesitate to merge their own PR after an approval if they think it is ready to go!
@@ -289,7 +289,7 @@ There is no official way to track long-term projects within 2i2c, but there are 
 The simplest way to track longer-term efforts is with a **Tracking Issue**.
 This is a GitHub Issue whose job is to keep track of many actions and deliverables over time that are needed to close the issue.
 They are generally encoded as **Task Lists** in the issue's top comment.
-Each item in the list tends to be a deliverable, and can be converted into its own GitHub Issue (e.g., to put on the [Sprint Board](coordination:sprint-board)) as-needed.
+Each item in the list tends to be a deliverable, and can be converted into its own GitHub Issue (e.g., to put on the [Cycle Board](coordination:cycle-board)) as-needed.
 
 (coordination:project-backlog)=
 ### Project Backlogs
@@ -301,7 +301,7 @@ Here is a common column structure:
 
 - {guilabel}`Needs Discussion/Refinement`: Deliverables that are high-priority but un-refined. Our goal should be having discussion and doing research in order to get these deliverables ready for work.
 - {guilabel}`Ready to Work`: Deliverables that are well-scoped and have a clear path forward, and are thus ready to implement. As deliverables in {guilabel}`In progress` are completed, we should replace them with deliverables from this column. Generally speaking, deliverables near the top have higher priority than those at the bottom.
-- {guilabel}`In progress`: Deliverables that we are currently working towards. This means that they should be added to the [Sprint Board](coordination:sprint-board) to track its completion.
+- {guilabel}`In progress`: Deliverables that we are currently working towards. This means that they should be added to the [Cycle Board](coordination:cycle-board) to track its completion.
 - {guilabel}`Blocked`: Deliverables that require another action or delivearable from the 2i2c team to complete before they can move forward.
 - {guilabel}`Waiting`: Deliverables that require another action from a **non-2i2c team member** before they can move forward.
 - {guilabel}`Done`: Deliverables that have been completed. We should close these issues and celebrate the improvements that we have made!

--- a/practices/development.md
+++ b/practices/development.md
@@ -31,7 +31,8 @@ During the cycle
   We use [the Team Backlog Board](coordination:deliverables-backlog) to coordinate our activities during the cycle.
   We provide updates about what we've been up to, what we're doing next, and where we need help via regular **asynchronous Slack stand-ups**.
   We add issues (or standalone PRs) belonging to the activities developed during the cycle into the [the Cycle Board](coordination:cycle-board).
-  
+
+(coordination:planning)=  
 ### Coordination planning meeting
 
 The team conducts a Coordination Planning meeting for 60 minutes at the beginning of each cycle.
@@ -241,8 +242,8 @@ Not all of them are followed strictly, though some are more important than other
 - **Be explicit about what feedback you want**.
   When you open a PR, include some language about specific things you'd like feedback with, if applicable.
   This helps others focus their attention.
-- **Use the review column on cycle boards**.
-  When a PR needs review, move any relevant issues to the {kbd}`Review` column of the active [Cycle Board](coordination:cycle-board) so others notice it.
+- **Use the Slack Geekbot to ask for help**.
+  When a PR needs review and there is no feedback, use the help section from the bot update to ask others for feedback!
 - **Merge after one approval**.
   If there is at least one approval on a PR, then anybody, including the PR author, may merge the PR.
   PR authors should not hesitate to merge their own PR after an approval if they think it is ready to go!

--- a/practices/development.md
+++ b/practices/development.md
@@ -13,7 +13,7 @@ This section describes how our development team carries out its planning and day
 ## Team Cycles
 
 To begin each cycle, we collectively choose items to work on (or continue working) in the next cycle.
-Each item should have a person assigned to it, who will be responsible for ensuring that the work gets done and a another person as a helper.
+Each item should have a person assigned to it and another person as a helper. The person assigned will be the one responsible for ensuring that the work gets done.
 However, our work within a cycle is a **team commitment**, and we are all responsible for helping one another accomplish our tasks.
 
 ### Cycle cadence

--- a/practices/development.md
+++ b/practices/development.md
@@ -12,9 +12,8 @@ This section describes how our development team carries out its planning and day
 (coordination:cycles)=
 ## Team Cycles
 
-The 2i2c team uses Cycles to coordinate with one another in focused cycles of work.
-To begin each cycle, we collectively choose items to work on in the next cycle.
-Each item should have a person assigned to it, who will be responsible for ensuring that the work gets done.
+To begin each cycle, we collectively choose items to work on (or continue working) in the next cycle.
+Each item should have a person assigned to it, who will be responsible for ensuring that the work gets done and a another person as a helper.
 However, our work within a cycle is a **team commitment**, and we are all responsible for helping one another accomplish our tasks.
 
 ### Cycle cadence
@@ -23,51 +22,37 @@ Our team works in **two-week cycles**.
 Here is a brief overview of each cycle.
 
 Wednesday (beginning of cycle)
-: Cycle begins with our [cycle planning meeting](meetings:cycle-planning).
+: Cycle begins with our [coordination planning meeting](meetings:coordination-planning).
 
   In this meeting we discuss major accomplishments in the previous cycle. We then prioritize and assign the items that each team member will work on for the next cycle, and review items that require discussion and planning.
 
 During the cycle
-: Team members work on the items assigned to them at the cycle planning meeting.
-  We use [the Cycle Board](coordination:cycle-board) to coordinate our activities during the cycle.
+: Team members work on the items assigned to them at the coordination planning meeting.
+  We use [the Team Backlog Board](coordination:deliverables-backlog) to coordinate our activities during the cycle.
   We provide updates about what we've been up to, what we're doing next, and where we need help via regular **asynchronous Slack stand-ups**.
-
-Tuesday of week 2 (end of cycle)
-: By the end of the day, team members should have completed all of their items for that cycle.
+  We add issues (or standalone PRs) belonging to the activities developed during the cycle into the [the Cycle Board](coordination:cycle-board).
   
-### Cycle planning meeting
+### Coordination planning meeting
 
-The team conducts a Cycle Planning meeting for 60 minutes at the beginning of each cycle.
+The team conducts a Coordination Planning meeting for 60 minutes at the beginning of each cycle.
 The goal of this meeting is to review our major work items, synchronize with one another, and prioritize work across team members.
 Our **Project Manager** role leads these meetings.
 It is also a chance to hand off the Support Steward role to the next person.
 
-See [the Cycle Planning issue template](https://github.com/2i2c-org/team-compass/blob/main/.github/ISSUE_TEMPLATE/meeting-cycle-planning.md) for the agenda / structure of these meetings.
+See [the Coordination Planning issue template](https://github.com/2i2c-org/team-compass/blob/main/.github/ISSUE_TEMPLATE/meeting-coordination-planning.md) for the agenda / structure of these meetings.
 
 (coordination:cycle-board)=
 ### The Cycle Board
 
-The Cycle Board is a place to keep track of the [Deliverables and tasks](coordination:deliverables) our team intends to work on for the week.
-It is a GitHub Projects board that is created for each week, and closed at the end of each week.
-The team's goal is to complete all items on the Cycle Board by the end of the Cycle.
-This is a team commitment - while one person may be assigned to a deliverable, we all commit to working together to get the work done.
-
-:::{admonition} The Cycle Board should...
-:class: tip
-- Have enough items to keep the team occupied for the week
-- Not have so many items that a team member gets overwhelmed
-- Under-estimate our team's total capacity, to provide room for unexpected work (e.g., support work)
-- Have a team member assigned to each item on the board
-:::
+The Cycle Board is a place to keep track of the [Deliverables and tasks](coordination:deliverables) our team is working on for the cycle.
+It is a GitHub Projects board that is created for each cycle, and closed at the end of each cycle.
 
 The Cycle Board is broken down into these columns:
 
-- {guilabel}`Up Next` Items that are ready to be worked on.
-- {guilabel}`In progress` An item that a team member is currently working towards.
-- {guilabel}`Done` Items that are complete! These should be celebrated archived in the next Cycle Planning meeting.
-
-In addition, we have a few other pieces of metadata to signal different kind of actions that would be needed 
-
+- {guilabel}`Todo` Items that are ready to be worked on.
+- {guilabel}`In Progress` An item that a team member is currently working towards.
+- {guilabel}`Review / QA` Items that are ready to be reviewed/tested.
+- {guilabel}`Done` Items that are complete! These should be celebrated and archived in the next Coordination Planning meeting.
 
 (coordination:team-syncs)=
 ## Daily team syncs
@@ -140,12 +125,12 @@ Tasks to complete
 [Click here to go to the Team Backlog](https://github.com/orgs/2i2c-org/projects/22).
 
 The Team Backlog is a GitHub Projects Board with a list of [Deliverables and tasks](coordination:deliverables) across all of our active projects.
-This represents the work that the team is planning to do in the near future.
+This represents the work that the team is doing AND planning to do in the near future.
 These items adhere to the following principles:
 
 - The order of items should be roughly according to priority, with higher priority items at the top of lists.
 - Items on the board should have a **status** that signals whether they are ready to work or need more refinement before working.
-- If an item has multiple components or would otherwise take longer than a cycle to complete, create new issues as sub-tasks, and add *them* to the Cycle Board.
+- If an item has multiple components or would otherwise take longer than a cycle to complete, create new issues as sub-tasks, and add *them* to a dedicated [Project Backlog](coordination:project-backlog).
 
 ### Assigning to an issue
 
@@ -211,11 +196,11 @@ This doesn't mean that we know **all** of the tasks needed to complete the item,
 
 [^invest]: A good resource for considering what kinds of information makes a deliverable "ready" is [the INVEST methodology](https://agileforall.com/new-to-agile-invest-in-good-user-stories).
 
-The team picks up work associated with a backlog item via our Cycle Planning meeting.
-In this case, there are two options:
+The team picks up work associated with a backlog item via our Coordination Planning meeting.
+In this case, there are three options:
 
-1. **Add the item to the Cycle Board**. If an item is scoped tightly enough that it can be completed within one cycle, then add it to the [Cycle Board](coordination:cycle-board) and complete it in a cycle.
-2. **Generate issues from tasks and add them to the Cycle Board**. For items that are more complex and require tasks that would take more than one cycle, use the **Task List** in the issue to generate new issues for use on the Cycle Board.
+1. **Add the item to the Team Backlog Board**. If an item is scoped tightly enough that it can be completed within one cycle, then add it to the [Team Backlog Board](coordination:deliverables-backlog) and complete it in a cycle.
+2. **Generate issues from tasks and add the parent item to the Team Backlog Board**. For items that are more complex and require tasks that would take more than one cycle, use the **Task List** in the issue to generate new issues.
 
    :::{tip}
    You can [use GitHub's task issue tracking features](https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists) to keep track of tasks associated with an issue.
@@ -223,6 +208,10 @@ In this case, there are two options:
 
 As work is done towards a backlog item, **update the top comment of the issue** with new information and tasks.
 Each parent issue is the {term}`Source of Truth` for all work associated with it (instead of, for example, an issue created as a sub-task for that item).
+
+   :::{tip}
+   Using a dedicated [Project Backlog](coordination:project-backlog) can be helpful to track longer-term planning (encompassing multiple cycles) for a specific project.
+   :::
 
 (coordination:deliverables:upstream)=
 ### Tracking upstream issues
@@ -289,7 +278,7 @@ There is no official way to track long-term projects within 2i2c, but there are 
 The simplest way to track longer-term efforts is with a **Tracking Issue**.
 This is a GitHub Issue whose job is to keep track of many actions and deliverables over time that are needed to close the issue.
 They are generally encoded as **Task Lists** in the issue's top comment.
-Each item in the list tends to be a deliverable, and can be converted into its own GitHub Issue (e.g., to put on the [Cycle Board](coordination:cycle-board)) as-needed.
+Each item in the list tends to be a deliverable, and can be converted into its own GitHub Issue as-needed.
 
 (coordination:project-backlog)=
 ### Project Backlogs

--- a/practices/development.md
+++ b/practices/development.md
@@ -12,7 +12,7 @@ This section describes how our development team carries out its planning and day
 (coordination:cycles)=
 ## Team Cycles
 
-To begin each cycle, we collectively choose items to work on (or continue working) in the next cycle.
+At the beginning of each cycle, we collectively choose items to work on (or continue working) in the next cycle.
 Each item should have a person assigned to it and another person as a helper. The person assigned will be the one responsible for ensuring that the work gets done.
 However, our work within a cycle is a **team commitment**, and we are all responsible for helping one another accomplish our tasks.
 

--- a/practices/meetings.md
+++ b/practices/meetings.md
@@ -83,14 +83,14 @@ For example, these are some goals we might have:
 - Zoom out and make sure we are on the right track
 - Discuss team process issues to make sure we are all supported
 
-It is **not a status update meeting** - this should be done via our GitHub issues and sprint planning!
+It is **not a status update meeting** - this should be done via our GitHub issues and cycle planning!
 
 You can [find notes from team meetings here](../meetings/eng/index.md).
 
-(meetings:sprint-planning)=
-### Sprint Planning meetings
+(meetings:cycle-planning)=
+### Cycle Planning meetings
 
-See [](coordination:sprints) for information about these meetings.
+See [](coordination:cycles) for information about these meetings.
 
 ### One on one meetings
 

--- a/practices/meetings.md
+++ b/practices/meetings.md
@@ -83,14 +83,14 @@ For example, these are some goals we might have:
 - Zoom out and make sure we are on the right track
 - Discuss team process issues to make sure we are all supported
 
-It is **not a status update meeting** - this should be done via our GitHub issues and cycle planning!
+It is **not a status update meeting** - this should be done via our GitHub issues and coordination planning!
 
 You can [find notes from team meetings here](../meetings/eng/index.md).
 
-(meetings:cycle-planning)=
-### Cycle Planning meetings
+(meetings:coordination-planning)=
+### Coordination Planning meetings
 
-See [](coordination:cycles) for information about these meetings.
+See [](coordination:planning) for information about these meetings.
 
 ### One on one meetings
 

--- a/projects/managed-hubs/support.md
+++ b/projects/managed-hubs/support.md
@@ -21,7 +21,7 @@ For most support requests, we use [a FreshDesk service](https://2i2c.freshdesk.c
 
 The Support Team is a **two-person team** of Support Stewards that work together.
 Tenure on the support team is **for four weeks**.
-Every **two weeks** (generally at the cycle meeting), a Support Steward cycles off the support team, and a new team member joins the team.
+Every **two weeks** (generally at the coordination meeting), a Support Steward cycles off the support team, and a new team member joins the team.
 The support team rotates through [the “Open Infrastructure Engineering Team” on this page](https://team-compass.2i2c.org/en/latest/about/team.html), in alphabetical order.
 
 :::{seealso}
@@ -63,7 +63,7 @@ If resolving a support issue requires ongoing or concerted work, open a backlog 
 
 Support backlog items should:
 
-- Be placed in our [Cycle Board](coordination:cycle-board).
+- Be placed in our [Team BackLog Board](coordination:deliverables-backlog).
 - Include a reference to any FreshDesk tickets if they exist.
 - Be prioritized over other backlog items for that cycle.
 
@@ -109,7 +109,7 @@ We should try to respond to all support-related communications within one workin
 The support team is primarily a **communicator** and a **router** - they are not necessarily the ones who carry out the changes needed to resolve a support issue.
 Instead, the support team is empowered to ask engineering team members to pick up backlog items that are related to support requests.
 
-When a support request is made that requires an action from a 2i2c engineer, a Support Steward should describe this change in a GitHub issue, and add it to the [Cycle Board](coordination:cycle-board).
+When a support request is made that requires an action from a 2i2c engineer, a Support Steward should describe this change in a GitHub issue, and add it to the [Team Backlog Board](coordination:deliverables-backlog).
 Think about an engineering team member that likely has the skills and capacity needed, and ask them if they are willing to take on resolving this issue.
 Try not to ask the same person for support help many times in a row - we should spread the work needed to address support issues across the team.
 

--- a/projects/managed-hubs/support.md
+++ b/projects/managed-hubs/support.md
@@ -21,7 +21,7 @@ For most support requests, we use [a FreshDesk service](https://2i2c.freshdesk.c
 
 The Support Team is a **two-person team** of Support Stewards that work together.
 Tenure on the support team is **for four weeks**.
-Every **two weeks** (generally at the sprint meeting), a Support Steward cycles off the support team, and a new team member joins the team.
+Every **two weeks** (generally at the cycle meeting), a Support Steward cycles off the support team, and a new team member joins the team.
 The support team rotates through [the “Open Infrastructure Engineering Team” on this page](https://team-compass.2i2c.org/en/latest/about/team.html), in alphabetical order.
 
 :::{seealso}
@@ -54,7 +54,7 @@ Many requests may be immediately resolved via a quick action or response to the 
 If a request requires consultation with the team, then:
 
 - Open a Slack thread in the {guilabel}`#support-freshdesk` channel to discuss with others. If we need to track a work item to resolve the ticket over time, then:
-- Open a GitHub issue with the {guilabel}`support` label, and add it to our Sprint backlog.
+- Open a GitHub issue with the {guilabel}`support` label, and add it to our Cycle backlog.
 
 (support:issues)=
 ### Support issues
@@ -63,9 +63,9 @@ If resolving a support issue requires ongoing or concerted work, open a backlog 
 
 Support backlog items should:
 
-- Be placed in our [Sprint Board](coordination:sprint-board).
+- Be placed in our [Cycle Board](coordination:cycle-board).
 - Include a reference to any FreshDesk tickets if they exist.
-- Be prioritized over other backlog items for that sprint.
+- Be prioritized over other backlog items for that cycle.
 
 ## Communication channels
 
@@ -109,7 +109,7 @@ We should try to respond to all support-related communications within one workin
 The support team is primarily a **communicator** and a **router** - they are not necessarily the ones who carry out the changes needed to resolve a support issue.
 Instead, the support team is empowered to ask engineering team members to pick up backlog items that are related to support requests.
 
-When a support request is made that requires an action from a 2i2c engineer, a Support Steward should describe this change in a GitHub issue, and add it to the [Sprint Board](coordination:sprint-board).
+When a support request is made that requires an action from a 2i2c engineer, a Support Steward should describe this change in a GitHub issue, and add it to the [Cycle Board](coordination:cycle-board).
 Think about an engineering team member that likely has the skills and capacity needed, and ask them if they are willing to take on resolving this issue.
 Try not to ask the same person for support help many times in a row - we should spread the work needed to address support issues across the team.
 


### PR DESCRIPTION
Since we are not actually doing sprints in a classic way, I realized we should adjust the documentation to reflect what we are actually doing :wink:.

The changes focus on getting rid of the "sprint" as a concept and replacing it with cycles.
We center the coordination at the backlog board level and use the "cycle" board just for tracking purposes.

Btw, this is in a draft state for early feedback.