### PR TITLE
Update airtable documentation for contracts and invoices

### DIFF
--- a/finance/accounting-statement-overview.md
+++ b/finance/accounting-statement-overview.md
@@ -1,6 +1,6 @@
 
 (accounting:statements-summary)=
-# Understanding CS&S accounting statements
+# Overview of CS&S accounting reports
 
 This section describes how to read
 

--- a/finance/accounting.md
+++ b/finance/accounting.md
@@ -1,26 +1,55 @@
 # Accounting data
 
 Accounting data describes the money that we **know** we have spent or that we **highly expect** to receive.
-There are a few kinds of accounting data we have access to:
 
-All 2i2c-specific accounting documents should be accessible on our Team Drive to anybody with a `@2i2c.org` address.
-We don't control the access conditions for the CS&S documents described below, so if you don't have access to these, ask the {role}`Executive Director`.
+## Accounting transactions airtable
 
-We split our financial and accounting data between two places:
+{term}`CS&S` provides us a monthly dataset of the last 6 months of all of all our accounting transactions.
+This is [in a Google Sheet that is automatically updated each day][gsheet].
+It includes the last 6 months of any transaction 2i2c has made (if we need more than 6 months of history, ask `fsp@2i2c.org` for a custom data dump).
 
-- [2i2c Drive Folder with our finance assets](https://drive.google.com/drive/folders/1D5NQKhPDP6zMQ8EdLcMOceTz-ek81nmX?usp=sharing) contains 2i2c-specific budgeting and modeling information. It is available to all team members.
+We have a copy of this sheet in an [**Accounting Transactions AirTable**][accounting-table][^airtable].
+Any columns that are synchronized with CS&S have a little lightning bolt (⚡) next to them.
+We use this to create [our accounting dashboard](accounting:dashboard).
 
-- [CS&S Drive Folder with their finance assets](https://drive.google.com/drive/folders/115EIa6cD4BNGIqOd2i7Rqu3MgsM73lgR?usp=sharing) contains assets that are stewarded by CS&S. It is available to 2i2c'c executive director.
+[^airtable]: See [](../administration/airtable.md) for how to access AirTable.
 
-See these subsections below for more information about accounting data.
+[gsheet]: https://docs.google.com/spreadsheets/d/1qH5IK18z79X8cEwlwDwnlArTiYnbRVIPGqdOUdrsF0c/edit?usp=sharing
 
+[accounting-table]: https://airtable.com/appbjBTRIbgRiElkr/tblDKGQFU0iEIa5Qb/viwAdsIgMwbqKDdZ0
+
+### Update our accounting data airtable
+
+We have a semi-automated process to update the data in our accounting table.
+Here are the steps to follow:
+
+% TODO: We should automate this with a CRON job, make.com/zapier integration, etc.
+%   ref: https://github.com/2i2c-org/team-compass/issues/703
+1. **Confirm that [the Google Sheet][gsheet] has been updated** by checking the `Automatic Operations Events Log` tab.
+2. **Delete all of the records** in the [accounting table][accounting-table].
+3. **Import the google sheets data**. Go to `Accounting Transactions` -> `Import Data` -> `Google Sheets` -> `Google sheets account`.
+   - Here's an image of the menu you want:
+
+     ![image](https://user-images.githubusercontent.com/1839645/230121196-0d398812-ba22-4cea-a42f-e3ad644a3e19.png)
+   - You'll see a list of Google Sheets in our account. Import the one titled `2i2c FYE23 Account Transactions - Auto Generated`.
+   - Check the `Skip first row` option during the import, so that we don't import the section title names.
+
+This should automatically import the data into the proper columns, you don't need to do anything else.
+
+When this action happens, an [AirTable automation will run](https://airtable.com/appbjBTRIbgRiElkr/wflVJQz277S6lF0E3/wtrHzwIWJLGTnJl0m) and attempt to link each new record with a corresponding **Contract**, using the `Xero ID` field.
+If a contract with the record's `Xero ID` is found, then a linked record will be created in the `Contracts` column.
+
+Here's a brief video describing the above process.
+
+```{video} https://drive.google.com/file/d/1eLHQ15sHF4ihCpEIAypjYUeof9q3CYYQ/view?usp=sharing
+```
 
 (accounting:statements)=
-## All transactions
+## Monthly reports
 
-{term}`CS&S` provides us a monthly table of all our accounting transactions.
-They are placed in the Shared CS&S Google Drive folder.
-**The CS&S accounting tables are the source of truth for our revenue and costs.**
+CS&S generates monthly reports for our current financial situation.
+You can find them in [our financial reports folder](https://drive.google.com/drive/folders/1vM_QX1J8GW5z8W5WemxhhVjcCS2kEovN?usp=sharing).
+
 See [](accounting-statement-overview.md) for more information about these sheets.
 
 ```{toctree}
@@ -28,25 +57,12 @@ See [](accounting-statement-overview.md) for more information about these sheets
 accounting-statement-overview.md
 ```
 
-We clean up and mirror these transactions in an [**Accounting Transactions AirTable**](https://airtable.com/appbjBTRIbgRiElkr/tblDKGQFU0iEIa5Qb/viwAdsIgMwbqKDdZ0).
-We use this to create [our accounting dashboard](accounting:dashboard).
-See [](../administration/airtable.md) for how to access AirTable.
-
-```{button-link} https://airtable.com/appbjBTRIbgRiElkr/tblDKGQFU0iEIa5Qb/viwAdsIgMwbqKDdZ0
-:color: primary
-
-All Transactions AirTable
-```
-
-
 (accounting:dashboard)=
-## Accounting summary dashboard
+## Summary dashboards
 
-We have a Sphinx page that summarizes important accounting information for us.
-It is generated from the [CS&S accounting statements](accounting:statements) that we get monthly.
-You can find this website at the following location:
+We have an [AirTable interface dashboard][airtable-dashboard] that displays several useful summaries and visualizations of our accounting data[^airtable].
 
-```{button-link} https://2i2c.org/kpis/finances/#accounting-tables
-:color: primary
-Accounting tables
-```
+We also have a [page in our KPIs website](https://2i2c.org/kpis/finances/#accounting-tables) that provides public summaries of this information for transparency to external stakeholders.
+
+[airtable-dashboard]: https://airtable.com/appbjBTRIbgRiElkr/pagbwk3T7S14rJ3tb
+

--- a/finance/contracts.md
+++ b/finance/contracts.md
@@ -4,19 +4,12 @@ A **contract** defines our formal relationship with any external organizations o
 We use **invoices** to exchange funds (incoming and outgoing) that are related to contracts.
 This section describes where you can find information about our active and past contracts and invoices.
 
-## Grant folders
-
-We use [the 2i2c Team Drive -> `Finances and Accounting -> Grants` folder](https://drive.google.com/drive/folders/1VvER_SxLDKjDYwfXYyEbPX9GN7YlsNpT?usp=sharing) to keep track of any materials related to a grant we are applying for or have received.  We use that same folder to track all of our preparations and materials for grants that we are applying for.
-
-- The [**Active and In Progress**](https://drive.google.com/drive/folders/1Mgio3WQfpXkuuy_i--ioY_9XHIff4cQe?usp=share_link) folder contains any grant that we've received, or that are in the middle of applying for.
-- The [**Rejected and Not Submitted**](https://drive.google.com/drive/folders/1BqCYoOvDrkv_f5eYbbrkP_3sHv2M6i7b?usp=share_link) folder contains any grant that we applied for and did not get, or that we started but did not finish.
-- The [**Completed**](https://drive.google.com/drive/folders/1BALUGZh2x_LsQuBSMXAfxeryeP9bMleD?usp=share_link) folder contains any grant that we received and have now completed such that no action is needed.
-
 (contracts:active)=
 ## Active contracts
 
 {term}`CS&S` tracks all of our contracts in an [AirTable](accounts:airtable).
 We synchronize this AirTable to our own in the link below, and generate [dashboards to summarize important data](contracts:dashboards).
+Any columns that are synchronized with CS&S have a little lightning bolt (⚡) next to them.
 
 This table includes both **service contracts** and **grants**.
 Each row in this table is a single contract.
@@ -29,13 +22,29 @@ There may be multiple contracts (rows) for a single community, representing diff
 Contracts AirTable
 ```
 
-### Linked `Invoices` column
+### Special columns
+
+There are a few special columns worth highlighting, they are described below.
+
+#### Custom columns
+
+There are several columns that we add on our own.
+We [show each of these columns in our `Our added columns` view](https://airtable.com/appbjBTRIbgRiElkr/tbliwB70vYg3hlkb1/viwysz1Pyu242mGdt).
+As new columns are added, please add them to this view.
+
+```{admonition} These are not sources of truth unless explicitly stated
+In many cases we add custom columns manually in order to facilitate visualization, reporting, etc.
+These may not be well-structured or documented, and may not correspond to concrete things like specific contract types.
+Unless otherwise stated, don't consider our custom airtable columns as a source of truth.
+```
+
+#### Linked `Invoices` column
 
 Each contract has a list of the invoices that have been billed against it in the **`Invoices`** column.
 This list of invoices is in the `Invoices` column.
 See below for more context on how we use this.
 
-### `Service Type` column
+#### `Service Type` column
 
 We have one custom column that we add to the CS&S data, to represent the _type of service attached to a contract_.
 For example, whether a contract is for a _research hub_ or an _educational hub_.
@@ -77,3 +86,11 @@ Each graph should also have a title and subtitle describing its meaning.
 
 Invoicing and contracts dashboard
 ```
+
+## Grant folders
+
+We use [the 2i2c Team Drive -> `Finances and Accounting -> Grants` folder](https://drive.google.com/drive/folders/1VvER_SxLDKjDYwfXYyEbPX9GN7YlsNpT?usp=sharing) to keep track of any materials related to a grant we are applying for or have received.  We use that same folder to track all of our preparations and materials for grants that we are applying for.
+
+- The [**Active and In Progress**](https://drive.google.com/drive/folders/1Mgio3WQfpXkuuy_i--ioY_9XHIff4cQe?usp=share_link) folder contains any grant that we've received, or that are in the middle of applying for.
+- The [**Rejected and Not Submitted**](https://drive.google.com/drive/folders/1BqCYoOvDrkv_f5eYbbrkP_3sHv2M6i7b?usp=share_link) folder contains any grant that we applied for and did not get, or that we started but did not finish.
+- The [**Completed**](https://drive.google.com/drive/folders/1BALUGZh2x_LsQuBSMXAfxeryeP9bMleD?usp=share_link) folder contains any grant that we received and have now completed such that no action is needed.

--- a/partnerships/workflow.md
+++ b/partnerships/workflow.md
@@ -7,11 +7,11 @@
 % - [System for leads and contacts](https://github.com/2i2c-org/leads/issues/99)
 % - [System for monthly invoicing](https://github.com/2i2c-org/team-compass/issues/355)
 
-## Standard Operating Procedures for Partnerships Business
+This page describes the **Standard Operating Procedures for Partnerships Business**.
 
 2i2c provides interactive computing services to partner communities. These notes describe standard operating procedures used by 2i2c and CS&S to establish and cultivate business relationships with partner communities. The workflows orchestrate information exchanges (meetings, emails, negotiations) between 2i2c/CS&S and partners or prospective partners and produce documents (service agreements, quotes, statements of work, renewal notices, invoices, service descriptions, receipts).  
 
-### Arc of Partnership Formation
+## Arc of Partnership Formation
 
 The procedures describe action sequences our team will carry out as expression of interest in 2i2c evolves through phases Lead --> Prospect --> Partner: 
 
@@ -19,19 +19,19 @@ The procedures describe action sequences our team will carry out as expression o
 + A qualified lead becomes a _Prospect_ after a "verbal close" `yes` to form a partnership. The _prospect phase_ involves two parallel activities: business terms of the partnership are negotiated in the service agreement and accompanying documents; technical exchanges specify details and the requested services are deployed. The prospect phase ends with an "executed close" when the service agreement is fully signed by all parties in the partnership. 
 + A _Partner_ is an organization that has a signed agreement with 2i2c/CS&S.
 
-### Technology Context
+## Technology Context
 
 2i2c/CS&S use a variety of technologies and subscription services in our overall operation. Personnel involved in supporting 2i2c's leads --> partnerships business processes need to have accounts and appropriate access to these resources. The technologies and servies used in the leads --> partnership procedures are described next: 
 
-#### [Slack](https://2i2c.slack.com)
+### [Slack](https://2i2c.slack.com)
 
 2i2c uses Slack for asynchronous team communications, often threaded by focus area. Discussions related to partnerships and the workflows described in this section of the Team Compass mostly take place in the `#leads-and-partnerships` channel in 2i2c's Slack. Questions about the implementation of procedures in the leads, prospects, and partnerships phases are likely best posed in the `#leads-and-partnerships` channel in Slack. 
 
-#### [FreshDesk](https://2i2c.freshdesk.com)
+### [FreshDesk](https://2i2c.freshdesk.com)
 
 2i2c uses FreshDesk ([https://2i2c.freshdesk.com](https://2i2c.freshdesk.com)) to manage leads and support requests. FreshDesk's ticketing system is used to track information exchanges around a particular lead or support request. FreshDesk's canned messaging support is used in some of the standard operating procedures described below.  
 
-#### Google Drive
+### Google Drive
 
 2i2c uses Google Drive and Google docs to process and store business documents. Most of the procedures described below involve action sequences that affect the `Partnerships` folder inside the `2i2c Team Drive`. Some of the procedures take place inside the `2i2c + CS&S Shared Drive`.
 
@@ -55,23 +55,26 @@ An exploded tree-view of the Partnerships folder:
     |---Running Notes -- 2i2c + CS&S
 ```
 
-#### GitHub
+### GitHub
 
 2i2c uses GitHub to manage code and infrastructure with version control. 2i2c and partner communities collaborate on managed services, software development, documentation, and sharing of responsibilities using GitHub issues. 
 
 Infrastructure services operated by 2i2c are managed through the [infrastructure repository](https://github.com/2i2c-org/infrastructure/). Technical exchanges leading to the deployment of new hubs for partner communities mostly take place in [issues in the infrastructure repo](https://github.com/2i2c-org/infrastructure/issues). 
 
-#### AirTable
+### AirTable
 
-CS&S uses AirTable to process and store tabular data. Invoices and executed agreements with 2i2c's partners are stored and processed by CS&S using AirTable. 
+CS&S uses AirTable to process and store tabular data.
+They store a record of **all invoices and executed agreements** with 2i2c's partners. 
 
-#### DocuSign
+See [our Invoices and Contracts section](../../finance/contracts.md) for information about this table.
+
+### DocuSign
 
 CS&S uses DocuSign to execute agreements using digital signatures gathered from signatories to agreements between 2i2c/CS&S and partner organizations. 
 
-### Lead Phase Procedures
+## Lead Phase Procedures
 
-#### SOP: Hail the Lead
+### SOP: Hail the Lead
 
 A member of the 2i2c Partnerships Team sends an email to partnerships@2i2c.org requesting `Hail the Lead` action for **contact(s) with email addresses**. This message creates an issue in FreshDesk that will be used to track the lead as it progresses through the arc toward a singed partnership agreement.  2i2c's Partnerships Assistant carries out this action sequence:
 
@@ -90,7 +93,7 @@ A member of the 2i2c Partnerships Team sends an email to partnerships@2i2c.org r
 4. Confirm that service description has been automatically attached
 5. Confirm canned response includes a meeting invitation with 30 minute Calendly link
 
-#### SOP: Running Notes for First Meeting with Lead
+### SOP: Running Notes for First Meeting with Lead
 
 A lead confirmed an upcoming meeting with 2i2c. Calendly sends an automatic message with Zoom link to the contact and enters a calendar booking into Partnerships Lead's calendar. Partnerships Lead forwards email with meeting details to partnerships@2i2c.org triggering the following actions script:
  
@@ -102,7 +105,7 @@ A lead confirmed an upcoming meeting with 2i2c. Calendly sends an automatic mess
 6. Set sharing of running notes file (with editor rights) with lead contacts (meeting participants); Send message from Google notifying the availability of the shared running notes file. 
 
 
-#### SOP: Meet with Lead
+### SOP: Meet with Lead
 
 2i2c Partnerships and Community Teams will develop improved procedures for initial meetings with leads.
 
@@ -113,9 +116,9 @@ A lead confirmed an upcoming meeting with 2i2c. Calendly sends an automatic mess
 + Forecast upcoming procurement/negotiation and technical/deployment stages
 + Record notes and exchanges in Running Notes file
 
-### Prospect Phase Procedures
+## Prospect Phase Procedures
 
-#### SOP: Send Draft Contract
+### SOP: Send Draft Contract
 
 A member of 2i2c Partnerships Team sends email to partnerships@2i2c.org requesting `Send Draft Contract` to PartnerX contact email(s). 2i2c's Partnerships Assistant carrys out the following actions script: 
 
@@ -125,7 +128,7 @@ A member of 2i2c Partnerships Team sends email to partnerships@2i2c.org requesti
 4. Set sharing of service agreement (with editor rights) with lead contacts
 5. Add dated entry "YYYY-MM-DD Sent (Draft) Service Agreement as shared Google doc" to PartnerX >> Running Notes... file
 
-#### SOP: Service Agreement Negotiation
+### SOP: Service Agreement Negotiation
 
 2i2c's Partnerships Team works with the Prospect to upgrade the draft services agreement into an executable document that can be signed by all signatories. 
 
@@ -134,29 +137,40 @@ A member of 2i2c Partnerships Team sends email to partnerships@2i2c.org requesti
 + Specify addenda (statement of work; deliverables; ...)
 + Target: get to "ready to sign"
 
-#### SOP: DocuSign Agreement
+### SOP: DocuSign Agreement
 
 2i2c's Partnershps Team sends email to fsp@codeforscience.org requesting that the executable agreement be circulated for DocuSigning by all signatories.
 
 CS&S arranges for DocuSign requests from signatories.
 
-### Partnership Phase
+## Partnership Phase
 
-#### SOP: Launch Meeting
+### SOP: Launch Meeting
 
 2i2c's Community and Partnerships Teams will work to specify standard operating procedures for kickoff events to launch partnerships.
 
-#### SOP: Invoicing 
+### SOP: Invoicing 
 
 Procedure to be specified better in collaboration with CS&S
 
-#### SOP: Satisfaction Check-In
+### SOP: Satisfaction Check-In
 
 2i2c's Community and Partnerships Teams will work to specify standard operating procedures for checking in with partners.
 
-#### SOP: Renewal Tickler System
+### SOP: Renewal Tickler System
 
 2i2c's Community and Partnerships Teams, in collaboration with CS&S, will work to specify standard operating procedures for managing renewals of partnerships.
 
+(sales:questions-to-answer)=
+## When to decide to work with a lead
 
+To decide whether we should continue engaging with a particular lead, we need to know whether they are in-scope for our mission and likely to be able to successfully collaborate with us.
+The [`MANIAC-T` framework](https://xxiibrands.com/sales/qualify-your-sales-leads-with-maniac-t/) can be helpful in coming to a decision. Here is a short description of these guideilnes:
 
+* **Money**. Is there a specific amount of money set aside for the project? If they are seeking funding in order to pay for this, what are the details?
+* **Authority**. Does the contact have the authority to make a buying decision? Who else will need to be involved in the decision-making process?
+* **Need**. What are their clear pain-points with their current infrastructure setup? Do they seem to have a real need for change?
+* **Impending Event**. Do they have an upcoming event that is urgent or pressing?
+* **Application**. Is their use-case a good fit for 2i2c infrastructure? Would their use-case require major changes to our hubs? Is there a different organization better-suited to help them?
+* **Competition**. What alternative options are they considering? e.g., other organizations, internal approaches, or deciding to do nothing?
+* **Timeline**. What does the buying process look like for this prospect? E.g., finalizing a contract, or receiving a sub-award.

--- a/projects/managed-hubs/sales.md
+++ b/projects/managed-hubs/sales.md
@@ -1,32 +1,4 @@
 (managed-hubs:sales)=
 # Sales and invoicing process
 
-This section has information about pursuing and creating new contracts for 2i2c services.
-
-```{admonition} Work in progress
-We are still working out our sales and invoicing process and will update it here.
-```
-
-## Sending invoices
-
-For our monthly hub service, once we have an active contract with a community, CS&S will begin sending them monthly invoices according to the contract that we have with them.
-
-See [our Invoices AirTable](contracts:invoices) for a list of all invoices that CS&S has sent.
-
-See [our Contracts AirTable](conracts:active) for a list of all of our contracts.
-
-## Tips and FAQs
-
-(sales:questions-to-answer)=
-### When to decide to work with a lead
-
-To decide whether we should continue engaging with a particular lead, we need to know whether they are in-scope for our mission and likely to be able to successfully collaborate with us.
-The [`MANIAC-T` framework](https://xxiibrands.com/sales/qualify-your-sales-leads-with-maniac-t/) can be helpful in coming to a decision. Here is a short description of these guideilnes:
-
-* **Money**. Is there a specific amount of money set aside for the project? If they are seeking funding in order to pay for this, what are the details?
-* **Authority**. Does the contact have the authority to make a buying decision? Who else will need to be involved in the decision-making process?
-* **Need**. What are their clear pain-points with their current infrastructure setup? Do they seem to have a real need for change?
-* **Impending Event**. Do they have an upcoming event that is urgent or pressing?
-* **Application**. Is their use-case a good fit for 2i2c infrastructure? Would their use-case require major changes to our hubs? Is there a different organization better-suited to help them?
-* **Competition**. What alternative options are they considering? e.g., other organizations, internal approaches, or deciding to do nothing?
-* **Timeline**. What does the buying process look like for this prospect? E.g., finalizing a contract, or receiving a sub-award.
+See [the Partnerships workflow](../../partnerships/workflow.md) for our processes around leads, sales, and invoicing.


### PR DESCRIPTION
This updates our documentation for the latest accounting, invoicing, and contracting airtable structures. A few highlights:

- It updates to the latest CS&S automation process and has instructions to update the data
- It includes a little video showing this off
- It provides a bit more context for some special columns, including an overview of when/why we add columns and warns not to treat these as a source of truth yet
- Cleans up the sales docs that were semi-duplicated (and in the process consolidates them all under the `partnerships/workflow` page

### References

- This is a follow- up: #703 
- Relevant to https://github.com/2i2c-org/meta/issues/527 (cc @colliand )
- Part of: https://github.com/2i2c-org/infrastructure/issues/2456 (cc @pnasrat )