### PR TITLE
Document our GitHub accounts

### DIFF
--- a/administration/github.md
+++ b/administration/github.md
@@ -7,20 +7,19 @@ We have a **GitHub Team Organization** that is free due to our non-profit status
 
 We may need to re-apply for membership for this each year.
 
-## Internal teams
+## Teams
 
-[The `2i2c Team` team](https://github.com/orgs/2i2c-org/teams/2i2c-team) (`@2i2c-team`) is for every staff, steering council, and key collaborator of 2i2c.
-It should provide access to all private 2i2c repositories.
+- [**`@2i2c-team`**](https://github.com/orgs/2i2c-org/teams/2i2c-team).
+  For every staff member and key collaborator of 2i2c.
+  It should provide access to all private 2i2c repositories.
 
-In addition, there are several sub-teams underneath `2i2c Team`, grouped by topic area.
-Team members are added to one of these teams, and inherit `2i2c Team` status from this.
+  In addition, there are several sub-teams underneath `2i2c Team`, grouped by topic area.
+  Team members are added to one of these teams, and inherit `2i2c Team` status from this.
+- [**`@collaborators`**](https://github.com/orgs/2i2c-org/teams/collaborators).
+  For external collaborators that we would like to officially list in a team.
+  For example, if we want to quickly `@mention` a group of people or control fine-grained permissions of repositories.
 
-## External teams
-
-[The `Collaborators` team](https://github.com/orgs/2i2c-org/teams/collaborators) is for **external collaborators** that we would like to officially list in a team.
-For example, this is helpful if we want to quickly `@mention` a group of people or control fine-grained permissions of repositories.
-
-This team does not come with any special repository permissions on its own.
+  This team does not come with any special repository permissions on its own.
 
 ## Administrator access
 

--- a/administration/github.md
+++ b/administration/github.md
@@ -7,17 +7,9 @@ We have a **GitHub Team Organization** that is free due to our non-profit status
 
 We may need to re-apply for membership for this each year.
 
-## Administrator access
-
-Some individuals have `administrator access` to our GitHub organization.
-This allows them full control over the organization and its settings (including destructive actions).
-
-We currently do not have a policy for who has administrator access, so ask around if you believe that you need it.
-We will define a policy for access in the future.
-
 ## Internal teams
 
-[The `2i2c Team` team](https://github.com/orgs/2i2c-org/teams/2i2c-team) is for every staff, steering council, and key collaborator of 2i2c.
+[The `2i2c Team` team](https://github.com/orgs/2i2c-org/teams/2i2c-team) (`@2i2c-team`) is for every staff, steering council, and key collaborator of 2i2c.
 It should provide access to all private 2i2c repositories.
 
 In addition, there are several sub-teams underneath `2i2c Team`, grouped by topic area.
@@ -29,3 +21,18 @@ Team members are added to one of these teams, and inherit `2i2c Team` status fro
 For example, this is helpful if we want to quickly `@mention` a group of people or control fine-grained permissions of repositories.
 
 This team does not come with any special repository permissions on its own.
+
+## Administrator access
+
+Some individuals have `administrator access` to our GitHub organization.
+This allows them full control over the organization and its settings (including destructive actions).
+
+We currently do not have a policy for who has administrator access, so ask around if you believe that you need it.
+We will define a policy for access in the future.
+
+## Repository access
+
+Members of `@2i2c-team` have access to all 2i2c repositories, including private repositories.
+For non-members of this team, access is granted on a repository-by-repository basis.
+
+We do not have a policy for who may access repositories, so use your best judgment.

--- a/administration/github.md
+++ b/administration/github.md
@@ -1,0 +1,31 @@
+# GitHub organization
+
+## Organization plan
+
+We have a **GitHub Team Organization** that is free due to our non-profit status.
+[Here's a list of features in GitHub Team status](https://docs.github.com/en/free-pro-team@latest/github/getting-started-with-github/githubs-products#github-team).
+
+We may need to re-apply for membership for this each year.
+
+## Administrator access
+
+Some individuals have `administrator access` to our GitHub organization.
+This allows them full control over the organization and its settings (including destructive actions).
+
+We currently do not have a policy for who has administrator access, so ask around if you believe that you need it.
+We will define a policy for access in the future.
+
+## Internal teams
+
+[The `2i2c Team` team](https://github.com/orgs/2i2c-org/teams/2i2c-team) is for every staff, steering council, and key collaborator of 2i2c.
+It should provide access to all private 2i2c repositories.
+
+In addition, there are several sub-teams underneath `2i2c Team`, grouped by topic area.
+Team members are added to one of these teams, and inherit `2i2c Team` status from this.
+
+## External teams
+
+[The `Collaborators` team](https://github.com/orgs/2i2c-org/teams/collaborators) is for **external collaborators** that we would like to officially list in a team.
+For example, this is helpful if we want to quickly `@mention` a group of people or control fine-grained permissions of repositories.
+
+This team does not come with any special repository permissions on its own.

--- a/administration/index.md
+++ b/administration/index.md
@@ -8,6 +8,7 @@ structure
 css
 reimburse
 google-workspace
+github
 airtable
 zoom
 ```

--- a/noxfile.py
+++ b/noxfile.py
@@ -7,8 +7,7 @@ build_command = ["-b", "html", ".", "_build/html"]
 
 @nox.session
 def docs(session):
-    """Build the documentation. Use `-- live` to build documentation with a
-    live server to preview changes."""
+    """Build the documentation. Use `-- live` for a live server to preview changes."""
     session.install("-r", "requirements.txt")
     if "live" in session.posargs:
         session.posargs.pop(session.posargs.index("live"))

--- a/noxfile.py
+++ b/noxfile.py
@@ -7,23 +7,21 @@ build_command = ["-b", "html", ".", "_build/html"]
 
 @nox.session
 def docs(session):
+    """Build the documentation. Use `-- live` to build documentation with a
+    live server to preview changes."""
     session.install("-r", "requirements.txt")
-    cmd = ["sphinx-build"]
-    cmd.extend(build_command + session.posargs)
-    session.run(*cmd)
-
-
-@nox.session(name="docs-live")
-def docs_live(session):
-    session.install("-r", "requirements.txt")
-
-    AUTOBUILD_IGNORE = [
-        "_build",
-        "build_assets",
-        "tmp",
-    ]
-    cmd = ["sphinx-autobuild"]
-    for folder in AUTOBUILD_IGNORE:
-        cmd.extend(["--ignore", f"*/{folder}/*"])
+    if "live" in session.posargs:
+        session.posargs.pop(session.posargs.index("live"))
+        session.install("sphinx-autobuild")
+        AUTOBUILD_IGNORE = [
+            "_build",
+            "build_assets",
+            "tmp",
+        ]
+        cmd = ["sphinx-autobuild"]
+        for folder in AUTOBUILD_IGNORE:
+            cmd.extend(["--ignore", f"*/{folder}/*"])
+    else:
+        cmd = ["sphinx-build"]
     cmd.extend(build_command + session.posargs)
     session.run(*cmd)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ myst-parser[linkify]
 myst-nb
 pandas
 sphinx
-sphinx-autobuild
 git+https://github.com/2i2c-org/sphinx-2i2c-theme
 sphinx-copybutton
 sphinx-design


### PR DESCRIPTION
This adds documentation about our GitHub plan, access policy, and teams.

- closes https://github.com/2i2c-org/meta/issues/417