### PR TITLE
Be more specific about agendas for meetings

### DIFF
--- a/operations/meetings.md
+++ b/operations/meetings.md
@@ -17,16 +17,20 @@ As a distributed team, we pay a high coordination penalty for getting multiple p
   These must be made available to the team reasonably soon after the meeting.
 
 - **Meeting agendas must be available at least 36 hours (not counting weekends) ahead**.
-  Agendas should:
-  1. List any specific **decisions** people want to make progress on during the meeting.
-  2. Provide ideas for topics of possible discussion.
+  Agendas should list:
+  1. Any **questions** that people wish to discuss and answer during the meeting.
+  2. Any **decisions** people want to make progress on during the meeting, and where the final decision will be made.
+  3. Any **topics** to discuss in the meeting, with enough detail to help others decide if they wish to participate.
 
   Agendas should be concrete enough that people who can not be synchronously
   present can make comments on it, as well as make choices on whether they
   would like to attend or not.
+  Provide links to the **source of truth for discussion**, as well as any context needed to meaningfully participate.
 
-  If a meeting does not have an agenda 36 hours (not counting weekends) in
-  advance, then team members may assume it is cancelled and rescheduled.
+  **If there's not an agenda 36 hours before, assume the meeting is cancelled**.
+  Meeting facilitators are responsible for collecting potential agenda items from others ahead of time, and setting the meeting agenda 36 hours prior to the meeting start.
+  If there is no agenda at this point, the meeting should be deemed as cancelled.
+  The meeting facilitator should inform the team and delete the calendar event.
 
 - **Focus time on resolving uncertainty and making decisions**.
   Avoid the tendency to use meetings for updates - we should use asynchronous team processes (discussion in issues, Geekbot standups, etc) for sharing what we are up to day-to-day.

--- a/operations/meetings.md
+++ b/operations/meetings.md
@@ -22,7 +22,7 @@ As a distributed team, we pay a high coordination penalty for getting multiple p
   2. Provide ideas for topics of possible discussion.
 
   Agendas should be concrete enough that people who can not be synchronously
-  present can make comments on it, as well as make choices on wether they
+  present can make comments on it, as well as make choices on whether they
   would like to attend or not.
 
   If a meeting does not have an agenda 36 hours (not counting weekends) in

--- a/operations/meetings.md
+++ b/operations/meetings.md
@@ -15,9 +15,19 @@ As a distributed team, we pay a high coordination penalty for getting multiple p
 - **Take notes and make them accessible**.
   Meetings must have written notes that are accessible to others on the team.
   These must be made available to the team reasonably soon after the meeting.
-- **Meeting agendas must be available at least one working day ahead**.
-  Agendas should provide an idea for the topics of discussion and any major questions to resolve.
-  If a meeting does not have an agenda at least one working day in advance, then team members may assume it is cancelled.
+
+- **Meeting agendas must be available at least 36 hours (not counting weekends) ahead**.
+  Agendas should:
+  1. List any specific **decisions** people want to make progress on during the meeting.
+  2. Provide ideas for topics of possible discussion.
+
+  Agendas should be concrete enough that people who can not be synchronously
+  present can make comments on it, as well as make choices on wether they
+  would like to attend or not.
+
+  If a meeting does not have an agenda 36 hours (not counting weekends) in
+  advance, then team members may assume it is cancelled and rescheduled.
+
 - **Focus time on resolving uncertainty and making decisions**.
   Avoid the tendency to use meetings for updates - we should use asynchronous team processes (discussion in issues, Geekbot standups, etc) for sharing what we are up to day-to-day.
 

--- a/operations/meetings.md
+++ b/operations/meetings.md
@@ -27,10 +27,9 @@ As a distributed team, we pay a high coordination penalty for getting multiple p
   would like to attend or not.
   Provide links to the **source of truth for discussion**, as well as any context needed to meaningfully participate.
 
-  **If there's not an agenda 36 hours before, assume the meeting is cancelled**.
-  Meeting facilitators are responsible for collecting potential agenda items from others ahead of time, and setting the meeting agenda 36 hours prior to the meeting start.
-  If there is no agenda at this point, the meeting should be deemed as cancelled.
-  The meeting facilitator should inform the team and delete the calendar event.
+- **If there's not an agenda 36 hours before, the facilitator should cancel the meeting**.
+  Meeting facilitators should collect _potential_ agenda items from others ahead of time, and _set_ the agenda at least 36 hours prior to the meeting start.
+  If there is no set agenda at this time, facilitator should inform the team in Slack and delete the calendar event.
 
 - **Focus time on resolving uncertainty and making decisions**.
   Avoid the tendency to use meetings for updates - we should use asynchronous team processes (discussion in issues, Geekbot standups, etc) for sharing what we are up to day-to-day.


### PR DESCRIPTION
- Specify the amount of time in hours, rather than the more nebulous 'working day'. I think 36h without counting weekends should count for most TZ drift
- Provide slightly more detail on what shape the agenda should be in.