### PR TITLE
Add a communication overview section

### DIFF
--- a/communication/blog.md
+++ b/communication/blog.md
@@ -3,24 +3,6 @@
 Our most common form of communication is via [the blog at 2i2c.org/blog](https://2i2c.org/blog).
 It is managed by our [Hugo website repository](https://github.com/2i2c-org/2i2c-org.github.io).
 
-## Checklist
-
-Here's a blog-post checklist to help us keep track of the major actions needed to publish a new post.
-Open an issue about your post and copy/paste this checklist into it.
-
-```
-- [ ] Write draft of blog post in markdown
-- [ ] Open a PR to the 2i2c.github.io repository and ask for feedback
-- [ ] Publish the post
-- [ ] Send out a series of tweets from the `2i2c_org` account that summarizes the post.
-- [ ] Tell the team about it and re-tweet!
-- [ ] Decide if this post is worthy for a mailing list update
-- [ ] If so, go to mailchimp.com and create a new email campain
-- [ ] Copy the post's content, paste it into the mailchimp interface
-- [ ] Send off the mailchimp campain
-- [ ] You're done! 🎉
-```
-
 (blog:topics)=
 ## What to post on the blog
 
@@ -41,3 +23,22 @@ Here are a few ideas for blog post topics for inspiration:
 - **Open source updates**. If we do particular service work, or make a strong technical improvement in an open source project, we should tell the world about it.
 - **Updates from the Managed JupyterHub Serivce**. As hub service infrastructure grows and evolves, and as we serve more communities with it, we should tell others about the impact we are having.
 - **Topic dives**. There may be particular topics that we want to write about, like open culture, cloud optimization, etc. These will help us crystallize our thoughts, demonstrate expertise, and share knowledge with others.
+
+
+## Blog post checklist
+
+Here's a blog-post checklist to help us keep track of the major actions needed to publish a new post.
+Open an issue about your post and copy/paste this checklist into it.
+
+```
+- [ ] Write draft of blog post in markdown
+- [ ] Open a PR to the 2i2c.github.io repository and ask for feedback
+- [ ] Publish the post
+- [ ] Send out a series of tweets from the `2i2c_org` account that summarizes the post.
+- [ ] Tell the team about it and re-tweet!
+- [ ] Decide if this post is worthy for a mailing list update
+- [ ] If so, go to mailchimp.com and create a new email campain
+- [ ] Copy the post's content, paste it into the mailchimp interface
+- [ ] Send off the mailchimp campain
+- [ ] You're done! 🎉
+```

--- a/communication/blog.md
+++ b/communication/blog.md
@@ -21,6 +21,7 @@ Open an issue about your post and copy/paste this checklist into it.
 - [ ] You're done! 🎉
 ```
 
+(blog:topics)=
 ## What to post on the blog
 
 Generally speaking, we can post as often as we wish.

--- a/communication/mailinglist.md
+++ b/communication/mailinglist.md
@@ -10,10 +10,7 @@ We have a single Mailchimp account and share access to team members via a single
 The {role}`Executive Director` is responsible for this information, though others on the team may have it as well.
 If you'd like access, ask the ED or one of the team members with this information.
 
-## What to share with our mailing list
-
-Here are a few ideas for major topics to share with our mailing lists:
-
+(mailinglist:topics)=
 ## Things to post in our mailing list
 
 - **Major community updates**. Our quarterly / annual community updates that summarize our major progress and challenges.

--- a/communication/mailinglist.md
+++ b/communication/mailinglist.md
@@ -4,18 +4,18 @@ We use [Mailchimp](https://mailchimp.com/) to send e-mails to individuals that h
 
 This is a more attentive and personal audience than our blog, so we use the mailing list to **signal boost particularly important information**, or to **ask others to signal-boost for us**.
 
-## How to access Mailchimp
-
-We have a single Mailchimp account and share access to team members via a single `username`/`password`.
-The {role}`Executive Director` is responsible for this information, though others on the team may have it as well.
-If you'd like access, ask the ED or one of the team members with this information.
-
 (mailinglist:topics)=
-## Things to post in our mailing list
+## What to post on our mailing list
 
 - **Major community updates**. Our quarterly / annual community updates that summarize our major progress and challenges.
 - **Job postings**. When we post a new job, share it with our mailing list and ask them to share it with their networks.
 - **Major blog posts**. If we write a blog post about our service that is particularly impactful or important, we can post it to our mailing list for extra visibility.
+
+## Access Mailchimp
+
+We have a single Mailchimp account and share access to team members via a single `username`/`password`.
+The {role}`Executive Director` is responsible for this information, though others on the team may have it as well.
+If you'd like access, ask the ED or one of the team members with this information.
 
 ## Send e-mails via Mailchimp
 

--- a/communication/social.md
+++ b/communication/social.md
@@ -1,30 +1,35 @@
 # Social media
 
 We use social media to signal boost and broadcast 2i2c's impact to the broader community.
-
-## Social media accounts
-
 Currently, we do not have a dedicated Social Media manager, so the responsibility for managing these accounts is spread amongst the team.
 
-### Twitter
+(socialmedia:topics)=
+## What to post on social media
+
+We use social media to signal-boost our efforts in 2i2c and upstream communities.
+Here are a few things to post:
+
+- Links to blog posts
+- Major announcements
+- Advertising job posts and other items we want to draw attention to
+- Re-tweeting and boosting other team members and their accounts
+
+We don't usually use social media to engage directly with other individuals or organizations, though it's not explicitly forbidden.
+We just have not had the resources to plan for this kind of engagement.
+
+## Twitter
 
 Our Twitter handle is ([@2i2c_org](https://twitter.com/2i2c_org)).
 Currently, there is nobody activately monitoring the Twitter account.
-We use it to post links to blog posts or major announcements in the newsletter.
-Many team members also use Twitter, so feel free to `@`-mention `@2i2c_org` if you wish!
 
 **How to access**: We access this account via a shared `username`/`password`.
 If you'd like access, ask the {role}`Executive Director` or somebody else with access.
 It is possible to have [multi-user access to Twitter accounts via TweetDeck](https://twitter.com/settings/teams) but we have not yet set this up.
 
-### LinkedIn
+## LinkedIn
 
 Here is [our LinkedIn page](https://www.linkedin.com/company/70495902/).
 We use LinkedIn roughly the same way that we use Twitter, though focus it more on signal-boosting blog posts and updates because fewer team members regularly use LinkedIn.
 
 **How to access**: We can add **page admins** to our LinkedIn account, which gives others the ability to manage the account and post content.
 If you'd like to be added, ask one of [the pre-existing account admins](https://www.linkedin.com/company/70495902/admin/manage-admins/).
-
-## Accessing social media accounts
-
-so if you'd like access to one of these accounts ask the Executive Director and they can give you access

--- a/communication/strategy.md
+++ b/communication/strategy.md
@@ -1,7 +1,15 @@
-# Communication strategy
+# Communication strategy and overview
 
 There are many ways to communicate with the outside world, and we have limited resources to devote towards communication.
 As such, we focus our efforts around **blog-style posts**, with signal boosting via **Twitter** and **Mailing Lists**.
+
+## Quick overview
+
+This is a quick overview of how we should use these communication channels, see the sub-sections for more detail.
+
+- **Mailing list**: For calls to action, major announcements and summaries, and links to collections of blog posts and other resources. See [](mailinglist:topics) for more details.
+- **Blog posts**: For ongoing updates about what we're up to and thinking about. Can be short or long, and as frequent as we like. More content is better, do not feel too stressed about getting it perfect! See [](blog:topics) for more details.
+- **Social media**: For signal-boosting the above things and advertising other major activities in 2i2c. We generally don't engage in social media conversation (due to resource constraints, not out of policy).
 
 ## Goals in communications
 

--- a/communication/strategy.md
+++ b/communication/strategy.md
@@ -9,7 +9,7 @@ This is a quick overview of how we should use these communication channels, see 
 
 - **Mailing list**: For calls to action, major announcements and summaries, and links to collections of blog posts and other resources. See [](mailinglist:topics) for more details.
 - **Blog posts**: For ongoing updates about what we're up to and thinking about. Can be short or long, and as frequent as we like. More content is better, do not feel too stressed about getting it perfect! See [](blog:topics) for more details.
-- **Social media**: For signal-boosting the above things and advertising other major activities in 2i2c. We generally don't engage in social media conversation (due to resource constraints, not out of policy).
+- **Social media**: For signal-boosting the above things and advertising other major activities in 2i2c as well as our team members. See [](socialmedia:topics) for more details.
 
 ## Goals in communications
 


### PR DESCRIPTION
A couple things, with the goal of making it easier to navigate this section

- Make each of the communications sections follow a similar structure, with "what topics to cover" as the first section in each.
- Add a short overview of all the pieces