### PR TITLE
Add Zenodo to communication page and update content

### DIFF
--- a/community/communication.md
+++ b/community/communication.md
@@ -3,11 +3,23 @@
 There are a few different ways that we communicate with stakeholders outside of 2i2c.
 See below for details.
 
-There are three main ways that 2i2c communicates with the outside world:
+## Blog
 
-- Twitter: [@2i2c_org](https://twitter.com/2i2c_org)
-  - Currently, there is nobody activately monitoring the Twitter account. We use it to post links to blog posts or major announcements in the newsletter.
+Our most common form of communication is via [the blog at 2i2c.org/blog](https://2i2c.org/blog).
+It is managed by our [Hugo website repository](https://github.com/2i2c-org/2i2c-org.github.io).
+
+## Social media
+
+We have a Twitter acccount ([@2i2c_org](https://twitter.com/2i2c_org)) for social media communication.
+Currently, there is nobody activately monitoring the Twitter account.
+We use it to post links to blog posts or major announcements in the newsletter.
+
+## Newsletter
+
 - Newsletter: [using Mailchimp](https://mailchimp.com/)
   - Users sign up to the newsletter via our landing page's contact form at [2i2c.org#contact](https://2i2c.org#contact). Email addresses are imported into Mailchimp for the newsletter.
-- Blog: [2i2c.org/blog](https://2i2c.org/blog)
-  - The blog is managed by our [Hugo website repository](https://github.com/2i2c-org/2i2c-org.github.io). All new posts are automatically sent to the mailing list on a weekly basis.
+
+## Zenodo community
+
+We have [a Zenodo community](https://zenodo.org/communities/2i2c/) that we use to upload and categorize any artifacts that warrant a DOI.
+Any 2i2c team member is welcome to add their Zenodo records to this community, and any team member may be added to the list of curators.


### PR DESCRIPTION
I needed to upload a Zenodo record, and realized that we didn't have a 2i2c "Community" on there. So I created one, and am documenting it here + updating some language as well.