### PR TITLE
Change to dirhtml builder

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,6 +12,7 @@ build:
 
 sphinx:
   configuration: conf.py
+  builder: dirhtml
 
 python:
   install:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To do so, follow these steps:
    $ nox -s docs
    ```
 
-This should create a local environment in a `.nox` folder, build the documentation (as specified in the `noxfile.py` configuration), and the output will be in `_build/html`.
+This should create a local environment in a `.nox` folder, build the documentation (as specified in the `noxfile.py` configuration), and the output will be in `_build/dirhtml`.
 
 To build live documentation that updates when you update local files, run the following command:
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -2,7 +2,7 @@ import nox
 
 nox.options.reuse_existing_virtualenvs = True
 
-build_command = ["-b", "html", ".", "_build/html"]
+build_command = ["-b", "dirhtml", ".", "_build/dirhtml"]
 
 
 @nox.session

--- a/reference/documentation/environment.md
+++ b/reference/documentation/environment.md
@@ -82,7 +82,7 @@ This differs slightly depending on the repository, but it usually works like thi
 3. **Build the documentation with Sphinx**. Finally, you can build the documentation locally with Sphinx using a command like so:
 
    ```shell
-   sphinx-build docs docs/_build/html
+   sphinx-build -b dirhtml docs docs/_build/dirhtml
    ```
 
 See [the Sphinx documentation](https://www.sphinx-doc.org/en/master/) for more details.


### PR DESCRIPTION
This updates to the `dirhtml` builder so that URLs no longer have `.html` at the end of them.