### PR TITLE
Add organizational leadership workflow docs

### DIFF
--- a/meetings/list.md
+++ b/meetings/list.md
@@ -33,12 +33,7 @@ It is led by our **`Community`** and **`Partnerships`** teams.
 
 ### Organizational strategy
 
-Covers our high-level organizational mission, values, and principles, our high-level team systems and structure, as well as our near-term goals and objectives.
-
-It is led by the **`Executive Director`**.
-
-- **Date**: [every other Wednesday at **5pm CET**](https://calendar.google.com/calendar/embed?src=c_nq8hl7qsm484g1p7mfkm29jpo8%40group.calendar.google.com&ctz=America%2FLos_Angeles)
-- **Notes and Agenda**: [google doc](https://drive.google.com/open?id=1HoNX8T8IQ1uhS2ryi1r9iS-nSbPT1b1Y7HsjosbHme8&authuser=1&usp=meetingnotes&showmeetingnotespromo=true)
+See [](organization:meeting-strategy).
 
 ## Monthly retrospectives
 

--- a/organization/index.md
+++ b/organization/index.md
@@ -4,14 +4,22 @@ Organization-wide strategy, policy, and structure.
 
 ```{toctree}
 :maxdepth: 2
+:caption: Organizational policy
 ../code-of-conduct/index.md
 mission
 structure
 leadership
 governance
 strategy
-communication
-information
 team-compass
 ../meetings/index
+communication
+information
+```
+
+Our organizational workflow describes how 2i2c's leadership organizes and coordinates amongst one another.
+
+```{toctree}
+:caption: Leadership workflow
+workflow
 ```

--- a/organization/workflow.md
+++ b/organization/workflow.md
@@ -13,7 +13,7 @@ It has a much broader scope (the entire organization), but focuses its efforts o
 The goal of our organizational leadership workflow is to:
 
 - Align on the strategy for 2i2c and our major objectives for accomplishing that strategy.
-- Align on the higheset priorities in each functional area.
+- Align on the highest priorities in each functional area.
 - Share information across functional areas and integrate them into our planning and prioritization.
 - Oversee our daily workflow for creating strategy, policy, and structure for 2i2c as an organization.
 

--- a/organization/workflow.md
+++ b/organization/workflow.md
@@ -1,0 +1,42 @@
+(organization:workflow)=
+# Leadership workflow
+
+This section describes how our leadership team carries out its planning and day-to-day work.
+
+## Overview
+
+The "organization-wide" team is a bit different than most other 2i2c teams.
+It has a much broader scope (the entire organization), but focuses its efforts on major cross-functional items, or high-level priorities to track over time.
+
+## Goals
+
+The goal of our organizational leadership workflow is to:
+
+- Align on the strategy for 2i2c and our major objectives for accomplishing that strategy.
+- Align on the higheset priorities in each functional area.
+- Share information across functional areas and integrate them into our planning and prioritization.
+- Oversee our daily workflow for creating strategy, policy, and structure for 2i2c as an organization.
+
+## Meetings
+
+(organization:meeting-strategy)=
+### Content meeting - Organizational strategy
+
+Covers our high-level organizational mission, values, and principles, our high-level team systems and structure, as well as our near-term goals and objectives.
+
+It is led by the **`Executive Director`**.
+
+- **Date**: [every other Wednesday](https://calendar.google.com/calendar/embed?src=c_nq8hl7qsm484g1p7mfkm29jpo8%40group.calendar.google.com&ctz=America%2FLos_Angeles)
+- **Notes and Agenda**: [google doc](https://drive.google.com/open?id=1HoNX8T8IQ1uhS2ryi1r9iS-nSbPT1b1Y7HsjosbHme8&authuser=1&usp=meetingnotes&showmeetingnotespromo=true)
+
+## Backlog
+
+We have a backlog dedicated to tracking two kinds of information across the organization.
+They are split across two different views of the same GitHub Projects board:
+
+- [**Priorities in each functional area**](https://github.com/orgs/2i2c-org/projects/34/views/7) contains the most important priorities in each functional area.
+- [**Organizational deliverables and tasks**](https://github.com/orgs/2i2c-org/projects/34/views/8) contains all active work items for the organization. These are generally carried out by leadership at 2i2c. This is similar to the team backlogs used elsewhere in 2i2c.
+
+## Slack channels
+
+- [`#team-leads`](https://2i2c.slack.com/archives/C047H7W78M6): For quick and/or information conversation around organizational strategy and policy.


### PR DESCRIPTION
This adds documentation about how the organizational leadership team organizes itself. Here are the major changes:

- Adds documentation about our meetings, slack, and backlog
- Adds [a new backlog to track our organizational tasks and priorities](https://github.com/orgs/2i2c-org/projects/34/views/8). closes https://github.com/2i2c-org/team-compass/issues/540
- I've also gone through the Team Backlog and moved items to the organizational one that I thought were at an organization-level rather than focused in a functional area


