### PR TITLE
Update open source strategy to include more upstream

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -47,7 +47,6 @@ html_theme_options = {
     "repository_branch": "main",
     "use_repository_button": True,
     "use_edit_page_button": True,
-    "extra_navbar": "",
 }
 myst_enable_extensions = [
     "colon_fence",

--- a/open-source/key-communities.md
+++ b/open-source/key-communities.md
@@ -3,6 +3,11 @@
 Key open source communities are those that align with 2i2c's values and that are central to 2i2c's mission.
 They build technology that is essential for the infrastructure that 2i2c offers.
 
+```{admonition} This is not exclusive!
+Team members are encouraged to make upstream contributions to communities other than those listed here.
+This section just describes the communities to which we devote extra resources and time.
+```
+
 ## Ways to support key communities
 
 While we try to make upstream contributions wherever we can, we make extra effort to support key communities.

--- a/open-source/strategy.md
+++ b/open-source/strategy.md
@@ -11,7 +11,7 @@ We know this will take extra effort from us - doing things on your own is faster
 
 ## Upstream work can't be done on nights and weekends
 
-Doing work in upstream communities is central to our work, and is treated as "on the clock".
+Doing work in upstream open source communities is central to our work, and is treated as "on the clock".
 Our sustainability strategy should aim to make these upstream contributions a realistic and sustainable part of our daily activities.
 However, be mindful of the time you're spending in upstream spaces, and talk to other team members to make sure you aren't putting too much burden on them.
 

--- a/open-source/strategy.md
+++ b/open-source/strategy.md
@@ -6,19 +6,19 @@ For policies related to funding, see [](funding.md).
 ## Upstream first
 
 Whenever possible, we should improve our own infrastructure via _upstream contributions_ to communities where we are not the sole stakeholder.
-We should prioritize [key communities](key-communities.md) and those that [align with our values](organization:values).
+We should prioritize [key communities](key-communities.md) and upstream communities that [align with our values](organization:values).
 We know this will take extra effort from us - doing things on your own is faster, but doing them together with open source communities leads to a healthier and more sustianable ecosystem.
 
 ## Upstream work can't be done on nights and weekends
 
-Doing work in upstream communities is central to our work, and work done with [key communities](key-communities.md) is treated as "on the clock".
+Doing work in upstream communities is central to our work, and is treated as "on the clock".
 Our sustainability strategy should aim to make these upstream contributions a realistic and sustainable part of our daily activities.
 However, be mindful of the time you're spending in upstream spaces, and talk to other team members to make sure you aren't putting too much burden on them.
 
 A good balance to shoot for is:
 
 - **80%**: Focus on 2i2c's mission, with an "upstream first" mentality. You can take whatever time you need to make upstream changes that serve 2i2c's interests in an inclusive way.
-- **20%**: Upstream-driven contributions. The work you do in upstream communities does not need to be driven by 2i2c's interests or strategy. Spend your time in the way you wany to have the most impact.
+- **20%**: Upstream-driven contributions. The work you do in upstream communities does not need to be driven by 2i2c's interests or strategy, though these communities should be related in some way to our work. Spend your time in the way you want to have the most impact.
 
 ## Center the community's strategy and mission
 
@@ -26,6 +26,7 @@ We wear multiple hats when working with upstream communities.
 While 2i2c's mission and strategy aim to support open communities, they are still independent entities with their own goals.
 We should recognize these differences between 2i2c and upstream communities, and be a model for how to balance the two in a healthy way.
 Our upstream contributions should center the needs of upstream communities over those of our own.
+For example, spend extra time "chopping wood and carrying water" like issue triage, bug fixes, or release maintenance.
 Be aware of potential conflicts of interests with your 2i2c hat on, and hold yourself (and others) accountable for acting in a community's best interests.
 
 ## Decisions should be made with the community, not us alone
@@ -46,7 +47,7 @@ We should use this position to make it _easier_ for those outside of 2i2c to gai
 We recognize that **2i2c is not the same thing as any open source community**, and we should avoid overpowering community dynamics just because we have access to resources.
 Our goal is to contribute and support, not to dominate.
 
-## Healthy need more than just technology
+## Make more than just technical contributions
 
 We prioritize work that builds a healthy, inclusive culture in upstream communities, not just getting in technical improvements that we need for our infrastructure.
 Look for leverage points to make a community healthier overall, not just for 2i2c's technical interests.

--- a/people/compensation.md
+++ b/people/compensation.md
@@ -7,7 +7,7 @@ We are a young organization, and this page describes the salary policy that we a
 It may not accurately reflect our current practices, but we share it for transparency and to provide a goal for our team to shoot for.
 :::
 
-:::{admonition}
+:::{note}
 We are working on an update of our existing compensation policy. More details about the upcoming changes will be updated here as soon we reach consensus and approval for the new policy.
 :::
 


### PR DESCRIPTION
This is an iterative update to our open source strategy documents with the following goals:

- Reduce ambiguity about whether non key-community contributions are still encouraged (they are!)
- Clarify language in a few places
- Add an example of what "community driven contributions" might look like (after feedback from an external stakeholder)

It also fixes a few Sphinx bugs that popped up in another section.