### PR TITLE
Only execute gen_support_stewards.py file when we are in an RTD build

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 from subprocess import run
 
@@ -91,9 +92,12 @@ def setup(app):
     app.add_crossref_type("team", "team")
 
 # -- Generate table of Support Stewards --------------------------------------
-
-path_script = Path(__file__).parent / "_data/support_stewards/gen_support_stewards.py"
-run(f"python {path_script}", shell=True)
+# This script requires the use of a token that is stored in the ReadTheDocs
+# environment. Hence let's only execute it if we are in an RTD build
+READTHEDOCS = os.environ.get("READTHEDOCS", False)
+if READTHEDOCS:
+    path_script = Path(__file__).parent / "_data/support_stewards/gen_support_stewards.py"
+    run(f"python {path_script}", shell=True)
 
 # -- Options for the rediraffe extension -------------------------------------
 # ref: https://github.com/wpilibsuite/sphinxext-rediraffe#readme


### PR DESCRIPTION
The script uses a token that is available in the build context, but might not be locally. We inspect the `READTHEDOCS` env var to determine whether we are building on the RTD platform or not, and hence whether the desired token will be present.