### PR TITLE
Add rediraffe and add a redirect for restructured get-started section

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,9 +13,6 @@ build:
 sphinx:
   configuration: conf.py
 
-# Explicitly opt out of trying to build additional formats such as PDF and ePub
-formats: []
-
 python:
   install:
     - requirements: requirements.txt

--- a/conf.py
+++ b/conf.py
@@ -18,6 +18,7 @@ extensions = [
     "sphinx_copybutton",
     "sphinx.ext.intersphinx",
     "sphinx_togglebutton",
+    "sphinxext.rediraffe",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -85,3 +86,14 @@ def setup(app):
     # And then document it like: {role}`Some new role name` to generate a link.
     # ref: https://www.sphinx-doc.org/en/master/extdev/appapi.html#sphinx.application.Sphinx.add_crossref_type
     app.add_crossref_type("role", "role")
+
+
+# -- Options for the rediraffe extension -------------------------------------
+# ref: https://github.com/wpilibsuite/sphinxext-rediraffe#readme
+#
+# This extensions help us relocated content without breaking links. If a
+# document is moved internally, put its path as a dictionary key in the
+# redirects dictionary below and its new location in the value.
+#
+rediraffe_branch = "main"
+rediraffe_redirects = {}

--- a/conf.py
+++ b/conf.py
@@ -96,4 +96,6 @@ def setup(app):
 # redirects dictionary below and its new location in the value.
 #
 rediraffe_branch = "main"
-rediraffe_redirects = {}
+rediraffe_redirects = {
+    "get-started": "operations/index",
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ git+https://github.com/2i2c-org/sphinx-2i2c-theme
 sphinx-copybutton
 sphinx-design
 sphinx-togglebutton
+sphinxext-rediraffe


### PR DESCRIPTION
The onboarding issue linked to a path that gave me 404 (get-started). That section is now contained under parts of team operations so I'm redirecting to the team operations index.

![redirect](https://user-images.githubusercontent.com/3837114/210207283-c8ce81bf-1d90-4063-92a8-9ff508226bfa.gif)
