### PR TITLE
Add engineering manager role

### DIFF
--- a/engineering/roles/engineering-manager.md
+++ b/engineering/roles/engineering-manager.md
@@ -1,0 +1,88 @@
+```{role} Engineering Manager
+```
+
+# Engineering Manager
+
+The Engineering Manager is responsible for ensuring that our engineering team has clear direction in their work and personal development, and are able to thrive according to their goals. They are responsible for creating a team culture and a system of roles and processes that makes our team successful, and allows our team members to thrive. This role jointly leads our engineering team along with our _tech lead_.
+
+## How it fits into our organizational structure
+
+Reports to the Executive Director. Members of the engineering team report to this person. Co-leads strategy and policy of the engineering team alongside the Tech Lead. Co-leads organizational priorities alongside other group leads.
+
+## Key responsibilities
+
+### Strategy, policy, and priorities for our cloud engineering team
+
+- Set strategic objectives and major priorities in partnership with our Tech Lead and our engineering team.
+- Advocate for the needs and goals of our engineering team in defining organizational and engineering goals, in partnership with the Executive Director and other group leads.
+
+### Site Reliability Engineering team practices
+
+- Foster a team culture that is inclusive, equitable, and remote-first.
+- Foster and participate in systems for feedback to team members, other group leaders, and our executive director to help them improve and embody our organizational values.
+- Define team processes and structures for monitoring our cloud infrastructure, continually improving it, and resolving incidents.
+- Ensure that our team processes lead to a scalable, reliable service that minimizes toil.
+- Ensure an equitable balance of development and operations work across the team to minimize burnout.
+
+### Our system of work
+
+- Provide guidance and support to team members to prioritize their work
+- Design systems of accountability that allow our team members to rely on one another and accomplish team goals.
+- Help team members translate our strategic priorities and objectives into actionable work items.
+- Provide medium- and long-term visibility over our strategic goals and whether we are on track for meeting them.
+
+### Mentorship and career development
+
+- Help our team members grow their skills and experience according to their interests and our team’s needs.
+- Provide a balance of oversight and autonomy to team members.
+- Run the performance review process for our engineers
+- Recommend and advocate for training and personal development opportunities
+
+## Useful qualities to have
+
+### You are an experienced engineering leader
+
+You have experience managing engineering teams, preferably experience with managing multiple engineering teams. You lead by example and empathy, understand the business and how to prioritize project work, emphasize mentorship, and create an environment of learning. You encourage diversity of ideas and know that the team is collectively stronger than any individual.
+
+### You are an effective team builder
+
+You know how to hire, train, and develop Site Reliability Engineers and operations leaders from all backgrounds. You understand the benefits of building a diverse and inclusive team. You value teamwork and believe in helping others feel safe to grow and develop. You help your teams get better at what they do, and you don’t need to be in the same room to help them succeed.
+
+### You can keep track of, prioritize, and manage multiple projects
+
+We're a growing team, and there's no shortage of things you could be doing in a day. You'll carve out time for functional projects and ensure the engineers on your teams solve issues that matter -- making our cloud infrastructure more efficient and agile, building a culture of reliability, and delivering outstanding service to the communities that we serve.
+
+### You have excellent communication skills
+
+You understand and appreciate what your stakeholders need and you can speak their language. You’ll regularly work with our Product, Community Guidance, and Partnerships teams, balancing engineering concerns (such as technical debt) with product and service concerns. Not only do you know how to share your knowledge with the team and write asynchronously-consumable documentation, but you know how to communicate your vision effectively with software and support teams.
+
+### You have a background in Site Reliability Engineering
+
+You’re comfortable talking about SLOs, incident management, and building a culture of reliability. You have empathy for the communities we serve and are eager to make improvements for them. You seek to reduce toil and understand what it means to take a software engineering approach to operations.
+
+### You know the cloud
+
+You’ve designed and maintained highly available, cloud-based infrastructures in AWS or another cloud offering. You understand how to leverage infrastructure-as-code tools and have experience implementing best practices for reliability and observability.  We currently use Terraform, Kubernetes, GitHub, and JupyterHub.
+
+### You have experience with open source communities
+
+You’ve worked in one or more multi-stakeholder community-driven open source projects. You understand the challenges and messiness that often comes with open communities, you have experience contributing to them, and an interest in growing a team that does most of its work via upstream contributions. While 2i2c does not directly manage any open source communities, it aims to be an active participant in many, and upstreaming improvements to open source projects is a core part of our workflow.
+
+### You value our values
+
+2i2c is a mission-driven organization defined by [our values and principles](https://2i2c.org/about/). You see how these values can empower meaningful work, thrive in a collaborative setting, and are eager to continue growing excited to be part of the team.
+
+## Salary rationale
+
+We are currently discussing our salary bands and levels [as per this proposal](https://github.com/2i2c-org/meta/issues/402#issuecomment-1419224044). According to that proposal (most likely to be implemented and already a reference for recent hires), the base salary associated with a Engineer Manager role (level 4) is $**151,200**.
+
+## References
+
+- [A collection of engineering manager role descriptions from several tech companies](https://docs.google.com/document/d/1V3qfl0WlSlzq557mf9jqBNINuWRGw-nkgpFnpKibSOo/edit#).
+- Blog post about deciding when to become an engineering manager: [blog post PDF](https://drive.google.com/file/d/1bSOEVBpYzdVvfEiWrmkqxrlu32kcaagW/view?usp=sharing) ([original blog link](https://charity.wtf/2019/01/04/engineering-management-the-pendulum-or-the-ladder/?utm_source=pocket_mylist)).
+- [The Venn Diagram of Team Leaders](https://larahogan.me/blog/team-leader-venn-diagram/).
+- Documentation about SRE management: [Google SRE Management Chapter](https://sre.google/sre-book/part-IV-management/).
+
+## Acknowledgements
+
+Many thanks to **Madhu Viswanathan** and **Emma F** for providing feedback and suggestions about the overall structure and wording of this role description and our processes around hiring. Much of the language above was inspired from Zapier’s Site Reliability Engineering descriptions.

--- a/engineering/structure.md
+++ b/engineering/structure.md
@@ -40,16 +40,11 @@ Our **Project Manager** ensures that we have an efficient system for coordinatin
 (engineering:roles)=
 ## Team roles
 
-```{role} Engineering Manager
+```{toctree}
+:glob:
+:maxdepth: 2
+roles/*
 ```
-
-### Engineering Manager
-
-:::{note}
-This role is a work-in-progress,
-:::
-
-Responsible for overseeing our engineering team, ensuring that it is operating in an effective and equitable manner, and ensuring that each team member's work is aligned with their goals and interests.
 
 This role is currently un-filled.
 


### PR DESCRIPTION
Over the last few months we have been iterating on an **Engineering Manager role description**. This is a role that oversees our engineering team and the systems of support and work around that team.

We've had several iterations on a Google Doc, and had a few +1's from folks on the language. This PR adds it to our Team Compass so that we can formalize the role.

### Feedback

- We've already had a lot of iteration on this, so please provide focused feedback with specific things to change, rather than really large / broad changes.
- If you object to anything, or think anything crucial is missing, please say so.
- Note that this is still a first iteration, and we can continue to refine this role and its description once we have somebody serving in it.

### References

- closes #514 
- note that we'll still need to #656 