### PR TITLE
Re-usable workflow for linkcheck

### DIFF
--- a/.github/workflows/doc-links.yml
+++ b/.github/workflows/doc-links.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   linkcheck:
-    uses: 2i2c-org/.github/.github/workflows/documentation-link-check.yml@main
+    uses: 2i2c-org/.github/.github/workflows/documentation-link-check.yaml@main
     with:
       docs_path: .
       # Issue: https://github.com/2i2c-org/team-compass/issues/453

--- a/.github/workflows/doc-links.yml
+++ b/.github/workflows/doc-links.yml
@@ -1,72 +1,17 @@
 name: Build documentation and check links
 
 on:
+  pull_request:  # TODO: REMOVE THIS WHEN DONE PLAYING AROUND
   workflow_dispatch:
   schedule:
   # Runs at 1am each day.
   - cron: '0 1 * * *'
 
-env:
-  # Issue: https://github.com/2i2c-org/team-compass/issues/453
-  BROKEN_LINKS_ISSUE_NUMBER: 453
-  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
 jobs:
   linkcheck:
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2
-      - uses: excitedleigh/setup-nox@v2.1.0
-
-      - name: Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
-      - name: Install docs requirements
-        run: pip install -r requirements.txt
-    
-      - name: Build the documentation
-        run: |
-          nox -s docs -- -W
-
-      # ref: https://github.com/lycheeverse/lychee-action
-      # ref: https://github.com/lycheeverse/lychee#commandline-parameters
-      - name: Check documentation for broken links
-        uses: lycheeverse/lychee-action@v1.5.0
-        id: linkCheck
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-        continue-on-error: true  # So we'll trigger the next steps if job fails
-        with:
-          fail: true
-          # Rationale for excluding specific sites:
-          # 2i2c-org/meta + 2i2c-org/leads + 2i2c-org/projects: All private
-          # /edit: Auto-generated and will break when adding new pages
-          # issues/: Links to GitHub issue queries always result in network error
-          args: >
-            _build/html/**/*.html
-            --insecure
-            --max-retries 10
-            --exclude-link-local
-            --exclude mailto
-            --exclude file://
-            --exclude https://github.com/2i2c-org/meta
-            --exclude https://github.com/2i2c-org/leads
-            --exclude https://github.com/orgs/2i2c-org/projects/
-            --exclude https://github.com/2i2c-org/team-compass/edit/
-            --exclude https://github.com/issues?
-          jobSummary: true
-      
-      # If our linkcheck failed, then update the broken link issue and re-open
-      - name: Create issue from Lychee output
-        if: steps.linkCheck.outcome == 'failure'
-        uses: peter-evans/create-issue-from-file@v4.0.0
-        with:
-          issue-number: ${{env.BROKEN_LINKS_ISSUE_NUMBER}}
-          title: Broken links in documentation
-          content-filepath: ./lychee/out.md
-
-      - name: Re-open the links issue
-        if: steps.linkCheck.outcome == 'failure'
-        run: gh issue reopen $BROKEN_LINKS_ISSUE_NUMBER
-
+    uses: choldgraf/scratch/.github/workflows/linkcheck.yml@main
+    with:
+      docs_path: .
+      # Issue: https://github.com/2i2c-org/team-compass/issues/453
+      issue_number: 453
+      requirements_path: requirements.txt

--- a/.github/workflows/doc-links.yml
+++ b/.github/workflows/doc-links.yml
@@ -7,6 +7,7 @@ on:
   - cron: '0 1 * * *'
 
 jobs:
+  # ref: https://github.com/2i2c-org/.github/blob/main/.github/workflows/documentation-link-check.yaml
   linkcheck:
     uses: 2i2c-org/.github/.github/workflows/documentation-link-check.yaml@main
     with:

--- a/.github/workflows/doc-links.yml
+++ b/.github/workflows/doc-links.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   linkcheck:
-    uses: choldgraf/scratch/.github/workflows/linkcheck.yml@main
+    uses: 2i2c-org/.github/.github/workflows/documentation-link-check.yml@main
     with:
       docs_path: .
       # Issue: https://github.com/2i2c-org/team-compass/issues/453

--- a/.github/workflows/doc-links.yml
+++ b/.github/workflows/doc-links.yml
@@ -1,7 +1,6 @@
 name: Build documentation and check links
 
 on:
-  pull_request:  # TODO: REMOVE THIS WHEN DONE PLAYING AROUND
   workflow_dispatch:
   schedule:
   # Runs at 1am each day.

--- a/.github/workflows/doc-links.yml
+++ b/.github/workflows/doc-links.yml
@@ -12,6 +12,4 @@ jobs:
     uses: 2i2c-org/.github/.github/workflows/documentation-link-check.yaml@main
     with:
       docs_path: .
-      # Issue: https://github.com/2i2c-org/team-compass/issues/453
-      issue_number: 453
       requirements_path: requirements.txt


### PR DESCRIPTION
This PR uses a re-usable GitHub workflow that I've been playing around with here:

- https://github.com/choldgraf/scratch/blob/main/.github/workflows/linkcheck.yml

It will build the Sphinx documentation in a repository, reformat any warnings to be markdown-friendly, and open an issue of our choosing with the information. You can see an example of what this issue looks like here:

- https://github.com/2i2c-org/team-compass/issues/453

If there aren't any objections, I'd like to move that re-usable linkcheck action into our `.github` repository, and then re-use it across our individual repos so that we have a single workflow for checking our documentation links/references w/ Sphinx. That should reduce our repetition and also reduce the noise associated with broken links, since it would just create a new issue if there are broken links.