### PR TITLE
Prevent autobuild from looping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ tmp/
 .DS_Store
 .nox
 __pycache__
-_data/support_stewards/*.txt

--- a/_data/support_stewards/gen_support_stewards.py
+++ b/_data/support_stewards/gen_support_stewards.py
@@ -101,9 +101,11 @@ def main():
     slack = SlackUsergroupMembers()
     usernames_and_avatars = slack.get_users_in_usergroup("support-stewards")
 
-    # Set filepaths
-    data_path = Path(__file__).parent
-    support_stewards_file = data_path.joinpath("support-stewards.txt")
+    # Create a tmp dir and set filepaths
+    project_root = Path(__file__).resolve().parent.parent.parent
+    tmp_dir = project_root.joinpath("tmp")
+    tmp_dir.mkdir(parents=True, exist_ok=True)
+    support_stewards_file = tmp_dir.joinpath("support-stewards.txt")
 
     # Begin MyST definition of grid with cards
     grid_md = dedent("""

--- a/projects/managed-hubs/support.md
+++ b/projects/managed-hubs/support.md
@@ -111,7 +111,7 @@ Hub Administrators
 
 The Support Steward role rotates through the below Support Team members.
 
-```{include} ../../_data/support_stewards/support-stewards.txt
+```{include} ../../tmp/support-stewards.txt
 ```
 
 ## Communication channels


### PR DESCRIPTION
This redirects the output of the gen_support_stewards.py file to the tmp dir which is already both git- and sphinx-ignored. This prevents the live build from continuously looping because the _data/support_stewards folder always had changes due to regeneration.