### PR TITLE
Add strategy board links

### DIFF
--- a/organization/strategy.md
+++ b/organization/strategy.md
@@ -1,56 +1,22 @@
-# Strategy and goals
+# Strategy and objectives
 
-Our Strategic Plan is a combination of active and aspirational priorities that help us get closer to achieving our organizational mission. These are broken down into **strategic goals and objects for each**.
+This page describes 2i2c's overall organizational plan and most important objectives.
+Our Strategic Plan is a combination of active and aspirational priorities that help us get closer to achieving our organizational mission.
 
-Currently, 2i2c's Strategic Plan consists of a 1-year "bootstrap strategy".
-Our primary goal is to build a foundation for 2i2c and clarify out strategy and objectives for the coming years.
-This plan was created by the Founding Team of 2i2c [and is located here](https://docs.google.com/document/d/13uxWKWMMAdvM-knC5fMOj8tP_HQVvijIIE9jZgTItX4/edit?usp=sharing).
-This page is a summary and synthesis of the ideas in that document.
+{octicon}`calendar` Last updated: **`2022-11-08`**.
 
-The following objectives should be accomplished by **October of 2021**.
+## Strategic plan
 
-## Build a foundation for 2i2c's operations
+We are in the process of revamping our strategic plan, see the following issue to track our progress: https://github.com/2i2c-org/meta/issues/166 and see [this blog post](https://2i2c.org/blog/2022/strategic-update/) for some background on our current thinking.
 
-**Rationale:**
+(strategy:objectives)=
+## Strategic objectives
 
-2i2c needs an organizational home, structure, and governing body in order to begin exploring how it can best-accomplish its mission.
-It also needs resources that can fund people's time to begin work.
- 
-**Objectives:**
+Our strategic objectives are the most important things we must accomplish in order to execute on our strategic plan.
+These are broken down by the major functional areas of 2i2c, and stewarded by the leads of each area.
+We use a GitHub Project board to track these objectives, which can be found at the link below:
 
-- 2i2c has an organizational home that can sign contracts, hold liability, and administer our operations.
-- 2i2c has a governing body and rules for governance.
-- 2i2c has organizational funding for core staff for at least a year.
-- 2i2c has hired core staff for its first year of operations
-- 2i2c has organizational structure to handle both its engineering and the business operations.
-- 2i2c has a clearly-defined Mission, Vision, and Values.
-- 2i2c has a strategic plan for the next 1-3 years.
-
-## Launch the Managed JupyterHubs pilot
-
-**Rationale:**
-
-One of 2i2c's goals is to serve the research and education community through Managed Services that utilize infrastructure for interactive computing.
-It will take some exploration and learning to understand how to best-design these services.
-As a start, we wish to launch a **Managed JupyterHubs** service, and will begin with a pilot to explore this model.
- 
-**Objectives:**
-
-- 2i2c manages JupyterHubs for at least two institutions.
-- 2i2c manages more lightweight, community-specific JupyterHubs for several smaller groups in research and education.
-- 2i2c manages a "generic" JupyterHub that is not tied to any single institution or group.
-- 2i2c has a beta-level sustainability model for the first iteration of our Managed JupyterHub Service.
-- 2i2c has built relationships with cloud providers that facilitate our ability to serve these hubs to our users.
-
-## Launch major collaborations
-
-**Rationale:**
-
-2i2c wishes to conduct focused development in collaboration with others in research and education.
-We wish to engage in several major projects that will support infrastructure that aligns with our mission, and that also feeds into our Managed JupyterHub Service.
-
-**Objectives:**
-
-- 2i2c has launched a project around serving educational hub infrastructure to under-served educational institutions.
-- 2i2c has launched a project to provide infrastructure development and support for the earth sciences community.
-- 2i2c has made significant contributions across several open source communities that are related to the infrastructure it serves.
+```{button-link} https://github.com/orgs/2i2c-org/projects/34/views/7
+:color: primary
+Strategic Objectives
+```

--- a/organization/workflow.md
+++ b/organization/workflow.md
@@ -31,12 +31,17 @@ It is led by the **`Executive Director`**.
 
 ## Backlog
 
-We have a backlog dedicated to tracking two kinds of information across the organization.
-They are split across two different views of the same GitHub Projects board:
+We have to track efforts across the leaders of each functional area at 2i2c.
+This is similar to the team backlogs used elsewhere in 2i2c but focused at an organizaiton-wide level.
 
-- [**Priorities in each functional area**](https://github.com/orgs/2i2c-org/projects/34/views/7) contains the most important priorities in each functional area.
-- [**Organizational deliverables and tasks**](https://github.com/orgs/2i2c-org/projects/34/views/8) contains all active work items for the organization. These are generally carried out by leadership at 2i2c. This is similar to the team backlogs used elsewhere in 2i2c.
+```{button-link} https://github.com/orgs/2i2c-org/projects/34
+:color: primary
+
+Organizational backlog
+```
+
+We also track [our strategic objectives](strategy:objectives) in this board.
 
 ## Slack channels
 
-- [`#team-leads`](https://2i2c.slack.com/archives/C047H7W78M6): For quick and/or information conversation around organizational strategy and policy.
+[`#team-leads`](https://2i2c.slack.com/archives/C047H7W78M6): For quick and/or informational conversation around organizational strategy and policy.


### PR DESCRIPTION
This adds links to our strategic priorities view in the organizational backlog, and some explanation around it. It also (temporarily) removes the strategic plan that was listed there and provides links to our issue for updating it.

We will need to continue updating these docs as we flesh out our strategic plan, but this incorporates the discussion / decisions in the latest planning meeting.

- closes https://github.com/2i2c-org/team-compass/issues/553