### PR TITLE
Move documentation structure guidelines from infrastructure repo

### DIFF
--- a/index.md
+++ b/index.md
@@ -57,6 +57,7 @@ Reference and archival information for our teams.
 :maxdepth: 2
 reference/calendar.md
 reference/team.md
+reference/docs-structure.md
 reference/terminology.md
 reference/inspiration.md
 ```

--- a/projects/managed-hubs/incidents.md
+++ b/projects/managed-hubs/incidents.md
@@ -177,8 +177,8 @@ This lets us use notes, status updates from pagerduty as well as messages from S
    Best guesses will do!
 5. **Add Data Sources** that we will use to keep track of the actions that happened around the incident.
    - Link to the slack channel we created for this incident as a "Data Source", filled in with an appropriate time to cover all the messages there.
-   - Add any other channels where there was conversation there about the incident (e.g., GitHub Issues or Pull Requests).
-     % How can you add GitHub data sources?
+   % TODO: Add info on how to add GitHub issues/PRs to the timeline when we figure out how to do it.
+   % - Add any other channels where there was conversation there about the incident (e.g., GitHub Issues or Pull Requests).
 
    Click `Save Data Sources` to populate the timeline below with messages from the slack channels.
 6. **Fill out the timeline**. The goal is to be concise but make it possible for someone reading it to answer "what happened, and when?".

--- a/projects/managed-hubs/incidents.md
+++ b/projects/managed-hubs/incidents.md
@@ -178,6 +178,7 @@ This lets us use notes, status updates from pagerduty as well as messages from S
 5. **Add Data Sources** that we will use to keep track of the actions that happened around the incident.
    - Link to the slack channel we created for this incident as a "Data Source", filled in with an appropriate time to cover all the messages there.
    - Add any other channels where there was conversation there about the incident (e.g., GitHub Issues or Pull Requests).
+     % How can you add GitHub data sources?
 
    Click `Save Data Sources` to populate the timeline below with messages from the slack channels.
 6. **Fill out the timeline**. The goal is to be concise but make it possible for someone reading it to answer "what happened, and when?".

--- a/projects/managed-hubs/incidents.md
+++ b/projects/managed-hubs/incidents.md
@@ -189,7 +189,7 @@ This lets us use notes, status updates from pagerduty as well as messages from S
 8. **Click "Save & View Report"** when you are done, and ask other members of the incident response team to review the incident report.
    They might add missing context, additional action items / summary details, or redact information. The person listed as
    the "Owner of the Review Process" is still responsible for making sure the rest of the process is completed.
-9. After sufficient review, and if the Incident Commander is happy with its completeness, **mark the Status dropdown as "Reviewed"**.
+9. After sufficient review, and if the Incident Commander is happy with its completeness, edit the report again, **mark the Status dropdown as "Reviewed"**, and then click "Save & View Report" again.
 10. Download the PDF, and add it to the [`2i2c/incident-reports`](https://github.com/2i2c-org/incident-reports) repository under
     the `reports/` directory. This make sure our incidents are all *public*, so
     others can learn from them as well. Given review is already completed in the pagerduty interface, you don't need to wait

--- a/projects/managed-hubs/incidents.md
+++ b/projects/managed-hubs/incidents.md
@@ -190,7 +190,7 @@ This lets us use notes, status updates from pagerduty as well as messages from S
    They might add missing context, additional action items / summary details, or redact information. The person listed as
    the "Owner of the Review Process" is still responsible for making sure the rest of the process is completed.
 9. After sufficient review, and if the Incident Commander is happy with its completeness, **mark the Status dropdown as "Reviewed"**.
-10. Download the PDF, and add it to the [`2i2c/infrastrtucture`](https://github.com/2i2c-org/incident-reports) repository under
+10. Download the PDF, and add it to the [`2i2c/incident-reports`](https://github.com/2i2c-org/incident-reports) repository under
     the `reports/` directory. This make sure our incidents are all *public*, so
     others can learn from them as well. Given review is already completed in the pagerduty interface, you don't need to wait
     for review to add the report here.

--- a/projects/managed-hubs/incidents.md
+++ b/projects/managed-hubs/incidents.md
@@ -113,6 +113,16 @@ Here is the process that we follow for incidents:
    This officially marks the beginning of an incident, and will help make sure we don't accidentally miss steps during or after the incident.
 
 3. **Try resolving the issue** and communicate on the incident-specific channel while you gather information and perform actions - even if only to mark these as notes to yourself.
+
+   ```{admonition} Do not use threaded Slack messages
+   :class: warning
+
+   Do **NOT** use threads when communicating in this Slack channel.
+   When coming to write the [incident report](incidents:create-report) after the event, PagerDuty can import messages from the Slack channel in order to construct a timeline.
+   However, it cannot import threaded messages, only those that are sent directly to the channel.
+   Hence if the cause of an incident was established in a thread, this cannot be reflected automatically in the incident report.
+   ```
+
 4. **Delegate to Subject Matter Experts as-needed**. The Incident Commander is empowered to delegate actions to Subject Matter Experts in order to investigate and resolve the incident quickly.[^note-on-delegation]
 5. **Communicate our status every few hours**. The {term}`External Liason` is
    expected to communicate incident status and plan with the {term}`Community

--- a/projects/managed-hubs/incidents.md
+++ b/projects/managed-hubs/incidents.md
@@ -71,7 +71,7 @@ PagerDuty has a 'Severity' field for incidents. We do not use this field current
 ### External communication
 
 - The {term}`Incident Commander` acts as the primary point of communication with external stakeholders like the {term}`Community Representative`s.
