### PR TITLE
Add hiring process documentation

### DIFF
--- a/hr/hiring.md
+++ b/hr/hiring.md
@@ -1,0 +1,48 @@
+# Hiring and Job Search Process
+
+This page contains information about the hiring process at 2i2c.
+It is meant to be a helpful guide and resources to streamline hiring in the future[^references].
+
+[^references]: 
+    - This interview structure is heavily-inspired by [the IOI strategic director interview template](https://docs.google.com/document/d/1q9tfzu5VRi6kW4A5JLOF7CXHzVNJQE502q68BmfRUjs/edit) and [Code for Science and Society's hiring process](https://docs.google.com/document/d/12IgSVi2UMfW3PPHkK3iPESghM2kgZ_E-4mYhOzO1JRo/edit).
+    - We take heavy inspiration from [Project Include's inclusive hiring documentation](https://projectinclude.org/hiring).
+
+
+## Hiring Team
+
+The hiring team carries out the hiring process.
+The team consists of two different types of people:
+
+```{glossary}
+Hiring Lead
+  The Hiring Lead oversees the hiring process for a candidate.
+  They are usually:
+
+  - The direct supervisor of the person to be hired
+  - Experienced with the goals and needs of this hire.
+  - Experienced with the skills and qualities needed for the job
+  - Familiar with hiring processes in general (at 2i2c or elsewhere)
+
+Hiring team members
+  Individuals that help out with various parts of the hiring process.
+  We aim to spread the load of serving on hiring committees across team members, and try to have committee members for individuals that will work closely with the new hire.
+```
+
+## The hiring process
+
+Most of our hiring process is defined in a collection of Google Document templates that are meant to be copied and modified for new hires.
+Here are two relevant links:
+
+- [This Google Drive Folder for our hiring process documents](https://docs.google.com/document/d/1O1dBkkp_ZYRcDip-tYtwaacsCPclHI3c5aIFXR_mmEA/edit?usp=sharing) has all template files we use in hiring.
+- [This Hiring Process Outline](https://docs.google.com/document/d/12OGWrjBXRQwfGuR1lE-uxJLsCKrKu5yvm3xNibndJTA/edit?usp=sharing) describes the overall process and steps to organize our candidate search.
+
+Briefly, this is the process that we follow:
+
+- Create and post the job.
+- Create an AirTable application portal with {term}`CS&S`.
+- Applicants answer several questions and provide their CV.
+- Triage all applicants and narrow down to 4-8 we wish to learn more about.
+- Screen 4-8 applicants with a 30 minute phone call.
+- Interview 1-3 applicants in a 90 minute interview.
+- Discuss and rank candidates.
+- Make an offer.

--- a/hr/index.md
+++ b/hr/index.md
@@ -6,6 +6,7 @@ This includes employment information, salary information, benefits, etc.
 ```{toctree}
 compensation.md
 titles/index.md
+hiring.md
 time-off.md
 ```
 


### PR DESCRIPTION
This adds links to new documentation about 2i2c's hiring process. It is primarily a brief overview of major parts of our hiring process, as well as a link to templates and the hiring outline we can use in future hires.

I've taken the hiring documents from the latest hire, generalized and removed identifiable information from them, and turned them into templates in a dedicated folder at the link below. This is a **public link**, and is where the bulk of our "hiring process" is defined.

 - [Hiring folder here](https://docs.google.com/document/d/12OGWrjBXRQwfGuR1lE-uxJLsCKrKu5yvm3xNibndJTA/edit?usp=sharing)
- [Hiring process outline](https://docs.google.com/document/d/12OGWrjBXRQwfGuR1lE-uxJLsCKrKu5yvm3xNibndJTA/edit?usp=sharing)

closes https://github.com/2i2c-org/team-compass/issues/436