### PR TITLE
Move strategy docs here from service

### DIFF
--- a/engineering/strategy.md
+++ b/engineering/strategy.md
@@ -1,0 +1,41 @@
+# Engineering strategy
+
+We make a few base assumptions about the kind of infrastructure we will focus on in this pilot.
+Here are several major components.
+
+### Where to deploy the infrastructure
+
+We'll focus our deployments on **major commercial cloud providers**.
+These are the most likely places for organizations to want to run cloud infrastructure, and are the most scalable and sustainable.
+In addition, getting Jupyter infrastructure to run well on all of the major cloud providers will have a large impact on a community's right to replicate.
+
+We'll focus on the following cloud providers:
+
+- Google Cloud
+- Amazon Web Services
+- Microsoft Azure
+
+In the short term, we favor deploying hubs on Google Cloud Platform.
+This is because GCP has the most stable Kubernetes offering of all of the cloud providers.
+We follow [team guidelines for when to deploy new Kubernetes clusters](infra:cluster:when-to-deploy).
+For new hubs that don't require their own Kubernetes cluster, we plan to run them on Google Cloud until our team has capacity to run more infrastructure across Azure and AWS.
+
+### Why Jupyter and JupyterHub?
+
+- The Jupyter ecosystem is a collection of building blocks that are highly customizable and composable. They are popular and useful for many use-cases, but still require expertise to customize for a particular need. This is well-suited for 2i2c's skillset and the kind of service it wishes to provide.
+- Jupyter is a community-led and multi-stakeholder ecosystem that aligns well with 2i2c's commitment to vendor-agnosticity and the [Right to Replicate](https://2i2c.org/right-to-replicate/).
+- JupyterHub allows you to access centralized infrastructure for a community, but in a way that gives that community a lot of control over the details. It is a good balance between "SaaS" and "Fully bespoke community infrastructure". JupyterHub can be deployed via a single repository, but is also deployable by individual people or communities, providing them a clear off-ramp.
+
+## Deployment and operations strategy
+
+Our goal is to provide a service that minimizes infrastructural complexity while providing JupyterHubs that can be used my Communities of Practice independently of one another.
+We wish to minimize the amount of engineering labor needed to develop and operate these deployments.
+Below are a few major aspects of the service that we believe provide a good chance of accomplishing these goals:
+
+- Deploy independent JupyterHubs from a centralized deployment system
+- Use Terraform to build Kubernetes clusters on cloud providers, and Kubernetes as a base to run the actual JupyterHub infrastructure.
+- JupyterHubs should be pre-configured for a use-case, but customizable by the community
+- JupyterHubs will respect the Community's [Right to Replicate](https://2i2c.org/right-to-replicate/)
+- JupyterHubs may be more bespoke than is sustainable provided we can learn from them.
+- JupyterHubs should be able to connect with external datasets and services, as the community needs.
+- JupyterHubs should be customizable by the communities they serve, ideally without intervention from a 2i2c Engineer.

--- a/organization/strategy.md
+++ b/organization/strategy.md
@@ -9,6 +9,24 @@ Our Strategic Plan is a combination of active and aspirational priorities that h
 
 We are in the process of revamping our strategic plan, see the following issue to track our progress: https://github.com/2i2c-org/meta/issues/166 and see [this blog post](https://2i2c.org/blog/2022/strategic-update/) for some background on our current thinking.
 
+(strategy:growth)=
+## Our growth strategy
+
+Growing this service will require balancing two aspects of our team:
+
+- Our **capacity** to serve a given number of communities at a certain complexity of use-case.
+- Our **commitments** to serve a specific set of communities.
+
+Because we are in a growth phase, we want our commitments to be near (or slightly above) our capacity.
+We can increase our capacity by making infrastructure and process improvements, or by growing our team.
+In the early phases of this pilot, we will focus on the former, and as our infrastructure and process is refined, we will consider the latter.
+In either case, we should choose a pricing model that gives us enough buffer to be able to hire new team members when the right time comes.
+
+To carry this out, we'll take on new communities in "batches" and define pricing models for each that at least cover [our estimated costs](../sustainability/costs/people.md).
+When we take on a new batch of communities, we should feel some tension as it challenges our process, support, and infrastructure in new ways.
+As we make process and infrastructure improvements, will self-assess whether our capacity has grown.
+If it has grown enough, we'll decide to bring on more communities.
+
 (strategy:objectives)=
 ## Strategic objectives
 

--- a/product/index.md
+++ b/product/index.md
@@ -6,4 +6,6 @@ They work alongside engineering teams to define ways in which we aim to improve 
 ```{toctree}
 structure.md
 workflow.md
+pricing/strategy
+pricing/cost-model
 ```

