### PR TITLE
Fix broken URLs

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-team-member.md
+++ b/.github/ISSUE_TEMPLATE/new-team-member.md
@@ -41,7 +41,7 @@ Follow the checklist below to onboard a new team member!
 
 **External**
 
-- [ ] Add to [2i2c website](https://2i2c.org/about/)
+- [ ] Add to [2i2c website](https://2i2c.org/organization/)
 - [ ] Tweet about their arrival!
 
 **Wrap up**

--- a/code-of-conduct/index.md
+++ b/code-of-conduct/index.md
@@ -92,7 +92,7 @@ In addition to having a code of conduct, we have four lightweight [social rules]
 
 The enforcement provisions in this code of conduct do not apply to the social rules. We won't give you a strong warning or expel you from the 2i2c community just for breaking a social rule.
 
-If you have any questions about any part of the code of conduct or social rules, please reach out to [any 2i2c team member](https://2i2c.org/about/#our-team).
+If you have any questions about any part of the code of conduct or social rules, please reach out to [any 2i2c team member](https://2i2c.org/organization).
 
 ```{toctree}
 social-rules
@@ -114,7 +114,7 @@ Instead of filling out a code of conduct violation report, please contact law en
 
 ### Getting help
 
-If you or someone else at 2i2c is struggling and needs help, don’t hesitate to reach out to the 2i2c Executive Director and [Steering Council members](https://2i2c.org/about/#steering-council) in person or over email.
+If you or someone else at 2i2c is struggling and needs help, don’t hesitate to reach out to the 2i2c Executive Director and [Steering Council members](https://2i2c.org/organization) in person or over email.
 
 ## License
 

--- a/code-of-conduct/social-rules.md
+++ b/code-of-conduct/social-rules.md
@@ -1,7 +1,7 @@
 (social-rules)=
 # Social Rules
 
-2i2c has a few social rules. They help ensure that the 2i2c community lives up to [our values](https://2i2c.org/about#values), which is a fundamental part of 2i2c’s mission. They also create a friendly, intellectual environment where you can spend as much of your energy as possible on interactive computing, open infrastructure, learning, discovery, and collaboration.
+2i2c has a few social rules. They help ensure that the 2i2c community lives up to [our values](https://2i2c.org/mission/), which is a fundamental part of 2i2c’s mission. They also create a friendly, intellectual environment where you can spend as much of your energy as possible on interactive computing, open infrastructure, learning, discovery, and collaboration.
 
 The social rules are:
 

--- a/conf.py
+++ b/conf.py
@@ -70,6 +70,7 @@ linkcheck_ignore = [
     "https://icsi.berkeley.edu*",  # Because it's broken often
     "https://sociocracyforall.org*",  # Because it raises a 403 but still works
     "https://airtable.com*",  # Because it has some kind of security that returns a 403
+    "https://app.asana.com*",  # Because it has some kind of security that returns a 403
 ]
 
 # -- Sphinx setup script ---------------------------------------------------

--- a/engineering/secrets.md
+++ b/engineering/secrets.md
@@ -88,7 +88,7 @@ Once you've completed those steps, do the following:
    1. Identify when a file is encrypted or not, and
    2. Use `.gitignore` rules to assist us in not committing unencrypted secrets to the repository
 
-   See our [infrastructure docs](https://infrastructure.2i2c.org/en/latest/topic/secrets.html) for more information on this.
+   See our [infrastructure docs](https://infrastructure.2i2c.org/en/latest/topic/access-creds/secrets.html) for more information on this.
    :::
 
 ### Learn more about `sops`

--- a/organization/mission.md
+++ b/organization/mission.md
@@ -5,7 +5,7 @@
 Our mission is the guiding principle behind everything that we do.
 It defines where we should invest in our capabilities, what kind of impact we want to have, and what kind of work we say yes (or no) to.
 
-Our mission is currently defined in [the About pages](https://2i2c.org/about/) of our brochure site.
+Our mission is currently defined in [the the Mission, values, and strategy page](https://2i2c.org/mission/) of our brochure site.
 
 (organization:values)=
 ## Our values
@@ -13,7 +13,7 @@ Our mission is currently defined in [the About pages](https://2i2c.org/about/) o
 Our values are ideas that we believe are important for 2i2c to follow as it works towards its mission.
 We strive to make decisions that align with our values, though recognize that they are sometimes in tension with one another and cannot be followed perfectly.
 
-Our values are currently defined in [the About pages](https://2i2c.org/about/) of our brochure site.
+Our values are currently defined in [the Mission, values, and strategy page](https://2i2c.org/mission/) of our brochure site.
 
 ## Key stakeholders
 

--- a/organization/structure.md
+++ b/organization/structure.md
@@ -23,7 +23,7 @@ We nonetheless document these structures to understand how our work and responsi
 The Steering Council defines the mission, vision, and values of 2i2c.
 It also provides oversight to the Executive Director.
 
-**Membership**: [Listed on the 2i2c website](https://2i2c.org/about/#steering-council).
+**Membership**: [Listed on the 2i2c website](https://2i2c.org/organization).
 
 **Communication**: The Steering Council Google group ([`steering-council@2i2c.org`](mailto:steering-council@2i2c.org)) is the only “official” way to communicate with others on the Steering Council.
 
@@ -47,7 +47,7 @@ Group leads of 2i2c report to this role.
 
 They are currently the primary interface to {term}`CS&S` administration.
 
-**Membership**: The current Executive Director of 2i2c is listed on the [Our Team page of the website](https://2i2c.org/about/#our-team).
+**Membership**: The current Executive Director of 2i2c is listed on the [Our Team page of the website](https://2i2c.org/organization).
 
 ## Functional areas
 


### PR DESCRIPTION
This fixes a few broken URLs in our team compass. I'll merge it quickly since it's just spot-checking a few issues.

We still have some broken glossary references in there, but I think that'll be trickier to track down so I just wanna fix these obvious ones.