### PR TITLE
Support process lead by Engineering.

### DIFF
--- a/projects/managed-hubs/support.md
+++ b/projects/managed-hubs/support.md
@@ -9,6 +9,8 @@ The content on this page might change over time, and we welcome suggested change
 
 This section contains information that our team uses to triage, communicate, and resolve {term}`Support Requests` that come from communities.
 
+Currently, Engineering has the authority to design the system of roles and processes that defines "support at 2i2c", and to advocate for the resources needed to fill those roles. This will naturally be done in collaboration with others in 2i2c, but Engineering leads the effort and has an outsized role in the decision-making.
+
 (support:process)=
 ## Overview of the support process
 


### PR DESCRIPTION
This change actually documents in our team compass the agreement we achieved as described in https://github.com/2i2c-org/team-compass/issues/655.