### PR TITLE
Update the onboarding instructions

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-team-member.md
+++ b/.github/ISSUE_TEMPLATE/new-team-member.md
@@ -36,6 +36,9 @@ Follow the checklist below to onboard a new team member!
 - [ ] Grant appropriate permissions on [RTD projects](https://readthedocs.org/)
 - [ ] NameCheap administration privileges to `2i2c.org` and `2i2c.cloud`
 
+**Roles**
+- [ ] Onboard into the [Support Steward Role](https://github.com/2i2c-org/team-compass/issues/new?assignees=&labels=type%3A+onboard&template=new-team-member.md&title=Onboarding+%3Cname%3E)
+
 **External**
 
 - [ ] Add to [2i2c website](https://2i2c.org/about/)

--- a/.github/ISSUE_TEMPLATE/new-team-member.md
+++ b/.github/ISSUE_TEMPLATE/new-team-member.md
@@ -22,7 +22,7 @@ Follow the checklist below to onboard a new team member!
 **Communication**
 
 - [ ] Send them a link to the [2i2c Team Compass](https://team-compass.2i2c.org/en/latest/) and its [Team Operations section](https://team-compass.2i2c.org/en/latest/operations/index.html)
-- [ ] Send them a link to the [2i2c Google Drive](https://drive.google.com/drive/folders/1ABxxSFycGfCzQc9czfwer_dat-GVi4jw?usp=sharing)
+- [ ] Send them a link to the [2i2c Team Google Drive](https://drive.google.com/drive/u/1/folders/0AJcabtB-T0LnUk9PVA)
 - [ ] Schedule an onboarding meeting for after they've read through the docs
 
 **Permissions**


### PR DESCRIPTION
Following @consideRatio's feedback in https://github.com/2i2c-org/team-compass/issues/595, this updates the onboarding instructions with one more step and updates the link to the shared 2i2c Google Drive