### PR TITLE
Add finance page

### DIFF
--- a/finance/index.md
+++ b/finance/index.md
@@ -1,0 +1,15 @@
+# Finance and accounting
+
+Main documentation for 2i2c's financial and accounting information.
+
+## Assets
+
+- [2i2c Drive Folder with our finance assets](https://drive.google.com/drive/folders/1D5NQKhPDP6zMQ8EdLcMOceTz-ek81nmX?usp=sharing)
+- [CS&S Drive Folder with their finance assets](https://drive.google.com/drive/folders/115EIa6cD4BNGIqOd2i7Rqu3MgsM73lgR?usp=sharing)
+
+## Budget projections
+
+We have a Google Sheet that can be used to create rough budget projections given some input data about our income and expenses.
+The first tab explains how to use and interpret the sheet.
+
+- [Budget projections](https://docs.google.com/spreadsheets/d/1zDO_kqnJ1PH3GWOMks5E_1oIpoAJgseWhj3oCohUVZk/edit#gid=929955044)

--- a/index.md
+++ b/index.md
@@ -33,6 +33,7 @@ Information broken down by major functional and topic areas of 2i2c.
 coordination/index
 infrastructure/index
 community/index
+finance/index
 administration/index
 hr/index
 about/index


### PR DESCRIPTION
This adds a finance page to our team compass, as well as a few links to major places where we keep finance information and documentation.

It also adds a link to a little "budget projection" Google Sheet which we can use to project out our finances in the future to help us make decisions.