### PR TITLE
Add link to presentations folder

### DIFF
--- a/communication/publishing.md
+++ b/communication/publishing.md
@@ -3,6 +3,7 @@
 We occasionally publish outputs with Digital Object Identifiers so that they can be more easily indexed, discovered, and referenced by others in the scholarly community.
 This page describes information about this process.
 
+(publishing:zenodo)=
 ## Zenodo
 
 We use [Zenodo](https://zenodo.org/) for minting DOIs and publishing outputs.

--- a/communication/talks.md
+++ b/communication/talks.md
@@ -1,4 +1,12 @@
-# Talks and conferences
+# Talks, presentations, and conferences
+
+## Shared folder for slides and presentations
+
+We have a [shared folder with slides in our team drive](https://drive.google.com/drive/folders/1unn_3l2wMKuwlhSPqK1xcUu6kmqwoXun?usp=share_link).
+Its goal is to provide content that other team members can re-use and share with others.
+Team members are encouraged to add slides to this folder over time!
+
+If you publish your talk on Zenodo, please add it to [our Zenodo community](publishing:zenodo).
 
 ## When to give talks
 


### PR DESCRIPTION
This documents the folder we've used to store presentation decks about 2i2c, and also adds a cross-link to our zenodo community docs.

closes https://github.com/2i2c-org/team-compass/issues/692