### PR TITLE
Document Ramp and fix some engineering links

### DIFF
--- a/administration/reimburse.md
+++ b/administration/reimburse.md
@@ -6,7 +6,7 @@ Our fiscal sponsor, {term}`CS&S`, use [a service called Ramp](https://ramp.com/)
 If you'd like access to our Ramp account or need to use it, reach out to one of these people.
 
 (admin:credit-card)=
-## Ramp credit card
+## Our credit cards
 
 We have two Ramp credit cards: one that is designed specifically to reimburse cloud costs, and another that is for general purposes.
 This allows us to pay directly out of our organizational funds without requiring a team member to pay up-front.
@@ -48,3 +48,12 @@ For contractors, we also need to include the following language in your contract
 
 If you do not wish to make the payment yourself, we can make a payment with our [Ramp Credit Card](admin:credit-card).
 To do this, contact the [Executive Director](titles:exec-dir) or the [Partnerships Lead](titles:partnerships-lead).
+
+## How to approve transactions in Ramp
+
+Someone with **Administrator privileges** in [our Ramp account](https://app.ramp.com/business-overview) must approve any transactions that are made with Ramp.
+Here is the process that we follow for this:
+
+1. Go to [the Ramp inbox](https://app.ramp.com/inbox). This should list any items that need action from you or others.
+2. If it is empty, then there's nothing to do!
+3. If it has items for Review, click on each one and follow the prompts to include any important missing information.

--- a/engineering/access.md
+++ b/engineering/access.md
@@ -1,5 +1,5 @@
 (infrastructure:access)=
-# Cloud infrastructure location
+# Accounts and cloud access
 
 We run a variety of service and cloud infrastructure, and have many GitHub repositories and ongoing services dedicated to this.
 
@@ -7,9 +7,15 @@ We run a variety of service and cloud infrastructure, and have many GitHub repos
 
 You can find all of the information about our infrastructure and how to access it in [the `2i2c-org/infrastructure` repository](https://infrastructure.2i2c.org).
 
-## Who has access to infrastructure
+## Who has access to cloud infrastructure
 
 Our {term}`Engineering Team` has access to all of the cloud infrastructure that we run for each community.
 In addition, some other team members may be given access in order to facilitate supporting and engaging with communities.
 
-The list of 2i2c staff that have access to our infrastructure is here: {doc}`infra:topic/config`.
+The list of 2i2c staff that have access to our infrastructure is here: {external:infra:doc}`topic/access-creds/index`.
+
+## PagerDuty Account
+
+We have [a paid PagerDuty account at `2i2c-org.pagerduty.com`](https://2i2c-org.pagerduty.com/).
+This is used for our uptime monitoring and reporting services.
+See {external:infra:doc}`topic/monitoring-alerting/uptime-checks` for more details.

--- a/partnerships/communication.md
+++ b/partnerships/communication.md
@@ -1,7 +1,0 @@
-# Communication channels
-
-## Partnerships e-mail address
-
-We use a [shared e-mail inbox](org:communication:shared-email) called `partnerships@2i2c.org` to collect any inbound communication from those that wish to partner with 2i2c.
-
-It is attached to the `2i2c Partnerships` Google Group.

--- a/partnerships/inbox.md
+++ b/partnerships/inbox.md
@@ -1,8 +1,0 @@
-# Partnerships and sustainability
-
-Partnerships and sustainability oversees the strategy and system that 2i2c uses to sustain itself via partnerships with other communities.
-This includes partnerships via paid contracts, as well as via informal and formal collaboration.
-
-```{toctree}
-communication.md
-```


### PR DESCRIPTION
I double-checked that all of the right accounts are now being billed on Ramp.com, and ticked them off in https://github.com/2i2c-org/meta/issues/377. This PR documents Ramp a little bit more and fixes a few links.

- closes https://github.com/2i2c-org/meta/issues/377