### PR TITLE
Document shared e-mail address and Google Workspace

### DIFF
--- a/administration/google-workspace.md
+++ b/administration/google-workspace.md
@@ -1,0 +1,20 @@
+# Google workspace
+
+We have a Google Workspace account that gives us `@2i2c.org` e-mail addresses with GMail, Google Drive, and a few other services as well.
+
+We access and configure our account via the [Google Workspaces admin panel at `workspace.google.com`](https://workspace.google.com/).
+
+To access it, click on `Admin Console`.
+
+## Access and permissions
+
+Any team lead should have administrative access to this space - if you don't then please request it and it will be granted.
+
+## Adding new members
+
+You may add new team members to our Google Workspace account via the `Admin Panel`.
+This will give them Google Drive access as well as an `@2i2c.org` account.
+However, **we pay monthly for every person-specific e-mail address**.
+
+As a rule of thumb, **any team members of 2i2c get a workspace account**.
+In addition, Steering Council members may get an account as well if they wish and if they intend to actively use it.

--- a/administration/index.md
+++ b/administration/index.md
@@ -7,4 +7,5 @@ This chapter contains administrative information at 2i2c.
 structure
 css
 reimburse
+google-workspace
 ```

--- a/organization/communication.md
+++ b/organization/communication.md
@@ -80,3 +80,4 @@ Creating groups is free and relatively easy, so if you wish to create a group fo
 
 :::{seealso}
 See [our Google Workspaces documentation](../administration/google-workspace.md) for more information.
+:::

--- a/organization/communication.md
+++ b/organization/communication.md
@@ -60,3 +60,23 @@ In addition, the Zoom account that is connected to this room is also available f
 The username for this account is `hello@2i2c.org` and you should ask a team member for the password if you wish to use it.
 
 For public-facing zoom meetings that are hosted with this account, create a zoom link that is unique to the meeting, rather than using the general team room.
+
+## Personal e-mail
+
+Each of 2i2c's team members has an `@2i2c.org` email account.
+We generally use e-mail to communicate _externally_.
+We use Slack, GitHub issues, and Zoom to communicate _internally_.
+However, if it's important communicate something to a team member that isn't suitable for a GitHub issue, and needs to be more permanent than Slack, then it's fine to send e-mails.
+
+(org:communication:shared-email)=
+## Shared e-mail and Google groups
+
+We also use some shared e-mail addresses via **Google Groups** to allow multiple people to check a single shared inbox.
+For example, our `hello@2i2c.org` e-mail is attached to a Google Group that many people may check for generic inbound communication.
+
+By joining the group behind one of these groups you'll be able to receive e-mail it receives, and you may also _send e-mail via this address_.
+
+Creating groups is free and relatively easy, so if you wish to create a group for your team or area, reach out to somebody that has administrative privileges.
+
+:::{seealso}
+See [our Google Workspaces documentation](../administration/google-workspace.md) for more information.

--- a/partnerships/communication.md
+++ b/partnerships/communication.md
@@ -1,0 +1,7 @@
+# Communication channels
+
+## Partnerships e-mail address
+
+We use a [shared e-mail inbox](org:communication:shared-email) called `partnerships@2i2c.org` to collect any inbound communication from those that wish to partner with 2i2c.
+
+It is attached to the `2i2c Partnerships` Google Group.

--- a/partnerships/inbox.md
+++ b/partnerships/inbox.md
@@ -1,0 +1,8 @@
+# Partnerships and sustainability
+
+Partnerships and sustainability oversees the strategy and system that 2i2c uses to sustain itself via partnerships with other communities.
+This includes partnerships via paid contracts, as well as via informal and formal collaboration.
+
+```{toctree}
+communication.md
+```


### PR DESCRIPTION
This adds some documentation describing our Google Workspace account as well as some of our shared e-mail addresses and google groups.

closes https://github.com/2i2c-org/team-compass/issues/129