### PR TITLE
Product and Community docs

### DIFF
--- a/code-of-conduct/index.md
+++ b/code-of-conduct/index.md
@@ -34,7 +34,7 @@ In addition, the 2i2c community and experience often extends outside those space
 
 The 2i2c Code of Conduct does not apply to interactions between users of a Managed JupyterHub, though we encourage leaders in those communities to adopt a Code of Conduct for their hub infrastructure. The Code of Conduct does apply to any interaction between a user of a Managed JupyterHub and a 2i2c Team Member.
 
-:::\{important}
+:::{important}
 When in doubt, please [report unacceptable behavior](coc:reporting) to us. If someone’s behavior outside of a 2i2c space makes you feel unsafe at 2i2c, that is absolutely relevant and actionable for us.
 :::
 

--- a/hr/titles/product-community-lead.md
+++ b/hr/titles/product-community-lead.md
@@ -1,4 +1,76 @@
 # Product and Community Lead
 
-We are still developing this role and will update this text once we have a solid prototype for it!
-In the meantime, you can [find some context about this role here](https://2i2c.org/blog/2022/job-product-community-lead/).
+:::{note}
+We are currently experimenting with this role, and will evolve these goals, responsibilities, etc as we learn more.
+We should revisit this section in September 2022.
+:::
+
+## Key goal
+
+There are three key goals for this role:
+
+- Empower the communities we serve to have impact with our infrastructure.
+- Guide our development and service design to reflect the needs of our users.
+- Develop the organizational strategy and structure needed to accomplish these goals within 2i2c.
+
+## Rationale
+
+Solely providing infrastructure to communities via an engineering team is not enough. Working with the modern open source stack, using the cloud to its advantage, and bringing these tools into specific domains requires a lot of extra experience and expertise.
+We believe that 2i2c is in a good position to **provide guidance and support to leaders in the communities that we serve**, allowing them to get up-to-speed with the infrastructure more effectively so that they can have an impact.
+We also believe that it's crucial to **develop infrastructure in collaboration with the communities that we're serving**.
+A team of engineers tends to focus on code and infrastructure, and having a role that focuses on connecting with communities will give them an excellent perspective on what those communities need.
+
+The skills, interests, and career paths for interfacing with communities, guiding them, and participating in design and prioritization efforts with engineers are significantly different from engineering track jobs.
+As such, this role will lead efforts around a new _class_ of jobs within 2i2c: Product and Community.
+
+## Qualities and experience
+
+We are still defining the qualities and experience for this role, but below are a few abstract qualities that will make somebody succeed in this role.
+
+- Demonstrated ability to lead and grow distributed communities of practice (e.g., 3+ years as a leader of an open source community)
+- Demonstrated ability to design and manage technical products (e.g., 3+ years experience as a product manager, or as a product-level lead in an open source community)
+- Demonstrated experience in growing and guiding organizations and teams that do technical development or service work (e.g., 3+ years as a manager or organizational leadership role)
+- Extensive experience with open source workflows, research and educational contexts, and an understanding of the value that hosted infrastructure provides.
+
+## Responsibilities and Expectations
+
+We are still developing the responsibilities and expectations for the role, and will revisit this as we've come to a better understanding of them.
+
+Here is a short list of relevant ideas. Note that this role may do many of these as an "individual contributor" inititally due to our small size, but ultimately the goal is for this role to grow into a leadership and strategy position that may guide and manage others.
+
+- Actively reach out to communities that we serve and learn about their goals and how 2i2c's infrastructure fits into those goals.
+- Actively guide our engineering team's efforts around design and prioritization.
+- Help us consider and discuss trade-offs that we must make in support requests and features.
+- Design and grow structures, spaces, etc for communication between 2i2c and communities we serve, as well as within communities.
+- Lead efforts to provide support for our communities in their use of the infrastructure, and route requests to the engineering team as needed.
+- Lead content creation to empower communities to use our infrastructure more effectively
+- Define strategy, goals, and assessment criteria for Product and Support.
+- Define roles and job titles for team members that do work in this area, as well as their connections with others on the team.
+- As resources are available, manage and mentor other team members within Product and Community at 2i2c.
+- Interface with the Partnerships Lead to incorporate sustainability in the design and evolution of our services.
+
+## Salary rationale
+
+This is a leadership-level role within 2i2c and focused on Product and Community work. As such we should use the GuideStar salary criteria for the “top” position in a relevant category. It should be appropriate for an early-mid career leader who has demonstrated some experience in the organizational aspects needed to succeed in this role.
+
+We'll plan to use the **Top Program Position** job category within GuideStar to define the base salary for this role. The median base salary for this role is $122,000.
+
+## Appendix: Inspiration for the role
+
+Here are a few roles that provided inspiration for this position:
+
+- **Product Manager**: Understand the communities that we work with, and to use this to help us make decisions about what to build, how to present it, and how to engage with stakeholders. Help us prioritize the work that is most impactful for our mission, and help us navigate trade-offs in the evolution of our services.
+- **Developer Advocate**: Guide and teach those in the communities we serve - particularly community leaders that go on to teach others - in how to use our infrastructure most-effectively.
+- **Research Applications Manager**: The [**Research Applications Manager**](https://the-turing-way.netlify.app/collaboration/research-infrastructure-roles/ram.html) is a role that has been pioneered by the Turing Institute, and is similarly described as a connector that brings together many perspectives and encourages a participatory, team-based approach to research.
+
+Other comparable titles:
+
+- Community Success Lead
+- Community Impact Lead
+- Director of Community Impact
+- Director of Community Success
+- Infrastructure Applications Lead
+- Product Manager
+- Community Success Lead
+- Infrastructure Impact Lead
+- Community Advocate Lead

--- a/hr/titles/product-community-lead.md
+++ b/hr/titles/product-community-lead.md
@@ -27,9 +27,9 @@ As such, this role will lead efforts around a new _class_ of jobs within 2i2c: P
 
 We are still defining the qualities and experience for this role, but below are a few abstract qualities that will make somebody succeed in this role.
 
-- Demonstrated ability to lead and grow distributed communities of practice (e.g., 3+ years as a leader of an open source community)
-- Demonstrated ability to design and manage technical products (e.g., 3+ years experience as a product manager, or as a product-level lead in an open source community)
-- Demonstrated experience in growing and guiding organizations and teams that do technical development or service work (e.g., 3+ years as a manager or organizational leadership role)
+- Demonstrated ability to lead and grow distributed communities of practice (e.g., 3+ years as a leader of an open source community).
+- Demonstrated ability to design and manage technical products (e.g., 3+ years experience as a product manager, or as a product-level lead in an open source community).
+- Demonstrated experience in growing and guiding organizations and teams that do technical development or service work (e.g., 3+ years as a manager or organizational leadership role).
 - Extensive experience with open source workflows, research and educational contexts, and an understanding of the value that hosted infrastructure provides.
 
 ## Responsibilities and Expectations
@@ -43,7 +43,7 @@ Here is a short list of relevant ideas. Note that this role may do many of these
 - Help us consider and discuss trade-offs that we must make in support requests and features.
 - Design and grow structures, spaces, etc for communication between 2i2c and communities we serve, as well as within communities.
 - Lead efforts to provide support for our communities in their use of the infrastructure, and route requests to the engineering team as needed.
-- Lead content creation to empower communities to use our infrastructure more effectively
+- Lead content creation to empower communities to use our infrastructure more effectively.
 - Define strategy, goals, and assessment criteria for Product and Support.
 - Define roles and job titles for team members that do work in this area, as well as their connections with others on the team.
 - As resources are available, manage and mentor other team members within Product and Community at 2i2c.
@@ -53,7 +53,7 @@ Here is a short list of relevant ideas. Note that this role may do many of these
 
 This is a leadership-level role within 2i2c and focused on Product and Community work. As such we should use the GuideStar salary criteria for the “top” position in a relevant category. It should be appropriate for an early-mid career leader who has demonstrated some experience in the organizational aspects needed to succeed in this role.
 
-We'll plan to use the **Top Program Position** job category within GuideStar to define the base salary for this role. The median base salary for this role is $122,000.
+We'll plan to use the **Top Program Position** job category within GuideStar to define the base salary for this role. The median base salary for this role is $122,000 as of now (mid-2022).
 
 ## Appendix: Inspiration for the role
 


### PR DESCRIPTION
This ports our Product and Community Lead google doc + blog post into our team compass, as the starting point for a set of expectations, job description, etc for this role. I believe we are still figuring out the details here, but I think this is a good starting point to iterate from, and helps set public expectations of what the person who is hired can expect.

Once somebody begins this role, I think we should re-visit this page with them and understand how it matches / mis-matches their vision for it, and potentially make some updates and tweaks accordingly.