--- a/product/pricing/cost-model.md
+++ b/product/pricing/cost-model.md
@@ -1,0 +1,24 @@
+(costs:human)=
+# Staffing cost model
+
+This page is a short description of the costs that we cover with service fees in order to sustain our service.
+If you're interested in cloud costs (which we pass through directly to communities), see [](cloud.md).
+
+Our biggest cost is paying salaries for team members that carry out the services we provide.
+This includes cloud operations and development, open source support, guidance and support for our communities, etc.
+
+:::{seealso}
+You can find more about our compensation philosophy in our [compensation and benefits page](https://team-compass.2i2c.org/en/latest/hr/compensation.html).
+:::
+
+At present, we choose monthly hub fees based on assumptions about _how many hubs an engineer can operate and support_.
+We assume this is the primary bottleneck that limits our capacity.
+This gives us an "engineering cost per hub" and we use this as a base to estimate the extra fees we need to charge to cover the non-engineering roles that are needed for the service.
+
+- **Cost of a 2i2c engineer**. If we assume that a 2i2c engineer is paid `$140,000/year`, with a `30%` benefits markup. This covers the design, development, and ongoing operation of cloud infrastructure for 2i2c's hubs.
+- **Community support fees**. We add a `10%` markup to cover 2i2c's extra costs in providing ongoing support and community guidance for our hubs. This includes communications and guidance for community representatives as well as support for hub issues.
+- **Open source support fees**. We add a `10%` markup to cover 2i2c's extra costs in ongoing open source engagement and support. This includes upstreaming contributions to open source projects, community engagement and leadership, and collaboration and planning.
+- **Fiscal sponsor fees**. We add a `15%` markup to cover the fee of our fiscal sponsor, [Code for Science and Society](https://codeforscience.org/) (for see [](tc:structure:fiscal-sponsor) for information about the services that CS&S provides).
+
+The result is roughly `$250,000` annually for each engineering position.
+The fees for each hub are thus determined by dividing this annual cost by the estimated number of hubs of a given type that we can realistically support.

--- a/product/pricing/strategy.md
+++ b/product/pricing/strategy.md
@@ -1,0 +1,86 @@
+(product:pricing-strategy)=
+# Pricing strategy
+
+This page describes the rationale and strategy behind our pricing.
+
+```{list-table}
+:widths: auto
+:stub-columns: 1
+
+- - Last Updated
+  - 2022-05-06
+- - Next checkpoint
+  - 2022-08
+```
+
+## Guiding principles of our prices
+
+The following principles guide our decision-making around pricing our services.
+We believe that following these principles allows us to deliver the best services for our communities in a way that aligns with our mission and values.
+Our prices should:
+
+- Sustain and grow 2i2c's services and allow it to thrive as an organization.
+- Support the extra cost associated with open source contributions.
+- Reflect a holistic understanding of open source support, not just code.
+- Be competitive with other "Data Science environment as a service" offerings (see below for how we consider ourselves relative to similar offerings).
+- Be sustainable for the communities we serve, with mechanisms to accommodate institutions with fewer resources.
+
+
+## Pricing structure
+
+Currently, we base our pricing on two major items:
+
+### Flat monthly fees
+
+We charge a flat monthly fee to cover [our personnel costs](costs/people.md).
+We estimate the number of hubs an engineer can run, and use this to estimate our costs per hub after adding in project management and administration costs.
+
+Most hubs take extra effort during the _set up_ phase, and relatively less effort to maintain over time (depending on how many change requests a community makes).
+As such we suspect that this pricing structure does not cover our costs in the first month or two, but regains those costs in subsequent months.
+
+In the future we may try to perform a more nuanced mapping of costs onto effort from our team, but for now we wish to keep things simple and predictable while we learn more.
+
+### Pass-through cloud costs
+
+In addition to our monthly hub fees, we pass cloud costs [directly to the communities we serve](costs/cloud.md), without taking any percentage markup.
+We do this for two reasons:
+
+1. In our eyes, we are running infrastructure _on behalf of each community_, and wish to act as if a member of that community were running the infrastructure themselves. We are simply being compensated for our time and expertise.
+2. Adding a percentage markup on cloud costs may create perverse incentives for us to avoid optimizing down a community's cloud costs.
+
+For these reasons, we are currently [passing through cloud costs directly to communities](costs/cloud.md).
+
+## Base fees for three service types
+
+These are based on major use-cases in the communities we have served.
+
+- **Educational communities** need basic hubs that are reliable, secure, and that serve a community of users. They tend to charge course fees and can recoup some costs this way. Assume 22 educational hubs per engineer.
+- **Research communities** need a bit more power and complexity, and potentially access to more cloud infrastructure and data. They tend to have grant funding for fixed periods of time that is enough to cover an internal FTE. Assume 13 research hubs per engineer.
+- **Partnerships** happen with more advanced / well-resourced communities that want more bespoke infrastructure and new development, and we want a service option that allows for this flexibility. It takes significant extra effort to define and carry out these more complex relationships, and we should only engage in them if they cover a larger percentage of our costs. We'll use a lower-bound of 20% FTE per engineer for these engagements (ie, at-most 5 partnership-level engagements per engineer), though we suspect most will require more FTE time than this.
+
+Below is a table which summarizes these major points
+
+% Generated with https://www.tablesgenerator.com/markdown_tables
+
+| Type of service | Annual cost / engineer | % Eng. FTE | N Hubs / Eng. | Monthly fee | Annual fee total |
+|:---------------:|:----------------------:|:----------:|:-------------:|:-----------:|:----------------:|
+|    Education    |       $250,000.00      |    4-5%    |       22      |  $1,000.00  |    $12,000.00    |
+|     Research    |       $250,000.00      |    7-8%    |       14      |  $1,500.00  |    $18,000.00    |
+|   Partnership   |       $250,000.00      |    >=20%   |      <=5      | >=$4,166.67 |   >=$50,000.00   |
+
+### Markup for running on dedicated clusters
+
+In general we want our fees to scale with the amount of complexity that we have to manage. If we run JupyterHubs on community-specific cloud infrastructure, we have more responsibility and moving parts to keep track of. For example, we’ll need to manage credentials for cloud accounts, set up infrastructure that connects with those accounts, and manage a dedicated kubernetes cluster for the community. We’ll also need to provide billing reports per-cluster for cloud costs. All of this is extra complexity we must deal with, and so a 50% markup is a conservative estimate to cover this labor.
+
+## What we are missing
+
+We know that there are some communities that will not be well-served by the options described above. Our goal during the alpha is to build sustainability in order to meet these communities in the future. If the model described above doesn’t fit your needs well (e.g., wrong kind of service, too expensive, etc) please provide feedback, as this can help us evolve the service over time.
+
+Below are a few things that we know we are missing:
+
+- **Under-resourced communities**. For many communities, $12,000 a year is too much cost to justify. Our mission requires that we serve these communities as well, not just the ones with larger budgets. This proposal is a step towards sustainability, with the goal of developing new models that can serve under-resourced organizations as well. A few ideas to explore are sponsorship models, tiered pricing models that adjust price based on a community’s budget size, and reducing our internal costs (and thus the fees for our services).
+- **Lightweight hubs**. For many individuals or communities, these offerings might involve more complexity than what they need. We’d like to offer a much more scalable and lightweight hub service that people could quickly spin up. We hope to prototype and experiment with ideas after the initial roll-out of the alpha service.
+- **Communities that need multiple hubs**. For organizations with many sub-communities and complexity, a single hub is likely not enough to meet their needs. These communities may be better-served by their own dedicated federation of hubs, with a different pricing / growth model than the offerings described here. For now we’ll treat these as partnership opportunities, but may wish to standardize this in a service offering in the future.
+- **Significant differences in community size**. Our pricing model assumes that most communities have a relatively similar degree of complexity and size between them. However, when communities grow to a certain size (say, two orders of magnitude), it generates additional work in supporting users and hub operations. We hope to better-understand the costs associated with serving these larger communities, and identify ways to recover them via our pricing.
+- **Cloud payments as a service**. In some cases we manage the billing infrastructure and payments for communities (as opposed to them paying cloud providers directly). We do not currently charge explicitly for performing this service. In this case we take on extra work and complexity in tracking and paying cloud bills. We should estimate how much work and risk/liability is entailed in this, and work with our fiscal sponsor to understand how to cover these costs.
+- **Liability for cloud payments**. For communities where we manage their cloud billing, we hold some liability because we’ll need to pay the cloud provider for their usage before they pay us. We should work with our fiscal sponsor to understand our risk here (for example, what if a community charges $50,000 in cloud costs and then refuses to pay their invoice). We should also explore potential ways to mitigate this risk (for example, pre-billing communities for *estimated* cloud usage to create a buffer, or asking for a deposit.


### PR DESCRIPTION
This moves several strategy / planning documents into the Team Compass, as they used to be in docs.2i2c.org, and this made it hard to keep track of them. We can decide to re-delegate/move these elsewhere in the future, but for now I think we should keep them in the TC since it is easier to spot as a source of truth.

### References

- Sibling to https://github.com/2i2c-org/docs/pull/174