### PR TITLE
Add extra documentation about Python and Sphinx

### DIFF
--- a/index.md
+++ b/index.md
@@ -57,7 +57,7 @@ Reference and archival information for our teams.
 :maxdepth: 2
 reference/calendar.md
 reference/team.md
-reference/docs-structure.md
+reference/documentation/overview.md
 reference/terminology.md
 reference/inspiration.md
 ```

--- a/operations/team-compass.md
+++ b/operations/team-compass.md
@@ -15,6 +15,12 @@ There are a few major reasons why we use a Team Compass:
 - **Provenance**. Almost all organizational decisions are made via edits to the Team Compass, or in documentation that we link to from the Team Compass.
   Because we conduct most discussions in GitHub repositories and issues, we have a historical record of the evolution of 2i2c, as well as provenance behind its decisions.
 
+## Update the team compass
+
+The Team Compass should be updated frequently as information about 2i2c changes.
+Do not hesitate to propose a change!
+See [our Documentation Guide](../reference/documentation/overview.md) for instructions of how to edit our Team Compass (and other documentation that 2i2c uses).
+
 ## What is a Source of Truth
 
 The Team Compass is a {term}`Single Source of Truth`, meaning that it is the definitive answer for questions about 2i2c's policy and state.
@@ -27,69 +33,3 @@ Single Source of Truth
 ```
 
 [^source-of-truth]: **References for Single Source of Truth**: For a few examples, see [this Bitergia post](https://blog.bitergia.com/2020/08/25/why-ospo-teams-need-a-single-source-of-truth/) and [the GitLab SSOT section](https://about.gitlab.com/handbook/values/#single-source-of-truth).
-
-
-## How to update the team compass
-
-The Team Compass should be updated frequently as information about 2i2c changes.
-Do not hesitate to propose a change!
-This page contains instructions for how to build the Team Compass locally, and how to update the website.
-
-The Team Compass is built using Sphinx, along with themes and extensions that are used by the [Jupyter Book project](https://jupyterbook.org). It is hosted via GitHub Pages and changes are auto-deployed via GitHub Actions.
-
-## Propose a change to the team compass
-
-If you'd like to update information in this book, you can do so via editing the book's source files. These are a collection of markdown files in [the book's repository](https://github.com/2i2c-org/team-compass).
-
-To propose an edit directly from the documentation, click {fab}`github` -> {fas}`pencil-alt`.
-
-### Option 1: Use the GitHub UI
-
-The easiest way to propose a change to the Team Compass is by using the GitHub User Interface.
-To do so, navigate to the GitHub page for a file that you'd like to edit, and click on the pencil ({fa}`pencil-alt`) icon.
-
-Make whatever changes you like using the GitHub interactive editor, and then click `Create a new branch for this commit and start a pull request.`.
-This will create a Pull Request with your proposed changes.
-
-### Option 2: Make the change locally
-
-The other option is to make the change locally on your computer, push it to GitHub, and then propose a Pull Request.
-To do this, you should be familiar with `git`.
-To do so, follow these steps:
-
-1. **Clone the source files**. First, clone the source files for the Team Compass:
-
-   ```
-   git clone https://github.com/2i2c-org/team-compass
-   cd team-compass
-   ```
-2. **Make your changes**. Edit the markdown files in the Team Compass and the content will be updated.
-3. **(optional) Preview your changes**. To preview the book locally, build it with `nox`:
-
-   ```
-   pip install nox
-   nox -s docs-live
-   ```
-
-   This will build the book using Sphinx, and put HTML outputs in `_build/html`.
-   You can then preview them by opening up one of the `.html` files in a web browser.
-
-(team-compass:structure)=
-## Structure of the Team Compass
-
-This team compass is organized into a few major sections.
-
-### Getting started material
-
-Should be a small number of top-level pages that help folks get started with the most important information about 2i2c, assuming they are a newcomer.
-
-### Topic areas
-
-Several top-level sections that roughly map onto **major functional areas** of 2i2c.
-There should be no more than around 10 topic areas here.
-Each topic area has a number of sub-topics with more information.
-
-### Reference material
-
-Reference material contains factual and more structured information about 2i2c.
-It is meant as a quick reference and doesn't go into as much explanation and depth.

--- a/reference/documentation/content.md
+++ b/reference/documentation/content.md
@@ -1,0 +1,21 @@
+# Write content with MyST markdown
+
+Our documentation is written in [MyST Markdown](https://myst.tools), using a parser for Sphinx developed by the [Executable Books project](https://executablebooks.org).
+
+## MyST Markdown overview
+
+The quickest way to learn how to write with MyST Markdown is to [read the MyST Markdown overview](https://jupyterbook.org/en/stable/content/myst.html).
+
+## MyST Markdown cheat-sheet
+
+For a reference of many kinds of MyST Markdown, see [the MyST Markdown cheat-sheet](https://jupyterbook.org/en/stable/reference/cheatsheet.html).
+This shows many common types of content people write, and how they look with MyST source code.
+
+## Interactive MyST explorer
+
+See [the MyST-JS documentation](https://myst.tools/docs/mystjs/typography) has live examples of MyST Markdown that you can edit to see their output.
+This is another useful reference and a way to quickly play around with different formats.
+
+:::{warning}
+Some of the syntax in MyST-JS is slightly different from MyST-Python - the project is working to unify these experiences.
+:::

--- a/reference/documentation/edit.md
+++ b/reference/documentation/edit.md
@@ -1,0 +1,85 @@
+# Edit the documentation
+
+2i2c's documentation should be dynamic and constantly changing.
+It is important that our documentation reflect our current practices, so that other team members know how to contribute and what to expect.
+
+These sections cover the major ways that you can make edits to our documentation.
+
+(documentation:edit:github)=
+## Make edits with the GitHub UI
+
+The easiest way to edit documentation is to use GitHub's user-interface directly.
+This will allow you to make changes in your browser, and propose them via a **Pull Request**.
+
+To do so here are some basic steps:
+
+### Navigate to the repository for the documentation you wish to edit
+
+Navigate to the documentation in the repository of your choice.
+If the repository is purely for documentation, then our documentation is usually in the root of the repository.
+If the repository also contains code, then our documentation is usually in a `docs/` folder.
+
+For example, [the repository for our Team Compass is at this URL](https://github.com/2i2c-org/team-compass).
+
+### Navigate to the file you wish to edit
+
+In the Github UI, open the file that you wish to edit by clicking on it.
+For example, [here is the URL for the page you are currently reading](https://github.com/2i2c-org/team-compass/blob/main/reference/documentation/edit.md).
+
+### Trigger "Edit Mode" in the GitHub UI
+
+There is a little pencil icon ({fas}`pencil-alt`) in the the top-right of the page.
+Click on it, and it will turn on "editing mode".
+
+### Make your edits
+
+Make edits to the page's markdown as you wish.
+For information about how to write MyST Markdown in our documentation, see [](content.md).
+
+### Create a Pull Request
+
+When you're done making your edits, click `Create a new branch for this commit and start a pull request`.
+This will create a Pull Request with your proposed changes.
+
+In the Pull Request, give it a title and description that describe the changes you've made.
+If the edits are very minor, don't hesitate to merge them yourself (e.g., correcting a typo).
+If they are more complex, ping a team member for a review.
+
+## Edit documentation locally
+
+If you are comfortable with or interested in learning Sphinx-based documentation workflows, you can also make changes to documentation locally on your computer, push it to GitHub, and then propose a Pull Request.
+
+:::{admonition} Learn ahead of time
+This section assumes you have a basic knowledge of how to use `git`.
+See [the Software Carpentry training on `git`](https://swcarpentry.github.io/git-novice/) to learn how to use this tool.
+:::
+
+### Set up a local documentation environment
+
+To do so, see [](environment.md).
+
+### Clone the repository source files
+
+First, clone the source files for the repository you wish to edit.
+For example, to clone the source files of the Team Compass:
+
+```
+git clone https://github.com/2i2c-org/team-compass
+cd team-compass
+```
+
+### Make your changes
+
+Edit the markdown files in the Team Compass and the content will be updated.
+For guidance on how to write MyST Markdown, see [](content.md).
+
+### Preview your changes (optional)
+
+To preview your documentation locally, [see the instructions on installing and using `nox`](docs:install:nox).
+
+This will build the book using Sphinx, and put HTML outputs in an output folder in `_build/`.
+You can then preview them by opening up one of the `.html` files in a web browser.
+
+### Push your changes to GitHub and make a Pull Request
+
+Once you've made your local changes, commit them to the repository, push it to GitHub, and open a Pull Request.

--- a/reference/documentation/environment.md
+++ b/reference/documentation/environment.md
@@ -1,0 +1,88 @@
+# Set up a local documentation environment
+
+To create your documentation environment locally, you'll need a **Python environment** as well as **Nox** installed.
+If you wish to build Sphinx by-hand without **Nox**, you'll also need to install the dependencies for a given repository.
+
+:::{note}
+The easiest way to edit our documentation is to [use GitHub's UI editor](documentation:edit:github).
+Setting up your documentation environment locally is not required.
+:::
+
+(docs:install:python)=
+## Install Python
+
+First, you'll need to install **Python 3**.
+The easiest way to do this is by [installing `minioconda`](https://conda.io/projects/conda/en/stable/user-guide/install/index.html).
+This will give you a lightweight Python installation on your machine.
+
+## Install `git`
+
+We use [the `git` command line tool](https://git-scm.com/docs/user-manual) to manage "Version Control" for our repositories, and to keep track of changes.
+Install `git` locally with the following command:
+
+```shell
+conda install -c conda-forge git
+```
+
+(docs:install:nox)=
+## Install `nox`
+
+Most of our documentation is buildable with [the `nox` automation tool](https://nox.thea.codes/).
+This is a lightway way to execute commands in an isolated environment.
+It will let you both install the dependencies for your documentation and build it with a single command.
+
+To install `nox`, first [confirm you have installed Python](docs:install:python) then type:
+
+```shell
+pip install nox
+```
+
+To list all available options to use with `nox`, run:
+
+```shell
+nox -l
+```
+
+To build documentation locally, run:
+
+```shell
+nox -s docs
+```
+
+To build documentation with a live server that previews your changes, run:
+
+```shell
+nox -s docs -- live
+```
+
+### Clear the `nox` environment cache
+
+When you run a job with `nox`, it will automatically install the necessary dependencies for you and place them in a local folder called `.nox`.
+This is folder is usually _hidden_, and it contains all of the files needed to run a Nox build.
+
+To delete the environment and force Nox to re-install things from scratch, deleted this folder.
+For example, on `*nix` platforms, run:
+
+```shell
+rm -rf .nox
+```
+
+## Manually install the environment for documentation
+
+Normally, [Nox](docs:install:nox) will handle all of the environment installation for you.
+However if you prefer to install the environment manually and runs Sphinx yourself, you may do so.
+This differs slightly depending on the repository, but it usually works like this:
+
+1. **Find the environment files for the repository documentation**. These define the dependencies needed to build the documentation. It is usually in a file called `requirements.txt` or `environment.yml`. It is sometimes in `docs/requirements.txt`.
+2. **Install the environment for the documentation**. Manually install the dependencies with `pip` or `conda`. For example:
+
+   ```shell
+   pip install -r requirements.txt
+   ```
+3. **Build the documentation with Sphinx**. Finally, you can build the documentation locally with Sphinx using a command like so:
+
+   ```shell
+   sphinx-build docs docs/_build/html
+   ```
+
+See [the Sphinx documentation](https://www.sphinx-doc.org/en/master/) for more details.

--- a/reference/documentation/overview.md
+++ b/reference/documentation/overview.md
@@ -1,0 +1,14 @@
+# Documentation guide
+
+2i2c uses the same documentation setup across all of our repositories.
+This uses [the Sphinx documentation engine in Python](https://www.sphinx-doc.org/en/master/) along with [a custom Sphinx theme called the `2i2c-sphinx-theme`](https://github.com/2i2c-org/sphinx-2i2c-theme) that we use to standardize the look and feel and some menu items across all of our documentation sites.
+
+See the sections below for more information about the structure and instructions for editing our documentation.
+
+```{toctree}
+:maxdepth: 2
+edit
+content
+environment
+structure
+```

--- a/reference/documentation/structure.md
+++ b/reference/documentation/structure.md
@@ -6,13 +6,11 @@ detail. Well structured documentation aimed at different audiences is
 essential to 2i2c's long term health. This document lists the audiences
 we serve, what type of docs they might expect, and where we provide them.
 
-## Audiences
-
 For each feature we add or change we make, we should create & update
 documentation for all of these audiences, as applicable. There are a
 few key audiences that are outlined below.
 
-### The general public
+## The general public
 
 People visit our website to learn about us, and investigate if we could
 be of use to them. Communicating what value we can add to them is
@@ -21,7 +19,7 @@ extremely important, so any feature we write should be integrated into
 be on the value we can add to potential users, and should link to
 other kinda documentation for more detail if needed.
 
-### Hub users
+## Hub users
 
 Ultimately, our hubs are built to serve researchers, students and instructors.
 These are our *end users*, and they need to be able to
@@ -48,7 +46,7 @@ We should provide at least the following kinds of documentation:
 This documentation should exist in the [2i2c-org/docs](https://github.com/2i2c-org/docs)
 repository, available at [docs.2i2c.org](https://docs.2i2c.org)
 
-### Hub administrators
+## Hub administrators
 
 Hub administrators are the interface between the 2i2c engineers running
 the hub and the actual users of the hub. They are usually a part of the
@@ -75,7 +73,7 @@ of documentaiton.
 This documentation should exist in the [2i2c-org/docs](https://github.com/2i2c-org/docs)
 repository, available at [docs.2i2c.org](https://docs.2i2c.org/)
 
-### 2i2c engineers
+## 2i2c engineers
 
 These are folks tasked with building, maintaining, debugging and fixing
 2i2c infrastructure. Documentation targetting them should be in


### PR DESCRIPTION
This adds more information about how to make edits to our documentation, how to set up a local documentation environment, and some links to resources to learn more. The goal is to help team members learn about our documentation workflow more quickly.

It re-organizes some of the content that @sgibson91 pushed in https://github.com/2i2c-org/team-compass/pull/624 and nests it all under a `Documentation guide`. It's currently under the `# Reference` section but I'm fine moving it elsewhere if there is a better spot for it (e.g. `Team Operations`?).

### Requests

Could @colliand check out the instructions here and let me know if this would have made it easier to get started with our documentation?

### References

- part of #637 