### PR TITLE
Add Process and Operations meeting

### DIFF
--- a/meetings/list.md
+++ b/meetings/list.md
@@ -18,7 +18,7 @@ This includes ideas for how the infrastructure should improve, major development
 
 It is led by our **`Engineering`** and **`Product`** teams.
 
-- **Date**: [every Tuesday at **4pm CET**](https://calendar.google.com/calendar/embed?src=c_nq8hl7qsm484g1p7mfkm29jpo8%40group.calendar.google.com&ctz=America%2FLos_Angeles)
+- **Date**: [every Tuesday](https://calendar.google.com/calendar/embed?src=c_nq8hl7qsm484g1p7mfkm29jpo8%40group.calendar.google.com&ctz=America%2FLos_Angeles)
 - **Notes and Agenda**: [Google Doc](https://docs.google.com/document/d/1dUO2USQlRbcjOEkjlCu1gyTaPBZmGZSRF4L-_9xecmA/edit?usp=sharing)
 
 ### Community and Partnerships
@@ -28,7 +28,7 @@ This also includes building tutorials and learning material for communities.
 
 It is led by our **`Community`** and **`Partnerships`** teams.
 
-- **Date**: [every Thursday at **4pm CET**](https://calendar.google.com/calendar/embed?src=c_nq8hl7qsm484g1p7mfkm29jpo8%40group.calendar.google.com&ctz=America%2FLos_Angeles)
+- **Date**: [every Thursday](https://calendar.google.com/calendar/embed?src=c_nq8hl7qsm484g1p7mfkm29jpo8%40group.calendar.google.com&ctz=America%2FLos_Angeles)
 - **Running notes and agenda**: [google doc](https://drive.google.com/open?id=1vpZKiWFCG8Pb4pm8ny6S-lb_n31TOLIKma4r_0N-RPU&authuser=1&usp=meetingnotes&showmeetingnotespromo=true)
 
 ### Organizational strategy
@@ -37,8 +37,22 @@ Covers our high-level organizational mission, values, and principles, our high-l
 
 It is led by the **`Executive Director`**.
 
-- **Date**: [every other Wednesday at **5pm CET**](https://calendar.google.com/calendar/embed?src=c_nq8hl7qsm484g1p7mfkm29jpo8%40group.calendar.google.com&ctz=America%2FLos_Angeles)
+- **Date**: [every other Wednesday](https://calendar.google.com/calendar/embed?src=c_nq8hl7qsm484g1p7mfkm29jpo8%40group.calendar.google.com&ctz=America%2FLos_Angeles)
 - **Notes and Agenda**: [google doc](https://drive.google.com/open?id=1HoNX8T8IQ1uhS2ryi1r9iS-nSbPT1b1Y7HsjosbHme8&authuser=1&usp=meetingnotes&showmeetingnotespromo=true)
+
+### Process and operations
+
+Covers our operational practices and systems for coordination and planning.
+We discuss ways that we can improve organization-wide practices to become more efficient and effective at doing our work.
+
+It is led by the **`Project Manager`**.
+
+- **Date**: [every other Tuesday](https://calendar.google.com/event?action=TEMPLATE&tmeid=NzRsbm1vc3Y4ZmlmZ2xucDE3cWI0YmxlMmNfMjAyMjEwMjVUMTMwMDAwWiBjXzRoampvdW9qZDhwc3FsOWkxYThuZDF1ZmY0QGc&tmsrc=c_4hjjouojd8psql9i1a8nd1uff4%40group.calendar.google.com)
+- [ ] 
+- [ ] 
+- [ ] Add to team calendar
+- [ ] Document here
+- [ ] 
 
 ## Monthly retrospectives
 

--- a/meetings/list.md
+++ b/meetings/list.md
@@ -48,11 +48,6 @@ We discuss ways that we can improve organization-wide practices to become more e
 It is led by the **`Project Manager`**.
 
 - **Date**: [every other Tuesday](https://calendar.google.com/event?action=TEMPLATE&tmeid=NzRsbm1vc3Y4ZmlmZ2xucDE3cWI0YmxlMmNfMjAyMjEwMjVUMTMwMDAwWiBjXzRoampvdW9qZDhwc3FsOWkxYThuZDF1ZmY0QGc&tmsrc=c_4hjjouojd8psql9i1a8nd1uff4%40group.calendar.google.com)
-- [ ] 
-- [ ] 
-- [ ] Add to team calendar
-- [ ] Document here
-- [ ] 
 
 ## Monthly retrospectives
 


### PR DESCRIPTION
Every couple of weeks @damianavila and I have been meeting to discuss team processes, systems for coordination and planning, etc. We've been doing this as part of our one-on-one meetings, but now that we have defined "content meetings" series, we felt that it would be better to formalize this type of meeting and make it more accessible to others on the team.

So this PR adds a new type of content meeting called a **Process and Operations** meeting. This PR adds the meeting link and brief overview of the meeting purpose.