-- They may **delegate** this responsibilitiy to another team member if they wish (e.g., to the {term}`Support Steward` team.)
+- They may **delegate** this responsibility to another team member if they wish (e.g., to the {term}`Support Steward` team.)
 - We may interact with external stakeholders via comments in Incident Response issues if it helps resolve the incident more quickly.
 
 (incidents:communications)=

--- a/projects/managed-hubs/incidents.md
+++ b/projects/managed-hubs/incidents.md
@@ -54,7 +54,7 @@ now, we define an incident as one of:
    a. They can not log in
    b. They can not start their servers
    c. They can not execute code (no kernels can be started)
-3. A number of users (N>=2) cannot create or use Dask Gateway clusters.
+2. A number of users (N>=2) cannot create or use Dask Gateway clusters.
 
 Everything else is considered a support ticket only, not an incident. This *will* change in
 the future as our process matures.

--- a/reference/docs-structure.md
+++ b/reference/docs-structure.md
@@ -1,0 +1,102 @@
+# Guidelines for documentation structure
+
+We primarily offer documentation, peace of mind and expertise to
+our users - and code/configuration is simply an implementation
+detail. Well structured documentation aimed at different audiences is
+essential to 2i2c's long term health. This document lists the audiences
+we serve, what type of docs they might expect, and where we provide them.
+
+## Audiences
+
+For each feature we add or change we make, we should create & update
+documentation for all of these audiences, as applicable. There are a
+few key audiences that are outlined below.
+
+### The general public
+
+People visit our website to learn about us, and investigate if we could
+be of use to them. Communicating what value we can add to them is
+extremely important, so any feature we write should be integrated into
+[our website](https://2i2c.org/). The focus should
+be on the value we can add to potential users, and should link to
+other kinda documentation for more detail if needed.
+
+### Hub users
+
+Ultimately, our hubs are built to serve researchers, students and instructors.
+These are our *end users*, and they need to be able to
+get their work done.
+
+The infrastructure we provide is primarily opinionated bundles of
+upstream software, so we don't *need* to rewrite documentation for all
+the software they might use. However, since we make opinionated choices
+about JupyterHub deployments, some repetition of upstream documentation
+that assumes the specific choices we already make is helpful.
+
+We should provide at least the following kinds of documentation:
+
+1. **Tutorials** for common workflows on our infrastructure, since this is
+   heavily driven by the opinionated choices we have made while building it.
+2. **How-to guides** to help users accomplish a specific well defined task,
+   especially if it is something they know how to do in a different system.
+   The documentation titles should always be of the form **How do I `<title>`?**
+3. **Component reference** to inform users where to find documentation for
+   the component they might be having issues with. Most users are unfamiliar
+   with the intricate details of what component does what, so might not be
+   able to find the appropriate place to look at.
+
+This documentation should exist in the [2i2c-org/docs](https://github.com/2i2c-org/docs)
+repository, available at [docs.2i2c.org](https://docs.2i2c.org)
+
+### Hub administrators
+
+Hub administrators are the interface between the 2i2c engineers running
+the hub and the actual users of the hub. They are usually a part of the
+community using the hub, and are interested in the *configuration* of
+the hub infrastructure as well. They should be aware of possible
+configuration options they can choose to serve their community best, and
+be empowered to make those choices without interaction with 2i2c
+engineers wherever possible.
+
+They help make decisions about the configuration of the hub that benefits
+its users most, and hence we should provide at least the following kinds
+of documentaiton.
+
+1. **Configuration guides** to help them *pick* the configuration that
+   will be best fit for each of our major features - such as
+   authentication, kind of user interface, etc. Their hubs are then
+   configured with these choices in collaboration with 2i2c staff. Each
+   guide should mention *how* this implementation can occur - possibly
+   with a link to documentation for 2i2c engineers  .
+2. **How-to guides** to help admins accomplish very specific tasks during
+   the course of hub usage. Their titles should always be of the form
+   **How do I `<title>`?**.
+
+This documentation should exist in the [2i2c-org/docs](https://github.com/2i2c-org/docs)
+repository, available at [docs.2i2c.org](https://docs.2i2c.org/)
+
+### 2i2c engineers
+
+These are folks tasked with building, maintaining, debugging and fixing
+2i2c infrastructure. Documentation targetting them should be in
+[2i2c-org/infrastructure](https://github.com/2i2c-org/infrastructure)
+repository, regardless of the kind of hub it
+relates to. Since we run our hubs openly, with best practices that can
+be adopted by anyone, we should try write these to be as accessible to
+non 2i2c staff as possible - no secret sauce, minimal 2i2c specific
+process.
+
+Here are some contexts where they would need documentation.
+
+1. **Tutorials**, to help orient folks who might be working on areas
+   they aren't already familiar with. This should have clear links to
+   pre-requisite knowledge and how it can be acquired.
+2. **How-to guides** for performing common tasks that have not been
+   automated yet. Their titles should always be of the form
+   **How do I `<title>`?**
+3. **Topic guides**
+4. **References**, describing in detail parts of our infrastructure and
+   its configuration. This should ideally be kept in the code describing
+   our infrastructure - for example, [terraform-docs](https://github.com/terraform-docs/terraform-docs)
+   for terraform code, JSON Schema based document generator for YAML,
+   etc. This helps them be in sync with what we are actually doing.


### PR DESCRIPTION
This page used to be in the infrastructure repo, but I think it makes more sense in our team compass. See related:

- https://github.com/2i2c-org/infrastructure/pull/2091