### PR TITLE
Add invoicing procedures

### DIFF
--- a/administration/index.md
+++ b/administration/index.md
@@ -7,6 +7,7 @@ This chapter contains administrative information at 2i2c.
 structure
 css
 reimburse
+invoices
 google-workspace
 github
 airtable

--- a/administration/invoices.md
+++ b/administration/invoices.md
@@ -1,0 +1,6 @@
+# Send invoices
+
+For any team members that are paid off of fixed-term contracts, they must send monthly invoices to receive payment for their efforts.
+This page describes the process for doing so.
+
+1. **Prepare an invoice template**. 

--- a/administration/invoices.md
+++ b/administration/invoices.md
@@ -4,6 +4,8 @@ This page describes the process for sending invoices to our fiscal sponsor, {ter
 
 This includes any team members that are paid off of fixed-term contracts and submit monthly invoices for their work.
 
+## Invoicing process
+
 1. **Read the CS&S invoicing instructions**. CS&S [has instructions to invoice here](https://www.codeforsociety.org/resources/getting-paid-by-css).
    This is what you'll follow.
 2. **Prepare an invoice**. If you do not have one, [here is a template to get you started](https://docs.google.com/document/d/17aTwJkmYFXwqHa2QjYsy81hEXq64yfmo5g1SCGE6aK4/edit?usp=sharing).
@@ -13,3 +15,29 @@ This includes any team members that are paid off of fixed-term contracts and sub
    These are both organizational accounts to track the invoices and ensure visibility across the organization.
 5. **Do not hesitate to ask about the status of your invoice**.
    The above steps should be all you need to do, but do not hesitate to reach out again if things seem to be going slow.
+
+(invoices:template)=
+## Invoice template
+
+[Here is an invoice template](https://docs.google.com/document/d/17aTwJkmYFXwqHa2QjYsy81hEXq64yfmo5g1SCGE6aK4/edit?usp=sharing) that you can copy and modify.
+It is designed for a contractor, so some fields may not be correct.
+Make the modifications needed to include the information requested in the CS&S link above.
+
+(reimburse:grant-code)=
+## What is my grant code?
+
+Most reimbursements require a **grant code**.
+Each team member is paid from one or more grants so this helps CS&S know which account to draw from.
+The {role}`Executive Director` is the final say on which grant code is paying a given team member, but generally it is the same grant paying you over time.
+
+To find a list of grant codes:
+
+- Locate [our latest monthly account statement from CS&S](accounting:statements).
+- See the `Income Statement (Profit and Loss)` tab.
+- In the `Account` row, each item is a grant, it has the form:
+
+  ```none
+  MMM YYYY-MMM YYYY PROJECTNAME: GRANTCODE
+  ```
+
+  You want the value of `GRANTCODE`.

--- a/administration/invoices.md
+++ b/administration/invoices.md
@@ -1,6 +1,14 @@
-# Send invoices
+# Send invoices to CS&S
 
-For any team members that are paid off of fixed-term contracts, they must send monthly invoices to receive payment for their efforts.
-This page describes the process for doing so.
+This page describes the process for sending invoices to our fiscal sponsor, {term}`Code for Science and Society`.
 
-1. **Prepare an invoice template**. 
+This includes any team members that are paid off of fixed-term contracts and submit monthly invoices for their work.
+
+1. **Prepare an invoice**. If you do not have one, [here is a template to get you started](https://docs.google.com/document/d/17aTwJkmYFXwqHa2QjYsy81hEXq64yfmo5g1SCGE6aK4/edit?usp=sharing).
+2. **Confirm your grant code**. You will need to supply a **grant code** for your invoice.
+   This helps CS&S categorize your invoice for our accounting purposes.
+   Include this grant code in your invoice.
+3. **Send it to [`bills@codeforsociety.org`](mailto:bills@codeforsociety.org) and [`admin@2i2c.org`](mailto:admin@2i2c.org)**.
+   These are both organizational accounts to track the invoices and ensure visibility across the organization.
+4. **Do not hesitate to ask about the status of your invoice**.
+   The above steps should be all you need to do, but do not hesitate to reach out again if things seem to be going slow.

--- a/administration/invoices.md
+++ b/administration/invoices.md
@@ -4,11 +4,12 @@ This page describes the process for sending invoices to our fiscal sponsor, {ter
 
 This includes any team members that are paid off of fixed-term contracts and submit monthly invoices for their work.
 
-1. **Prepare an invoice**. If you do not have one, [here is a template to get you started](https://docs.google.com/document/d/17aTwJkmYFXwqHa2QjYsy81hEXq64yfmo5g1SCGE6aK4/edit?usp=sharing).
-2. **Confirm your grant code**. You will need to supply a **grant code** for your invoice.
-   This helps CS&S categorize your invoice for our accounting purposes.
-   Include this grant code in your invoice.
-3. **Send it to [`bills@codeforsociety.org`](mailto:bills@codeforsociety.org) and [`admin@2i2c.org`](mailto:admin@2i2c.org)**.
+1. **Read the CS&S invoicing instructions**. CS&S [has instructions to invoice here](https://www.codeforsociety.org/resources/getting-paid-by-css).
+   This is what you'll follow.
+2. **Prepare an invoice**. If you do not have one, [here is a template to get you started](https://docs.google.com/document/d/17aTwJkmYFXwqHa2QjYsy81hEXq64yfmo5g1SCGE6aK4/edit?usp=sharing).
+3. **Confirm your grant code**. You will need to supply a **grant code** for your invoice.
+   See [](reimburse:grant-code).
+4. **Send it to [`bills@codeforsociety.org`](mailto:bills@codeforsociety.org) and [`admin@2i2c.org`](mailto:admin@2i2c.org)**.
    These are both organizational accounts to track the invoices and ensure visibility across the organization.
-4. **Do not hesitate to ask about the status of your invoice**.
+5. **Do not hesitate to ask about the status of your invoice**.
    The above steps should be all you need to do, but do not hesitate to reach out again if things seem to be going slow.

--- a/administration/reimburse.md
+++ b/administration/reimburse.md
@@ -1,5 +1,5 @@
 (admin:reimbursement)=
-# Reimbursements with Ramp
+# Reimbursements and Ramp
 
 Our fiscal sponsor, {term}`CS&S`, use [a service called Ramp](https://ramp.com/) to handle all of our project billing and connect it with our grants.
 
@@ -10,63 +10,9 @@ We have an [organizational credit card](admin:credit-card) to purchase things di
 To do this, contact the {role}`Executive Director` or the {role}`Partnerships Lead`.
 :::
 
-## Reimbursement process
-
 We do all of our reimbursements via our fiscal sponsor, {term}`CS&S`.
 There is a different process for employees vs. contractors, see below for more details.
 
-```{contents}
-:local:
-```
-
-(reimbursements:employees)=
-### Reimbursement for employees
-
-If you're an employee, you can request a reimbursement via an invoice.
-To do so, [follow the CS&S reimbursement guide](https://www.codeforsociety.org/resources/getting-paid-by-css).
-
-There are two fields that are project-specific:
-
-- **project**: is `2i2c`.
-- **grant code**: See [](reimburse:grant-code).
-
-(reimbursements:invoice-template)=
-#### Invoice template
-
-[Here is an invoice template](https://docs.google.com/document/d/17aTwJkmYFXwqHa2QjYsy81hEXq64yfmo5g1SCGE6aK4/edit?usp=sharing) that you can copy and modify.
-It is designed for a contractor, so some fields may not be correct.
-Make the modifications needed to include the information requested in the CS&S link above.
-
-(reimbursements:contractors)=
-### Reimbursement for contractors
-
-To reimburse expenses as a contractor, **submit a separate line item on your monthly invoice**, called `Reimbursement - <item>`.
-[Here's an invoice template](reimbursements:invoice-template) you can re-use.
-
-:::{admonition} This must be written into your contract
-We need to include the following language in your contract to make this legal:
-
-> Expenses: Organization agrees to reimburse Independent Contractor for all expenses reasonably incurred in the performance of the Engagement and approved by Organization in advance, upon presentation of supporting receipts and documentation.
-:::
-
-(reimburse:grant-code)=
-## What is my grant code?
-
-Most reimbursements require a **grant code**.
-Each team member is paid from one or more grants so this helps CS&S know which account to draw from.
-The {role}`Executive Director` is the final say on which grant code is paying a given team member, but generally it is the same grant paying you over time.
-
-To find a list of grant codes:
-
-- Locate [our latest monthly account statement from CS&S](accounting:statements).
-- See the `Income Statement (Profit and Loss)` tab.
-- In the `Account` row, each item is a grant, it has the form:
-
-  ```none
-  MMM YYYY-MMM YYYY PROJECTNAME: GRANTCODE
-  ```
-
-  You want the value of `GRANTCODE`.
 
 ## What can be reimbursed?
 
@@ -84,8 +30,28 @@ Currently, these are the expenses that we regularly reimburse:
 - Personal development / training for skills that are directly related to team responsibilities.
 - Infrequent equipment purchases for team members (computers, desks, etc) provided they are within a reasonable spend amount.
 
-## How to approve transactions in Ramp
+(reimbursements:employees)=
+## Reimbursement for employees
 
+If you're an employee, you can request a reimbursement via an invoice.
+To do so, see [](invoices.md).
+
+(reimbursements:contractors)=
+## Reimbursement for contractors
+
+To reimburse expenses as a contractor, **submit a separate line item on your monthly invoice**, called `Reimbursement - <item>`.
+
+See [](invoices.md) for instructions on how to submit an invoice.
+
+:::{admonition} This must be written into your contract
+We need to include the following language in your contract to make this legal:
+
+> Expenses: Organization agrees to reimburse Independent Contractor for all expenses reasonably incurred in the performance of the Engagement and approved by Organization in advance, upon presentation of supporting receipts and documentation.
+:::
+
+## Reimbursement for our 2i2c credit card
+
+If you purchase something with our 2i2c credit card, the transaction will show up in Ramp.
 Someone with **Administrator privileges** in [our Ramp account](https://app.ramp.com/business-overview) must approve any transactions that are made with Ramp.
 Here is the process that we follow for this:
 
@@ -93,7 +59,7 @@ Here is the process that we follow for this:
 2. If it is empty, then there's nothing to do!
 3. If it has items for Review, click on each one and follow the prompts to include any important missing information.
 
-## Send receipts to Ramp via e-mail
+### Send receipts to Ramp via e-mail
 
 Ramp has the ability to **automatically scan receipts via e-mail and attach them to purchases**.
 This can drastically speed up the process of approving recurring transactions.


### PR DESCRIPTION
This adds some basic instructions for sending invoices to CS&S, including the admin addresses to cc on the invoice.

cc @consideRatio - would this have been enough information for you? Or perhaps we should link out to the CS&S invoicing docs too?