### PR TITLE
Add "end of year" time off policy

### DIFF
--- a/community/freshdesk.md
+++ b/community/freshdesk.md
@@ -1,0 +1,18 @@
+# Using FreshDesk
+
+We [use FreshDesk](support:freshdesk) as part of our support processes.
+This service has its own functionality and quirks, and this page is a place to document some common actions we must take.
+
+(freshdesk:footer)=
+## Add a footer to all replies
+
+Sometimes it is useful to auto-add a footer to all support ticket responses.
+This will come pre-populated in our response, and we can then add more text as we wish.
+This is useful for things like [notifying communities about expected downtime](time-off:annual-expected).
+
+[Here's the FreshDesk page on adding a footer](https://support.freshdesk.com/en/support/solutions/articles/196889-i-want-to-insert-a-footer-into-all-my-replies-how-do-i-do-this-).
+And a quick summary:
+
+1. Go to `Admin` > `Workflows` > `Email Notifications`.
+2. Click on the `Templates` tab > `Agent Reply Template`.
+3. Edit the form in order to add the text you'd like.

--- a/community/index.md
+++ b/community/index.md
@@ -11,4 +11,5 @@ See [this blog post](https://2i2c.org/blog/2022/job-product-community-lead/) for
 ```{toctree}
 structure
 workflow
+freshdesk
 ```

--- a/engineering/access.md
+++ b/engineering/access.md
@@ -9,13 +9,13 @@ You can find all of the information about our infrastructure and how to access i
 
 ## Who has access to cloud infrastructure
 
-Our {term}`Engineering Team` has access to all of the cloud infrastructure that we run for each community.
+Our [Engineering Team](engineering:structure) has access to all of the cloud infrastructure that we run for each community.
 In addition, some other team members may be given access in order to facilitate supporting and engaging with communities.
 
-The list of 2i2c staff that have access to our infrastructure is here: {external:infra:doc}`topic/access-creds/index`.
+The list of 2i2c staff that have access to our infrastructure is here: {external+infra:doc}`topic/access-creds/index`.
 
 ## PagerDuty Account
 
 We have [a paid PagerDuty account at `2i2c-org.pagerduty.com`](https://2i2c-org.pagerduty.com/).
 This is used for our uptime monitoring and reporting services.
-See {external:infra:doc}`topic/monitoring-alerting/uptime-checks` for more details.
+See {external+infra:doc}`topic/monitoring-alerting/uptime-checks` for more details.

--- a/engineering/structure.md
+++ b/engineering/structure.md
@@ -1,3 +1,4 @@
+(engineering:structure)=
 # Structure and responsibilities
 
 This page describes the structure and roles of our Engineering team.

--- a/people/time-off.md
+++ b/people/time-off.md
@@ -57,11 +57,7 @@ Team members can use this time as they wish (including continuing to work), but 
 Here is our policy during this time:
 
 - All team meetings are cancelled during this time.
-- We monitor our support e-mail for major incidents, but do not guarantee a response for non-essential requests or questions.
-- If there is an incident, we will take steps to minimize damage and harm, and will plan time _after this period_ to resolve underlying problems.
-- We do not perform any non-essential cloud changes for communities.
-
-See [](support:expected-time-off) for our support changes during this time.
+- [](support:expected-time-off:policy) for our support policy during this time.
 
 ## Unknowns to resolve
 

--- a/people/time-off.md
+++ b/people/time-off.md
@@ -45,7 +45,7 @@ In this case, our guidelines around letting others know ahead of time are somewh
 Just do the best you can, and try to balance your own constraints with respect for the team’s bandwidth and planning.
 
 (time-off:annual-expected)=
-## End-of-year expected time off
+## Expected end-of-year time off
 
 The **final 14 days and the first 3 days of the year are "expected time off" for all of 2i2c**.
 

--- a/people/time-off.md
+++ b/people/time-off.md
@@ -47,7 +47,7 @@ Just do the best you can, and try to balance your own constraints with respect f
 (time-off:annual-expected)=
 ## End-of-year expected time off
 
-The **final 14 days of the year are "expected time off" for all of 2i2c**.
+The **final 14 days and the first 3 days of the year are "expected time off" for all of 2i2c**.
 
 During this time our organization operates at a reduced capacity and with greatly diminished commitments to our {external+docs:ref}`service level objectives <objectives:stability>`.
 
@@ -58,8 +58,8 @@ Here is our policy during this time:
 
 - All team meetings are cancelled during this time.
 - We monitor our support e-mail for major incidents, but do not guarantee a response for non-essential requests or questions.
-- We do not perform any non-essential cloud changes for communities.
 - If there is an incident, we will take steps to minimize damage and harm, and will plan time _after this period_ to resolve underlying problems.
+- We do not perform any non-essential cloud changes for communities.
 
 See [](support:expected-time-off) for our support changes during this time.
 

--- a/people/time-off.md
+++ b/people/time-off.md
@@ -44,6 +44,25 @@ Follow the process described above in this case - you are welcome to describe yo
 In this case, our guidelines around letting others know ahead of time are somewhat relaxed, as sick leave may happen unexpectedly.
 Just do the best you can, and try to balance your own constraints with respect for the team’s bandwidth and planning.
 
+(time-off:annual-expected)=
+## End-of-year expected time off
+
+The **final 14 days of the year are "expected time off" for all of 2i2c**.
+
+During this time our organization operates at a reduced capacity and with greatly diminished commitments to our {external+docs:ref}`service level objectives <objectives:stability>`.
+
+Our support and operational roles are still staffed, but with greatly reduced expectations around responsiveness and resolution.
+Team members can use this time as they wish (including continuing to work), but we wish to set the _expectation_ with internal and external partners that we will be less responsive.
+
+Here is our policy during this time:
+
+- All team meetings are cancelled during this time.
+- We monitor our support e-mail for major incidents, but do not guarantee a response for non-essential requests or questions.
+- We do not perform any non-essential cloud changes for communities.
+- If there is an incident, we will take steps to minimize damage and harm, and will plan time _after this period_ to resolve underlying problems.
+
+See [](support:expected-time-off) for our support changes during this time.
+
 ## Unknowns to resolve
 
 - This process is likely too informal if our team significantly scales in size and complexity.

--- a/people/titles.md
+++ b/people/titles.md
@@ -1,4 +1,4 @@
-# Job Titles
+# Job titles
 
 This describes the structure of our jobs across each group in the organization. They are inspired by the hiring/salary structure of several tech companies[^job-refs].
 

--- a/projects/managed-hubs/support.md
+++ b/projects/managed-hubs/support.md
@@ -247,6 +247,8 @@ Below is our policy for support during expected time off:
   % NOTE: In the future we may define a policy for support if a community knows and
   %   tells us they are doing essential work during expected time off.
   %   We can update this policy when we discuss and make a decision on this.
+  %
+  %   Some conversation in: https://github.com/2i2c-org/meta/issues/435
 - We will take steps to minimize harm and avoid catastrophic problems (e.g. incidents that drastically increase costs), but will not perform non-essential actions. We will assume there is _no essential work happening on any of our hubs for all communities_.
 - If there is a catastrophic incident, we will take the minimal number of actions to reduce risk and damage to a reasonable level.
 - For non-catastrophic incidents and general change requests, we will wait until _after this period_ to resolve them.

--- a/projects/managed-hubs/support.md
+++ b/projects/managed-hubs/support.md
@@ -239,12 +239,15 @@ There are some cases when we intentionally reduce our operations and support cap
 See [](time-off:annual-expected) for our broader policies and support commitments during this time.
 
 (support:expected-time-off:policy)=
-### Expected time off policy
+### Expected time off support policy
 
 Below is our policy for support during expected time off:
 
 - We monitor our support e-mail for major incidents, but do not guarantee a response for non-essential requests or questions.
-- We will take steps to minimize harm and avoid catastrophic problems (e.g. incidents that drastically increase costs), but will not perform non-essential actions. We will not treat "a general outage" as catastrophic unless we get an explicit signal in advance from a community representative they are doing essential work during this time.
+  % NOTE: In the future we may define a policy for support if a community knows and
+  %   tells us they are doing essential work during expected time off.
+  %   We can update this policy when we discuss and make a decision on this.
+- We will take steps to minimize harm and avoid catastrophic problems (e.g. incidents that drastically increase costs), but will not perform non-essential actions. We will assume there is _no essential work happening on any of our hubs for all communities_.
 - If there is a catastrophic incident, we will take the minimal number of actions to reduce risk and damage to a reasonable level.
 - For non-catastrophic incidents and general change requests, we will wait until _after this period_ to resolve them.
 

--- a/projects/managed-hubs/support.md
+++ b/projects/managed-hubs/support.md
@@ -254,11 +254,13 @@ Here are the steps we take to set expectations for our team and for other organi
   > We will provide operational support for significant cloud incidents and outages, but not for non-essential questions or change requests.
   > We will be less responsive than normal, and will return to answer your questions and resolve issues after the time off.
 
-% TODO: In the future, we want to add an extra step:
+% TODO: In the future, we want to add two extra steps:
 %
-% Send an e-mail to our mailing list for Community Representatives communicating our intent to be on expected reduced capacity.
-% 
-% See issue: https://github.com/2i2c-org/team-compass/issues/579
+% 1. Send an e-mail to our mailing list for Community Representatives communicating our intent to be on expected reduced capacity.
+%    ref: https://github.com/2i2c-org/team-compass/issues/579
+%
+% 2. Add a banner announcement to each of our community hubs.
+%    ref: https://github.com/2i2c-org/infrastructure/issues/1501
 
 ### Rotating team members during expected time off
 

--- a/projects/managed-hubs/support.md
+++ b/projects/managed-hubs/support.md
@@ -231,3 +231,35 @@ Support Budget
 
   :::
 ```
+
+(support:expected-time-off)=
+## Support during expected time off
+
+There are some cases when we intentionally reduce our operations and support capacity.
+See [](time-off:annual-expected) for our broader policies and support commitments during this time.
+
+### Support process during expected time off
+
+Here are the steps we take to set expectations for our team and for other organizations during expected time off:
+
+- **One month before the start of time off**. Add footer content to our `support@2i2c.org` and `hello@2i2c.org` responses that communicates our intent.
+  For example:
+
+  > **Note:** the 2i2c team will have **expected reduced capacity** from `STARTDATE` to `ENDDATE`.
+  > During this time, we will provide operational support for significant cloud incidents and outages, but not for non-essential questions or change requests.
+  > We will be less responsive than normal, and will return to answer your questions and resolve issues after the time off.
+- **During the time off**. Add an auto-responder to our FreshDesk accounts with a message like the following:
+
+  > **Note:** the 2i2c team is operating at an **expected reduced capacity** until `ENDDATE`.
+  > We will provide operational support for significant cloud incidents and outages, but not for non-essential questions or change requests.
+  > We will be less responsive than normal, and will return to answer your questions and resolve issues after the time off.
+
+% TODO: In the future, we want to add an extra step:
+%
+% Send an e-mail to our mailing list for Community Representatives communicating our intent to be on expected reduced capacity.
+% 
+% See issue: https://github.com/2i2c-org/team-compass/issues/579
+
+### Rotating team members during expected time off
+
+Because team members continue to serve as support stewards during this time, we should take care to avoid the same person serving in this role across multiple periods of expected time off.

--- a/projects/managed-hubs/support.md
+++ b/projects/managed-hubs/support.md
@@ -243,7 +243,9 @@ See [](time-off:annual-expected) for our broader policies and support commitment
 Here are the steps we take to set expectations for our team and for other organizations during expected time off:
 
 - **One month before the start of time off**. Add footer content to our `support@2i2c.org` and `hello@2i2c.org` responses that communicates our intent.
-  For example:
+  See [](freshdesk:footer) for instructions on doing this.
+
+  Example text:
 
   > **Note:** the 2i2c team will have **expected reduced capacity** from `STARTDATE` to `ENDDATE`.
   > During this time, we will provide operational support for significant cloud incidents and outages, but not for non-essential questions or change requests.

--- a/projects/managed-hubs/support.md
+++ b/projects/managed-hubs/support.md
@@ -233,10 +233,20 @@ Support Budget
 ```
 
 (support:expected-time-off)=
-## Support during expected time off
+## Expected time off and downtime
 
 There are some cases when we intentionally reduce our operations and support capacity.
 See [](time-off:annual-expected) for our broader policies and support commitments during this time.
+
+(support:expected-time-off:policy)=
+### Expected time off policy
+
+Below is our policy for support during expected time off:
+
+- We monitor our support e-mail for major incidents, but do not guarantee a response for non-essential requests or questions.
+- We will take steps to minimize harm and avoid catastrophic problems (e.g. incidents that drastically increase costs), but will not perform non-essential actions. We will not treat "a general outage" as catastrophic unless we get an explicit signal in advance from a community representative they are doing essential work during this time.
+- If there is a catastrophic incident, we will take the minimal number of actions to reduce risk and damage to a reasonable level.
+- For non-catastrophic incidents and general change requests, we will wait until _after this period_ to resolve them.
 
 ### Support process during expected time off
 

--- a/reference/calendar.md
+++ b/reference/calendar.md
@@ -1,5 +1,5 @@
 (team/calendar)=
-# Team Calendars
+# Calendars
 
 ## 2i2c Events
 

--- a/reference/terminology.md
+++ b/reference/terminology.md
@@ -1,4 +1,4 @@
-# Important Terminology
+# Important terminology
 
 Here are some helpful terms that we use at 2i2c.
 


### PR DESCRIPTION
This refines some of our time off policies around the "expected downtime" at the end of the year. It tries to focus this around setting expectations rather than forcing people to take one action or another. 

Some notes from our conversation about this in the team strategy meeting are here: https://docs.google.com/document/d/1HoNX8T8IQ1uhS2ryi1r9iS-nSbPT1b1Y7HsjosbHme8/edit#heading=h.24ru6ob0hmvh
