### PR TITLE
Update meeting guide with new frequency

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -50,7 +50,7 @@ myst_enable_extensions = [
     "deflist",
     "linkify",
 ]
-myst_url_schemes = ["https", "http", "ftp", "mailto"]
+
 intersphinx_mapping = {
     "docs": ("https://docs.2i2c.org/en/latest/", None),
     "infra": ("https://infrastructure.2i2c.org/en/latest/", None),

--- a/practices/meetings.md
+++ b/practices/meetings.md
@@ -47,8 +47,10 @@ During the meeting
 
 #### Who serves as the facilitator?
 
-Everybody on the engineering team, on a rotating basis. We rotate meeting facilitators **every month** and transition this role at the monthly team meeting. The meeting facilitator rotates through the [“Open Infrastructure Engineering Team” on this page](https://team-compass.2i2c.org/en/latest/about/team.html), in alphabetical order.
-
+Everybody on the engineering team, on a rotating basis.
+We rotate meeting facilitators **every month** and transition this role at the beginning of the month.
+The meeting facilitator rotates through the `@tech-team` usergroup on Slack in alphabetical order, using the code in the [`team-roles-geekbot-sweep` repository](https://github.com/2i2c-org/team-roles-geekbot-sweep).
+That repository also automatically generates [Geekbot Standups](https://geekbot.com/) that notifies which member of the engineering team in due to take over the role at the start of the month.
 
 ### Recorder
 
@@ -72,7 +74,7 @@ The following are meetings that we regularly hold.
 
 ### Monthly team meetings
 
-The 2i2c Team meets **monthly on Tuesdays** for 60 minutes, with an optional 30-minute extra time afterwards if we really need to extend conversation.
+The 2i2c Team meets **on the last Tuesday of each month** for 60 minutes, with an optional 30-minute extra time afterwards if we really need to extend conversation.
 
 See the [Team Calendar page](team/calendar) for information about when and where the meetings are held, as well as links to meeting notes.
 

--- a/projects/index.md
+++ b/projects/index.md
@@ -35,8 +35,8 @@ The [organizational foundation project](https://github.com/orgs/2i2c-org/project
 The Managed JupyterHub Service is a special project of 2i2c that is [developed and described at this website](managed-hubs/index.md).
 
 :::{admonition} Tracking deliverables
-- [the high level goals and strategy are described here](https://docs.2i2c.org/en/latest/about/strategy.html)
-- [the roadmap for the service is described here](https://docs.2i2c.org/en/latest/about/roadmap.html)
+- [the high level goals and strategy are described here](https://docs.2i2c.org/en/latest/about/strategy/index.html)
+- [the roadmap for the service is described here](https://docs.2i2c.org/en/latest/about/strategy/roadmap.html)
 :::
 
 More information about the Managed JupyterHub Service can be found in these sections:


### PR DESCRIPTION
This PR changes our team meeting docs to state that the new frequency is **monthly on the last Tuesday** and notes how the `team-roles-geekbot-sweep` repo allocates team members to the facilitator role and notifies them.

fixes #417 