### PR TITLE
Convert link checker action to CRON job

### DIFF
--- a/.github/workflows/doc-links.yml
+++ b/.github/workflows/doc-links.yml
@@ -1,13 +1,21 @@
-name: Test documentation for broken links
+name: Build documentation and check links
+
 on:
-  pull_request:
   workflow_dispatch:
+  schedule:
+  # Runs at 1am each day.
+  - cron: '0 1 * * *'
+
+env:
+  BROKEN_LINKS_ISSUE_NUMBER: 453
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   linkcheck:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
+      - uses: excitedleigh/setup-nox@v2.1.0
 
       - name: Setup Python
         uses: actions/setup-python@v2
@@ -15,7 +23,49 @@ jobs:
           python-version: 3.8
       - name: Install docs requirements
         run: pip install -r requirements.txt
-      
-      - name: make linkcheck
+    
+      - name: Build the documentation
         run: |
-          make linkcheck SPHINXOPTS='--color -W --keep-going'
+          nox -s docs -- -W
+
+      # ref: https://github.com/lycheeverse/lychee-action
+      # ref: https://github.com/lycheeverse/lychee#commandline-parameters
+      - name: Check documentation for broken links
+        uses: lycheeverse/lychee-action@v1.5.0
+        id: linkCheck
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        continue-on-error: true  # So we'll trigger the next steps if job fails
+        with:
+          fail: true
+          # Rationale for excluding specific sites:
+          # 2i2c-org/meta + 2i2c-org/leads + 2i2c-org/projects: All private
+          # /edit: Auto-generated and will break when adding new pages
+          # issues/: Links to GitHub issue queries always result in network error
+          args: >
+            _build/html/**/*.html
+            --insecure
+            --max-retries 10
+            --exclude-link-local
+            --exclude mailto
+            --exclude file://
+            --exclude https://github.com/2i2c-org/meta
+            --exclude https://github.com/2i2c-org/leads
+            --exclude https://github.com/orgs/2i2c-org/projects/
+            --exclude https://github.com/2i2c-org/team-compass/edit/
+            --exclude https://github.com/issues?
+          jobSummary: true
+      
+      # If our linkcheck failed, then update the broken link issue and re-open
+      - name: Create issue from Lychee output
+        if: steps.linkCheck.outcome == 'failure'
+        uses: peter-evans/create-issue-from-file@v4.0.0
+        with:
+          issue-number: ${{env.BROKEN_LINKS_ISSUE_NUMBER}}
+          title: Broken links in documentation
+          content-filepath: ./lychee/out.md
+
+      - name: Re-open the links issue
+        if: steps.linkCheck.outcome == 'failure'
+        run: gh issue reopen $BROKEN_LINKS_ISSUE_NUMBER
+

--- a/.github/workflows/doc-links.yml
+++ b/.github/workflows/doc-links.yml
@@ -7,6 +7,7 @@ on:
   - cron: '0 1 * * *'
 
 env:
+  # Issue: https://github.com/2i2c-org/team-compass/issues/453
   BROKEN_LINKS_ISSUE_NUMBER: 453
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
This updates our GitHub action for checking links to be a bit less noisy for each PR. It does these things:

- Each day it runs the action on a CRON job
- If broken links are found via the lychee action, then:
- It re-opens a dedicated link-checking issue with a list of the broken links.

So we can close that issue with PRs to fix the docs, and the issue will automatically re-open in the future if links break again.

Note I will merge this one in so that we can see how it works, might need to iterate a little bit.

### Future improvements

This removes link checking on individual PRs, with the goal of making them less prone to test failures because a non-related link broke. In the future, we could also add functionality to test links only for the files that were modified by the PR, but let's see how this goes first.