### PR TITLE
Add a table of Support Stewards to our docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ tmp/
 .DS_Store
 .nox
 __pycache__
+_data/support_stewards/*.txt

--- a/_data/support_stewards/gen_support_stewards.py
+++ b/_data/support_stewards/gen_support_stewards.py
@@ -12,7 +12,7 @@ class SlackUsergroupMembers:
     def __init__(self):
         token = os.environ.get("SLACK_BOT_TOKEN", None)
         if token is None:
-            raise ValueError("SLACK_BOT_TOKEN must be provided!")
+            print("SLACK_BOT_TOKEN does not exist. Skipping Support Steward table generation...")
 
         self.client = WebClient(token=token)
 

--- a/_data/support_stewards/gen_support_stewards.py
+++ b/_data/support_stewards/gen_support_stewards.py
@@ -1,0 +1,136 @@
+import os
+from collections import OrderedDict
+from pathlib import Path
+from textwrap import dedent, indent
+
+from slack_sdk import WebClient
+
+
+class SlackUsergroupMembers:
+    """Find the members of a given Slack usergroup"""
+
+    def __init__(self):
+        token = os.environ.get("SLACK_BOT_TOKEN", None)
+        if token is None:
+            raise ValueError("SLACK_BOT_TOKEN must be provided!")
+
+        self.client = WebClient(token=token)
+
+    def _get_usergroup_id(self, usergroup_name):
+        """Retrieve the ID of a named Slack usergroup
+        
+        Args:
+            usergroup_name (str): The display name of the desired Slack
+                usergroup
+        """
+        # List all usergroups in the workspace
+        response = self.client.api_call(api_method="usergroups.list")
+
+        # Find ID for the given usergroup
+        index = next(
+            idx
+            for (idx, usergroup) in enumerate(response["usergroups"])
+            if usergroup["handle"] == usergroup_name
+        )
+
+        self.usergroup_id = response["usergroups"][index]["id"]
+
+    def _get_user_ids(self, usergroup_name):
+        """
+        Retrieve the user IDs of the members of a given usergroup
+        """
+        self._get_usergroup_id(usergroup_name)
+
+        # Find all user IDs in the usergroup
+        response = self.client.api_call(
+            api_method="usergroups.users.list",
+            params={"usergroup": self.usergroup_id},
+        )
+        self.user_ids = response["users"]
+        return self.user_ids
+
+    def _retrieve_users_names_and_pics(self, user_id):
+        """For a given user ID, retrieve their 'real name', or display name if
+        available, and their profile picture
+
+        Args:
+            user_id (str): A Slack user ID
+
+        Returns:
+            username (str): The 'real name' or display name associated with the
+                given user ID
+            avatar_url (str): A URL to the Slack avatar of a given user ID
+        """
+        # Convert user IDs to 'real names', or 'display names' if available
+        response = self.client.api_call(
+            api_method="users.info",
+            params={"user": user_id},
+        )
+
+        username = response["user"]["profile"]["real_name"]
+        if username == "":
+            username = response["user"]["profile"]["display_name"]
+        
+        avatar_url = response["user"]["profile"]["image_512"]
+
+        return username, avatar_url
+
+    def get_users_in_usergroup(self, usergroup_name):
+        """Retrieve the members of a Slack usergroup
+
+        Returns:
+            dict: A dictionary of members of a Slack usergroup. Keys are the
+                Slack users' 'real names', or display names if available, and
+                values are a URL pointing to the user's avatar
+        """
+        self._get_user_ids(usergroup_name)
+
+        usernames_and_avatars = {}
+        for user_id in self.user_ids:
+            username, avatar_url = self._retrieve_users_names_and_pics(user_id)
+            usernames_and_avatars[username] = avatar_url
+
+        # Sort the dictionary alphabetically by key, i.e., display names
+        usernames_and_avatars = OrderedDict(sorted(usernames_and_avatars.items()))
+
+        return usernames_and_avatars
+
+
+def main():
+    # Get support stewards usernames and avatars
+    slack = SlackUsergroupMembers()
+    usernames_and_avatars = slack.get_users_in_usergroup("support-stewards")
+
+    # Set filepaths
+    data_path = Path(__file__).parent
+    support_stewards_file = data_path.joinpath("support-stewards.txt")
+
+    # Begin rST definition of grid with cards
+    snippet = dedent("""
+        .. grid:: 1 2 3 3
+           :gutter: 3
+           :class-container: contributor-grid
+        """)
+
+    # Add cards for the support stewards to the grid
+    for user, avatar_url in usernames_and_avatars.items():
+        # Create the card rST. Needs to be indented underneath its parent
+        snippet += indent(
+            dedent(f"""
+        .. grid-item-card::
+           :class-header: bg-light
+           :text-align: center
+
+           **{user}**
+
+           ^^^
+
+           .. image:: {avatar_url}
+        """), "   ")
+
+    # Write an rST snippet to include in the docs
+    support_stewards_file.write_text(snippet + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/_data/support_stewards/gen_support_stewards.py
+++ b/_data/support_stewards/gen_support_stewards.py
@@ -107,9 +107,10 @@ def main():
 
     # Begin rST definition of grid with cards
     snippet = dedent("""
-        .. grid:: 1 2 3 3
-           :gutter: 3
-           :class-container: contributor-grid
+        ```{grid} 1 2 3 3
+        :gutter: 3
+        :class-container: contributor-grid
+        ```
         """)
 
     # Add cards for the support stewards to the grid
@@ -117,16 +118,18 @@ def main():
         # Create the card rST. Needs to be indented underneath its parent
         snippet += indent(
             dedent(f"""
-        .. grid-item-card::
-           :class-header: bg-light
-           :text-align: center
+        ````{{grid-item-card}}
+        :class-header: bg-light
+        :text-align: center
 
-           **{user}**
+        **{user}**
 
-           ^^^
+        ^^^
 
-           .. image:: {avatar_url}
-        """), "   ")
+        ```{{image}} {avatar_url}
+        ```
+        ````
+        """))
 
     # Write an rST snippet to include in the docs
     support_stewards_file.write_text(snippet + "\n")

--- a/conf.py
+++ b/conf.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from subprocess import run
 
 # -- Project information -----------------------------------------------------
 
@@ -89,6 +90,9 @@ def setup(app):
     app.add_crossref_type("role", "role")
     app.add_crossref_type("team", "team")
 
+# -- Generate table of Support Stewards --------------------------------------
+
+run(["python", "_data/support_stewards/gene-support-stewards.py"])
 
 # -- Options for the rediraffe extension -------------------------------------
 # ref: https://github.com/wpilibsuite/sphinxext-rediraffe#readme

--- a/conf.py
+++ b/conf.py
@@ -92,7 +92,8 @@ def setup(app):
 
 # -- Generate table of Support Stewards --------------------------------------
 
-run(["python", "_data/support_stewards/gene-support-stewards.py"])
+path_script = Path(__file__).parent / "_data/support_stewards/gen_support_stewards.py"
+run(f"python {path_script}", shell=True)
 
 # -- Options for the rediraffe extension -------------------------------------
 # ref: https://github.com/wpilibsuite/sphinxext-rediraffe#readme

--- a/projects/managed-hubs/support.md
+++ b/projects/managed-hubs/support.md
@@ -111,8 +111,7 @@ Hub Administrators
 
 The Support Steward role rotates through the below Support Team members.
 
-```{eval-rst}
-.. include:: ../../_data/support_stewards/support-stewards.txt
+```{include} ../../_data/support_stewards/support-stewards.txt
 ```
 
 ## Communication channels

--- a/projects/managed-hubs/support.md
+++ b/projects/managed-hubs/support.md
@@ -107,6 +107,14 @@ Hub Administrators
   
 ```
 
+### Who are our Support Team?
+
+The Support Steward role rotates through the below Support Team members.
+
+```{eval-rst}
+.. include:: ../../_data/support_stewards/support-stewards.txt
+```
+
 ## Communication channels
 
 ### External communication

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,6 @@ sphinx-copybutton
 sphinx-design
 sphinx-togglebutton
 sphinxext-rediraffe
+
+# Slack SDK for pulling Support Steward info
+slack-sdk


### PR DESCRIPTION
This PR adds a table of all the team members who can serve as support stewards to our documentation. Names and avatars are pulled from Slack and appearance on this table is determined by membership of the `@support-stewards` Slack usergroup.

I added a Slack API token as an environment variable to the RTD project. Step 4 in this part of the documentation confused me: https://docs.readthedocs.io/en/stable/environment-variables.html#user-defined-environment-variables As I result, I have left the environment variable as "Private". This means that the table is not rendered in previews of the site in PRs, as we can see here: https://2i2c-team-compass--626.org.readthedocs.build/en/626/projects/managed-hubs/support.html#who-are-our-support-team But 🤞🏻 it should be when we merge. Here is a screenshot of the table from my local build:

<img width="766" alt="Screenshot 2023-01-25 at 16 55 18" src="https://user-images.githubusercontent.com/44771837/214818266-42fbc699-7ece-440e-96d3-ddece384bffe.png">

fixes #494 