### PR TITLE
Add airtable information

### DIFF
--- a/administration/airtable.md
+++ b/administration/airtable.md
@@ -1,0 +1,32 @@
+# AirTable accounts
+
+We use AirTable to track some of our leads, contracts, and invoicing data.
+This page covers this account and how to access it.
+
+[Here's a link to our primary AirTable workspace](https://airtable.com/appbjBTRIbgRiElkr).
+In addition, there are several bases within this workspace that are described below.
+
+## Log in to our shared account
+
+We have a single account on the "Pro" plan of AirTable.
+You can access the account with the username and password.
+Here's how to do so:
+
+1. **Ask a team member for the password**. If you'd like access, ask around the team to see who has the password and they can share it with you.
+   % TODO: In the future we need a more structured way to share access.
+   %   eventually, we'll need to pay for more than one account.
+2. **Log in to the account**. Once you do so, you'll have access to the **AirTable bases** under this workspace.
+
+## Base: Invoicing data from CS&S
+
+Our [`Invoices` base](https://airtable.com/appbjBTRIbgRiElkr/tblkmferOITqS2vH8/viwfuamzW4kbaQSSJ) has a record of **every invoice that CS&S has for 2i2c**.
+This includes anticipated future invoices and grants.
+
+See **the Base Guide** for more information by clicking on the ℹ️ button.
+
+## Base: Contracts data from CS&S
+
+Our [`Contracts` base](https://airtable.com/appbjBTRIbgRiElkr/tbliwB70vYg3hlkb1/viwWPJhcFbXUJZUO6) has a record of **every contract that CS&S has for 2i2c**.
+Each invoice should be attached to a contract.
+
+See **the Base Guide** for more information by clicking on the ℹ️ button.

--- a/administration/index.md
+++ b/administration/index.md
@@ -8,4 +8,5 @@ structure
 css
 reimburse
 google-workspace
+airtable
 ```


### PR DESCRIPTION
I've **upgraded our AirTable plan to the pro plan**. This will let us synchronize multiple airtables with the data that CS&S has provided, which we need for tracking invoices and contracts.

As a result, I've created a single shared AirTable account at `admin@2i2c.org`, and a password that I can share privately with anybody. We can work out a longer-term solution once we get a feel for it.

To begin, I've shared the password with @jmunroe but please let me know if you'd like access.