### PR TITLE
Add mastodon account

### DIFF
--- a/.github/ISSUE_TEMPLATE/blog-post.md
+++ b/.github/ISSUE_TEMPLATE/blog-post.md
@@ -19,5 +19,5 @@ title: "[blog] POST WORKING TITLE"
 - [ ] Post draft: {LINK} <!-- add a link to a URL when ready -->
 - [ ] Blog location: {LINK} <!-- E.g., the 2i2c blog or the Jupyter Blog -->
 - [ ] Publish to blog
-- [ ] Send out tweets and LinkedIn
-- [ ] Send to 2i2c listserv (optional)
+- [ ] Post on social media ([Twitter](https://twitter.com/2i2c_org), [Mastodon](https://hachyderm.io/@2i2c_org), and [LinkedIn](https://www.linkedin.com/company/2i2c-org/))
+- [ ] Send to 2i2c listserv (optional, generally this is for major updates)

--- a/.github/ISSUE_TEMPLATE/new-team-member.md
+++ b/.github/ISSUE_TEMPLATE/new-team-member.md
@@ -42,7 +42,7 @@ Follow the checklist below to onboard a new team member!
 **External**
 
 - [ ] Add to [2i2c website](https://2i2c.org/organization/)
-- [ ] Tweet about their arrival!
+- [ ] Mention their arrival on social media! (Twitter, Mastodon, LinkedIn)
 
 **Wrap up**
 

--- a/communication/blog.md
+++ b/communication/blog.md
@@ -24,21 +24,12 @@ Here are a few ideas for blog post topics for inspiration:
 - **Updates from the Managed JupyterHub Serivce**. As hub service infrastructure grows and evolves, and as we serve more communities with it, we should tell others about the impact we are having.
 - **Topic dives**. There may be particular topics that we want to write about, like open culture, cloud optimization, etc. These will help us crystallize our thoughts, demonstrate expertise, and share knowledge with others.
 
-
 ## Blog post checklist
 
-Here's a blog-post checklist to help us keep track of the major actions needed to publish a new post.
-Open an issue about your post and copy/paste this checklist into it.
+We have a blog post checklist that helps keep track of the major actions needed to post something and share it.
+Click the button below to find it.
 
-```
-- [ ] Write draft of blog post in markdown
-- [ ] Open a PR to the 2i2c.github.io repository and ask for feedback
-- [ ] Publish the post
-- [ ] Send out a series of tweets from the `2i2c_org` account that summarizes the post.
-- [ ] Tell the team about it and re-tweet!
-- [ ] Decide if this post is worthy for a mailing list update
-- [ ] If so, go to mailchimp.com and create a new email campain
-- [ ] Copy the post's content, paste it into the mailchimp interface
-- [ ] Send off the mailchimp campain
-- [ ] You're done! 🎉
+```{button-link} https://github.com/2i2c-org/team-compass/issues/new?assignees=&labels=%3Alabel%3A+blog-post&template=blog-post.md&title=%5Bblog%5D+POST+WORKING+TITLE
+
+Blog post issue template
 ```

--- a/communication/social.md
+++ b/communication/social.md
@@ -21,10 +21,20 @@ We just have not had the resources to plan for this kind of engagement.
 
 Our Twitter handle is ([@2i2c_org](https://twitter.com/2i2c_org)).
 Currently, there is nobody activately monitoring the Twitter account.
+If you'd like to use it please ask the team for access.
 
 **How to access**: We access this account via a shared `username`/`password`.
 If you'd like access, ask the {role}`Executive Director` or somebody else with access.
 It is possible to have [multi-user access to Twitter accounts via TweetDeck](https://twitter.com/settings/teams) but we have not yet set this up.
+
+## Mastodon
+
+Our Mastodon handle is (<a rel="me" href="https://hachyderm.io/@2i2c_org">@2i2c_org</a>).
+Currently, there is nobody actively monitoring the Mastodon account.
+If you'd like to use it please ask the team for access.
+
+**How to access**: We access this account via a shared `username`/`password`.
+If you'd like access, ask the {role}`Executive Director` or somebody else with access.
 
 ## LinkedIn
 

--- a/partnerships/workflow.md
+++ b/partnerships/workflow.md
@@ -77,14 +77,14 @@ A member of the 2i2c Partnerships Team sends an email to partnerships@2i2c.org r
 
 
 1. Send Canned Response "Hail the Lead" from FreshDesk to contact email(s):
-Start Email text:  
-Hello!
+   ```
+   Hello!
 
-Thank you for your interest in learning more about 2i2c. Please find a service description with pricing information attached to this email. If you have questions or wish to connect for a conversation, reach out to us by email using partnerships@2i2c.org or [schedule a virtual meeting by clicking here](https://calendly.com/colliand/25-minute-zoom-meeting). 
+   Thank you for your interest in learning more about 2i2c. Please find a service description with pricing information attached to this email. If you have questions or wish to connect for a conversation, reach out to us by email using partnerships@2i2c.org or [schedule a virtual meeting by clicking here](https://calendly.com/colliand/25-minute-zoom-meeting). 
 
-Best regards, 
-2i2c's Partnerships Team
-End Email text.
+   Best regards, 
+   2i2c's Partnerships Team
+   ```
 2. Change `From` field to `partnerships@2i2c.org`.
 3. Add cc: partnerships@2i2c.org
 4. Confirm that service description has been automatically attached


### PR DESCRIPTION
Documents our mastodon account. Also replaces "tweet" with "post to social media". While I was at it, I realized that we had two different blog post checklists (way to go Chris). So this also unifies them into a single issue template.

(also fixes up some whitespace bug that was in the partnerships page)