### PR TITLE
Add meeting notes and fix team page

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -13,7 +13,7 @@ author = "2i2c"
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    "myst_parser",
+    "myst_nb",
     "sphinx_design",
     "sphinx_copybutton",
     "sphinx.ext.intersphinx",
@@ -82,7 +82,7 @@ from bs4 import BeautifulSoup
 import pandas as pd
 from pathlib import Path
 
-resp = request.urlopen("https://2i2c.org/about/")
+resp = request.urlopen("https://2i2c.org/team/")
 text = resp.read().decode()
 
 teams = []
@@ -106,11 +106,8 @@ for row in BeautifulSoup(text, features="html.parser").select("div.people-widget
     teams.append(entry)
 
 # Sort and create CSV files to be imported in the Team page
-teams = pd.DataFrame(teams)
 Path(__file__).parent.joinpath("tmp").mkdir(exist_ok=True)
-for team, people in teams.groupby("team"):
-    people.sort_values("name").drop(columns=["team"]).to_csv(f"tmp/{team}.csv" , index=None)
-
+pd.DataFrame(teams).to_csv("tmp/team_membership.csv", index=None)
 
 # -- Sphinx setup script ---------------------------------------------------
 

--- a/conf.py
+++ b/conf.py
@@ -70,45 +70,6 @@ linkcheck_ignore = [
     "https://airtable.com*",  # Because it has some kind of security that returns a 403
 ]
 
-
-# -- Custom scripts ---------------------------------------------------
-
-# Hacky solution to list the latest engineering team members as reference
-# This grabs the latest list of team members from https://2i2c.org/about/
-# It then parses the HTML to grab the names and GitHub handles, then sorts by name
-# We can use this to define the order of team roles.
-from urllib import request
-from bs4 import BeautifulSoup
-import pandas as pd
-from pathlib import Path
-
-resp = request.urlopen("https://2i2c.org/team/")
-text = resp.read().decode()
-
-teams = []
-for row in BeautifulSoup(text, features="html.parser").select("div.people-widget > div"):  
-    # If not a `.people-person` item, it will be a group title
-    if "people-person" not in row.attrs.get("class"):
-        category = row.text.strip()
-        continue
-    entry = {"name": row.select("h2 a")[0].text, "team": category}
-
-    # Grab the listed contact links for this person
-    for link in row.select("ul.network-icon a"):
-        if "fa-github" in str(link):
-            handle = link.attrs["href"].split("/")[-1]
-            entry["github"] = f"[@{handle}]({link.attrs['href']})"
-        elif "mailto" in str(link):
-            entry["email"] = link.attrs["href"].split(":")[-1]
-        elif "twitter" in str(link):
-            handle = link.attrs["href"].split("/")[-1]
-            entry["twitter"] = f"[@{handle}]({link.attrs['href']})"
-    teams.append(entry)
-
-# Sort and create CSV files to be imported in the Team page
-Path(__file__).parent.joinpath("tmp").mkdir(exist_ok=True)
-pd.DataFrame(teams).to_csv("tmp/team_membership.csv", index=None)
-
 # -- Sphinx setup script ---------------------------------------------------
 
 def setup(app):

--- a/meetings/eng/2022.md
+++ b/meetings/eng/2022.md
@@ -1,5 +1,132 @@
 # 2022 Meeting Notes
 
+## 2022-06
+
+- Facilitator: Yuvi
+- Notetaker: Yuvi
+- Timekeeper: Chris
+
+### Onboard James!
+
+- Issue: https://github.com/2i2c-org/meta/issues/337
+  - July 1 as first day!
+  - Trying to pay attention to issues, slack, email & join in wherever.
+  - Wears more than 1 hat, taking off hats as appropriate. Intent is to be generally available for most 2i2c things
+- Interested in 'making research & education delightful'
+  - Documentation, training, onboarding!
+  - Nature of research & edu is that we keep having new cohorts of people who need to be onboarded!
+  - Participating in project Pythia hackathon working on documentation (xarray, dask, etc)
+- Figuring out and joining different communities!
+  - pangeo is a big one (one of the ones that 2i2c started to operationalize!)
+  - Finding names of other communities we're a part of! Finding their names, connecting on their communities, etc.
+  - Registered for Scientific community management program (along with Sarah!)
+  - Want to enable _other_ community managers too! So they feel empowered to do the things they need todo
+- Product side!
+  - Right to Replicate is core value of 2i2c
+  - Some experience in running helm, k8s, z2jh, etc.
+  - Has been a while, but am going to go through 2i2c's docs and see if it 'works'!
+  - Fill in holes as it's needed, get a feel for product as it is
+  - Run it on something like minikube to test it out
+- Figure out what a 3-6 month strategy for division of product & community would look like
+  - Already collecting with Jim on the partnership & sales side of it
+- Where are the sources of truth? Other ones James hasn't explored?
+  - Some on google drive
+    - Figuring out how to use team shared drives
+    - Google offers it for free for non profits, but because we're under CSS they might already have it
+    - Chris is going to figure out a shared Google Drive setup.
+
+### Language and naming around our managed hub service
+
+- Issue: https://github.com/2i2c-org/infrastructure/issues/1474
+- New diagrams of our service model from a recent CZI grant: https://docs.google.com/presentation/d/12Xkpin0sNwcBygArFUSalkrgfONgaRrfUYokyfIWWh8/edit
+- What do you call the _process_ of what we provide and communicate that to communities?
+  - How do you bring in the concept of that shared responsibility so we don't pigeonhole ourself as a SaaS?
+- 'Managed' implies 2i2c does 'everything' which is not true - we run it collaboratively
+  - As a user, being able to have control over the user experience without requiring that I leave.
+  - Open source communities often run into these issues
+  - Don't want to create two "classes" of people
+  - Need to create community processes to help people do this
+- Right to Participate is important
+  - Super early draft: https://hackmd.io/Y5SBMxV7R6CMqzeTXgm5kA?edit
+- Words to describe this
+  - Managed JupyterHub service was picked because cloud service was managed by us, so others won't have to worry about it
+    - We call it JupyterHub to give people the idea that it is an open source component, just using OSS tools
+  - One proposal: "Collaborative Hub"
+    - But feels like this refers to the artifact (e.g. "collaborative editing") not the process.
+  - Make up a new word? (a neologism)
+    - Collaborative hub model can be part of the bullet points, can be a brand new thing.
+    - Are we providing jupyterhub, and our product _is_ jupyterhub? Or is it JupyterHub+ other stuff? not sure what to call it.
+
+### Constraints / guiding principles to define this service
+
+- Key words / ideas
+  - Unburdening - "We do work so you don't have to"
+  - Participatory / Collaborative - "We invite your participation at several levels if you wish"
+  - Transparency - "All our work is done in the open"
+  - Reciprocity - "We do most of our work via upstream improvements"
+  - "Levels of Participation" and "Shared Responsibility" are both aspects of the service. Describe how we have a range of collaboration options.
+  - Putting many concepts into a single name is probably not possible, so we should choose a name that is not _misleading_ and explain the details with extra documentation.
+  - Contribute to a pre-existing large multi-stakeholder community
+
+- Collaborative, participatory service
+- Erik: Transparent operations
+- Sarah: Unburdening (traditionally, this is 'put in a postdoc who has no k8s knowledge')
+- Chris: Participatory is an important one, the ways in which the service is trying to take inspiration from healthy inclusive OSS communities.
+  - Notion there is OSS as a license, you can see all the code and you can fork it! But the dynamics of production are a single team of people (docutils) where they don't care about increasing participation.
+  - But participatory is something like JupyterHub itself, where there are pathways to getting in and increasing the set of people who are participating.
+  - Tension between participatory and unburdening, as we're asking for _labor_ for other organizations.
+- Sarah: "Levels of participation", which we _do_ have.
+  - We are running a managed kubernetes service & a collaborative hub service.
+  - We don't get specific k8s feature requests because they don't know what they want but they do ask for specific hub features!
+  - It's our job to figure out if it's a k8s feature or not.
+  - _Extra complicated to put all this in a single term_ as it's a spectrum of variation of input as we go down our big stack
+- Damian: Trying to have all these complex concepts working at different levels in one name is impossible.
+  - So maybe we just have a name for the thing we are offering. And a description of what we are offering, otherwise it'll be a bit difficult to come up with a name.
+  - We are providing JupyterHub+ other things, we are offering an opinionated way to deploy hubs on the cloud. This opinionated way is the product itself.
+- Chris: Signal boost communities compare services by end product (features, end product I get, etc) and 2i2c needs to sell that the _process_ by which you get it is as important as the product you are selling itself. Not intuitive for a lot of communities that are used to the producer / consumer pigoenhole that tech tends to create. Process is important!
+- Damian: Right to participate, evolving and getting it written will help us fight the battles against University IT, etc. Will help us get into that conversation at the level where we don't end up in the situation wrt columbia credits again.
+- Yuvi: "Upstream" and "Upstream contributions" is another important part of this. It is a differentiator between what we do and many other startups. We contribute to a _pre-existing_ large multi-stakeholder community.
+
+
+### Discuss making our operation and dev items assignments being two people by default
+
+- https://github.com/2i2c-org/team-compass/issues/444
+- How do we managed inefficiencies in the pairment
+- e.g., time zones and bottlenecks
+- One 'lead' developer who can work on the project and a 'companion' person who can help iterate quickly
+- We did this with sarah & erik for the CI/CD revamp! Worked really great, showcased the pattern is pretty good.
+- Trying to make this more official
+- Damian is trying to make requests for new hubs to use pairs of people, as these are 'must do'
+- Mismatch of tz makes things a bit inefficient.
+- Should come up with teams that might change composition, that collaborate together. But how to deal with tz?
+- We should adopt pairing in almost all our projects!
+- Chris: What are the 2/3 main problems we're trying to resolve with pairing?
+  - People start working on projects because they are assigned to work on those, but they are not getting feedback as soon as they are helpful. Lots of conversations / PRs open for days and days, but not because people don't like to provide feedback. Need to have interactive discussion to push things forward. Pairing tries to force this.
+  - We have a lot of complexity in our stack! Makes it easier to push forward because things can be complicated.
+  - Prevent siloing our knowledge about the idiosynchrasies of the infrastructure and of skills in general.
+
+### Upcoming other PM-related changes
+
+- 1:1 with engs (already 1:1 settle with other team members)
+  - Meetings but could be async as well
+  - Discuss dedicated boards
+  - General prioritization
+  - Figure out how to transition from leads to infra work
+  - Doesn't need to be synchronous, can also be async - the important thing is to have discussions focused on these topics.
+- General improvements to how we prioritize
+  - We might eventually have a big shared meeting to help prioritize stuff but we aren't there yet.
+  - Yuvi: Large prioritization meetings can end up being non-equitable, so happy to start on the 1:1 methods
+- How can we focus on the 'shaping' work in reducing uncertainity around issues?
+  - Damian: We currently have a process that is not actually happening, and we hope the 1:1 will help. Shaping of issue around dev is different from shaping for new hubs.
+  - Damian will reach out to schedule these
+  - Process for new hub request could be first goal to hit
+- Shoutout to Georgiana for gathering better information on the Callysto hub
+
+### Action items
+
+- Need to get credentials for James
+  - Chris is championing the onboarding, Sarah has offered to help with the technical bits
+
 ## 2022-05
 
 - Facilitator: Sarah
@@ -19,7 +146,6 @@ Make an offer:
 - DA: We have consensus on hiring top candidate? +1s all around...
 
 Additional option:
-
 
 Next steps (CH)
 
@@ -140,7 +266,7 @@ Discussion:
       - We really only care about the "major issues" when it comes to timezones". Most things are not required to fix immediately.
       - This is where a pager can be helpful.
     - Incident Commander is a concept from SRE
-      - When there is an *outage*, this person makes sure that it is resolved.
+      - When there is an _outage_, this person makes sure that it is resolved.
       - Used in "must be fixed immediately" situations.
       - Something like [Pager Duty](https://www.pagerduty.com/) is a good tool to try out.
   - What are the 2-3 things we can do next to improve things?
@@ -168,6 +294,7 @@ Discussion:
 - Our current agenda is split between a Google Calendar, a GitHub issue, and this HackMD.
 - We've hit confusion about syncing information across them etc.
 - Let's simplify with this structure:
+
   - Do not use a dedicated issue for these meetings. Remove the issue template for team meetings.
   - The 2i2c Team Calendar is the source of truth for this meeting. We expect team members to keep up-to-date w/ this calendar to know when meetings will happen.
   - Meeting calendar events have one link, which is to the meeting agenda/notes.
@@ -227,7 +354,7 @@ Discussion:
 - More standardized hubs -> we can support more communities. We need to have a grasp of what we aim for with regards to this.
   - Avoid one off features
 - Answer 1: Projecting into the feature is one way to answer
-  - Sarah: very few new communities *right now*, because we are to handle a new hub type: binderhubs
+  - Sarah: very few new communities _right now_, because we are to handle a new hub type: binderhubs
 
 **What is our biggest source of risk?**
 
@@ -306,7 +433,7 @@ A few questions and ideas:
 - Questions:
   - What do others think about the scope of this role? Does it make sense?
     - ES: At Sandvik, it would have been helpful to have somebody dedicating time to teaching others how to make use of the service.
-      - Collecting user experience data *quickly* rather than *slowly* can be critical.
+      - Collecting user experience data _quickly_ rather than _slowly_ can be critical.
       - "They'd be in a unique position to validate the value of certain features".
       - Could this role write feature proposals for open source communities?
     - GD: Could help build trust with communities, by having a more human connection
@@ -345,8 +472,8 @@ When communities want a hub to run in a particular datacenter, does this mean we
 - We might be thinking about this when it comes to the pangeo Binder
 - Would testing fix this?
   - In some cases, maybe, but not always
-  - For hubs that *want* to have full access, testing would not be a fix
-- Scenario where somebody *wants* to have full access
+  - For hubs that _want_ to have full access, testing would not be a fix
+- Scenario where somebody _wants_ to have full access
   - A time-boxed workshop where you don't want to hassle with manually adding a bunch of people
 - Could email reporting address this?
   - Having a single grafana that aggregates across the prometheus for each hub would help

--- a/reference/team.md
+++ b/reference/team.md
@@ -16,26 +16,71 @@ kernelspec:
 The 2i2c team is defined on [the `team/` page of our website](https://2i2c.org/team/).
 Below is a summary of the people on that page.
 
-% Uses the CSV auto-generated from the HTML at https://2i2c.org/team/
+% The code below uses urllib and beautifulsoup to grab the HTML of the team section
+% defined at https://2i2c.org/team . It then directly places the HTML here
+% and applies some light styles to make it look nice. This way the team structure
+% here and on 2i2c.org/team is always in-sync.
 
-```{code-cell}
+<style>
+.people-widget {
+    text-align: center;
+}
+
+.people-person {
+    width: 25%;
+}
+
+.people-person img {
+    border-radius: 10em;
+}
+
+.people-person h1 {
+    font-size: 1.5rem;
+}
+
+.people-person h2 {
+    font-size: 1.2rem;
+    margin-top: 1rem;
+}
+
+.people-person h3 {
+    font-size: 1rem;
+}
+
+.people-person ul {
+    list-style: none;
+    display: flex;
+    gap: 0.5rem;
+    justify-content: center;
+    padding: 0;
+}
+</style>
+
+```{code-cell} ipython3
 ---
 mystnb:
   markdown_format: myst
 tags: [remove-input]
 ---
-import pandas as pd
-from IPython.display import display, Markdown
+from urllib import request
+from bs4 import BeautifulSoup
+from IPython.display import HTML
 
-# This should be generated automatically by `conf.py`
-team = pd.read_csv("../tmp/team_membership.csv").fillna("")
+# Grab the latest HTML for our teams
+html = request.urlopen("https://2i2c.org/team/").read().decode()
+people = BeautifulSoup(html, features="html.parser").select("div.people-widget")[0]
 
-for team, people in team.groupby("team", sort=False):
-    display(Markdown(f"**{team}**"))
-    display(Markdown(people.drop(columns=["team"]).to_markdown(index=False)))
+# Replace links and image sources with 2i2c versions so they work
+for a in people.findAll('a'):
+  a['href'] = a['href'].replace("../", "https://2i2c.org/")
+for img in people.findAll('img'):
+  img['src'] = img['src'].replace("../", "https://2i2c.org/")
+
+# Output as HTML so MyST-NB will display it
+HTML(str(people))
 ```
 
-## Engineering team locations and times
+## Team member locations and times
 
 For a quick glance at which timezone each team member is in, see the [this `whena.re` website](https://whena.re/2i2c-engineering-team), or the iframe below.
 

--- a/reference/team.md
+++ b/reference/team.md
@@ -1,22 +1,38 @@
+---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.13.8
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+---
+
 # List of team members
 
-The 2i2c team is defined [on the `about/` page of our website](https://2i2c.org/about/).
+The 2i2c team is defined on [the `team/` page of our website](https://2i2c.org/team/).
 Below is a summary of the people on that page.
 
-% Auto-generated from the HTML at https://2i2c.org/about/
+% Uses the CSV auto-generated from the HTML at https://2i2c.org/team/
 
-## Open Infrastructure Team
+```{code-cell}
+---
+mystnb:
+  markdown_format: myst
+tags: [remove-input]
+---
+import pandas as pd
+from IPython.display import display, Markdown
 
-```{csv-table}
-:file: ../tmp/Open Engineering Team.csv
-:header-rows: 1
-```
+# This should be generated automatically by `conf.py`
+team = pd.read_csv("../tmp/team_membership.csv").fillna("")
 
-## Steering Council
-
-```{csv-table}
-:file: ../tmp/Steering Council.csv
-:header-rows: 1
+for team, people in team.groupby("team", sort=False):
+    display(Markdown(f"**{team}**"))
+    display(Markdown(people.drop(columns=["team"]).to_markdown(index=False)))
 ```
 
 ## Engineering team locations and times

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
+ipython
 myst-parser[linkify]
+myst-nb
 pandas
 sphinx
 sphinx-autobuild


### PR DESCRIPTION
This adds our team meeting notes from June, and also fixes up our team page to work again. It tries to be a bit more programmatic in how it generates this page by using MyST-NB to auto-create the markdown we need. ✨ 

closes #469