### PR TITLE
ENH: Update CSS administration information

### DIFF
--- a/administration/css.md
+++ b/administration/css.md
@@ -1,0 +1,29 @@
+# CS&S Administration
+
+There are a few ways in which we interact with {term}`Code for Science and Society`.
+This page provides an overview.
+
+## CS&S Handbooks
+
+CS&S has two handbooks that have information and policy for the organization.
+These apply to anybody that is employed or contracted by 2i2c.
+Below are links to each:
+
+- [The CS&S Handbook](https://www.notion.so/CS-S-Handbook-18cd12a6e44c4393857642da6a6b0fdf) is similar to our Team Compass.
+- [CS&S Employee Handbook](https://docs.google.com/document/d/1LDN8-iSak391uQC5AzvtzD9dIOmfHg8kihwlvzn8Cy8/edit#heading=h.gjdgxs) is more like an employee policy guide.
+
+## E-mail addresses
+
+CS&S has a few email addresses that they use for different kinds of communication.
+The two major addresses are:
+
+- **`operations@codeforscience.org`**: To discuss invoices, contracting, etc.
+  This includes most "administrative actions" that we need help with.
+- **`fsp@codeforscience.org`**: For more strategic and programs-level conversations.
+
+## Asana board
+
+CS&S has an Asana board that they occasionally use to tack work items.
+You can find it at this link:
+
+[CS&S Asana Board](https://app.asana.com/0/1200569652722016/list).

--- a/administration/index.md
+++ b/administration/index.md
@@ -2,55 +2,8 @@
 
 This chapter contains administrative information at 2i2c.
 
-(admin:expensify)=
-## Expensify
-
-Our fiscal sponsor, {term}`CS&S`, uses [an Expensify service](https://www.expensify.com/inbox) to handle all of our project billing and connect it with our grants.
-
-Only two people are able to be managers on this account, currently these are:
-
-- Chris Holdgraf
-- Jim Colliander
-
-If you'd like access to our Expensify account or need to use it, reach out to one of these people.
-
-(admin:credit-card)=
-### Expensify credit card
-
-For recurring payments for services, or major organizational expenses, we have an Credit card that is directly linked to our Expensify account.
-This allows us to pay directly out of our organizational funds without requiring a team member to pay up-front.
-
-## Reimbursement
-
-### What can be reimbursed?
-
-We reimburse team members that take on expenses as part of doing their work, provided that these expenses are aligned with the mission and goals of 2i2c.
-Any reimbursement request will need to be approved by either {term}`CS&S` or 2i2c's Executive Director.
-
-A good rule of thumb is to ask before you purchase something that you plan to reimburse in the future.
-As we understand our regular costs we will build a more sophisticated policy for what kinds of things can be reimbursed.
-
-Currently, these are the expenses that we regularly reimburse:
-
-- Monthly / annual fees for online services that are used across the entire 2i2c team.
-- Cloud infrastructure costs incurred as part of our services.
-- Conference travel / registration for conferences that we agree are in-scope for 2i2c's attendance.
-- Personal development / training for skills that are directly related to team responsibilities.
-- Infrequent equipment purchases for team members (computers, desks, etc) provided they are within a reasonable spend amount.
-
-### Reimbursement process
-
-We do all of our reimbursements via our fiscal sponsor, {term}`CS&S`.
-Here is the process that we follow:
-
-- **For employees**: Submit reimbursements via [Expensify](admin:expensify).
-- **For contractors**: Submit a separate line item on your monthly invoice, called `Reimbursement - <item>`
-
-For contractors, we also need to include the following language in your contract:
-
-> Expenses: Organization agrees to reimburse Independent Contractor for all expenses reasonably incurred in the performance of the Engagement and approved by Organization in advance, upon presentation of supporting receipts and documentation.
-
-### If you do not wish to pay yourself
-
-If you do not wish to make the payment yourself, we can make a payment with our [Expensify Credit Card](admin:credit-card).
-To do this, contact the [Executive Director](titles:exec-dir) or the [Partnerships Lead](titles:partnerships-lead).
+```{toctree}
+:maxdepth: 2
+css
+reimburse
+```

--- a/administration/reimburse.md
+++ b/administration/reimburse.md
@@ -1,0 +1,50 @@
+(admin:reimbursement)=
+# Reimbursement and credit cards
+
+Our fiscal sponsor, {term}`CS&S`, use [a service called Ramp](https://ramp.com/) to handle all of our project billing and connect it with our grants.
+
+If you'd like access to our Ramp account or need to use it, reach out to one of these people.
+
+(admin:credit-card)=
+## Ramp credit card
+
+We have two Ramp credit cards: one that is designed specifically to reimburse cloud costs, and another that is for general purposes.
+This allows us to pay directly out of our organizational funds without requiring a team member to pay up-front.
+
+**Chris Holdgraf** has the credit card information for these cards.
+Ask him if you need to use them.
+
+## Reimbursement policy
+
+### What can be reimbursed?
+
+We reimburse team members that take on expenses as part of doing their work, provided that these expenses are aligned with the mission and goals of 2i2c.
+Any reimbursement request will need to be approved by either {term}`CS&S` or 2i2c's Executive Director.
+
+A good rule of thumb is to ask before you purchase something that you plan to reimburse in the future.
+As we understand our regular costs we will build a more sophisticated policy for what kinds of things can be reimbursed.
+
+Currently, these are the expenses that we regularly reimburse:
+
+- Monthly / annual fees for online services that are used across the entire 2i2c team.
+- Cloud infrastructure costs incurred as part of our services.
+- Conference travel / registration for conferences that we agree are in-scope for 2i2c's attendance.
+- Personal development / training for skills that are directly related to team responsibilities.
+- Infrequent equipment purchases for team members (computers, desks, etc) provided they are within a reasonable spend amount.
+
+### Reimbursement process
+
+We do all of our reimbursements via our fiscal sponsor, {term}`CS&S`.
+Here is the process that we follow:
+
+- **For employees**: Submit reimbursements via [Ramp](admin:reimbursement).
+- **For contractors**: Submit a separate line item on your monthly invoice, called `Reimbursement - <item>`
+
+For contractors, we also need to include the following language in your contract:
+
+> Expenses: Organization agrees to reimburse Independent Contractor for all expenses reasonably incurred in the performance of the Engagement and approved by Organization in advance, upon presentation of supporting receipts and documentation.
+
+### If you do not wish to pay yourself
+
+If you do not wish to make the payment yourself, we can make a payment with our [Ramp Credit Card](admin:credit-card).
+To do this, contact the [Executive Director](titles:exec-dir) or the [Partnerships Lead](titles:partnerships-lead).


### PR DESCRIPTION
This provides some basic information about our relationship with CS&S. It also updates our documentation about Expensify to specify Ramp instead.

- closes https://github.com/2i2c-org/team-compass/issues/522