### PR TITLE
Clarify credit card numbers

### DIFF
--- a/finance/payments.md
+++ b/finance/payments.md
@@ -6,13 +6,24 @@ This section describes them.
 (admin:credit-card)=
 ## Credit cards
 
-We have two Ramp credit cards:
-
-- one that is designed specifically to reimburse cloud costs
-- another that is for general purposes.
-
-We pay for the majority of our organizational expenses via one of these processes.
-See [](admin:reimbursement) for our reimbursement processes.
+We have two Ramp credit cards.
 
 **Chris Holdgraf** has the credit card information for these cards.
 Ask him if you need to use them.
+
+```{seealso}
+See [](admin:reimbursement) for our reimbursement processes.
+```
+
+### General purpose card
+
+Ends in `4164`.
+
+This is used for most purchases by 2i2c, including recurring service payments, travel payments on behalf of team members, etc.
+
+### Cloud credits card
+
+Ends in `7770`.
+
+Used only for paying cloud providers (GCP, AWS, and Azure) for cloud costs.
+We generally intend to re-imburse ourselves via invoices to communities for any cost charged to this credit card.


### PR DESCRIPTION
In Slack @yuvipanda asked a question about whether a credit card associated with AWS was 2i2c's or my personal card. This PR clarifies our two credit cards and adds the final four digits of each for reference.