### PR TITLE
Make calendar page "calendar and meetings"

### DIFF
--- a/reference/calendar.md
+++ b/reference/calendar.md
@@ -1,5 +1,5 @@
 (team/calendar)=
-# Calendars
+# Calendars and meetings
 
 (calendar:events)=
 ## 2i2c Events


### PR DESCRIPTION
I think this will make it more glanceable and discoverable since it points to the source of truth about meetings.