### PR TITLE
Document authentication accounts

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-team-member.md
+++ b/.github/ISSUE_TEMPLATE/new-team-member.md
@@ -70,7 +70,6 @@ _This is only relevant for others that are joining our Engineering team._
     - An agreement has to be signed first, see https://github.com/2i2c-org/leads/issues/104
 - [ ] Add to appropriate Azure projects
   - [ ] Outside-organization subscription for `utoronto` see https://github.com/2i2c-org/team-compass/issues/386
-- [ ] Add to the [auth0 2i2c tenant](https://manage.auth0.com/dashboard/us/2i2c/tenant/admins)
 - [ ] Add to [quay.io 2i2c team](https://quay.io/organization/2i2c/teams/owners)
 - [ ] NameCheap administration privileges to `2i2c.org` and `2i2c.cloud`
 

--- a/administration/authentication.md
+++ b/administration/authentication.md
@@ -1,0 +1,14 @@
+# Authentication accounts for hubs
+
+This page describes the accounts that we use for authentication in our JupyterHubs.
+
+## CILogon
+
+We have an annual [**Essential Service** membership with CILogon](https://www.cilogon.org/subscribe).
+This allows us to use the CILogon service for authenticating users on our hubs.
+See [the `infrastructure/` docs](infra:hub-deployment-guide/configure-auth/cilogon) for more information.
+
+## Auth0
+
+We used to use [a 2i2c account with `Auth0`](https://manage.auth0.com/dashboard/us/2i2c/) for authenticating users on hubs.
+We ended our use of `Auth0` in April 2023 and no longer pay for a subscription, but keep this account in case we need it in the future.

--- a/administration/index.md
+++ b/administration/index.md
@@ -12,5 +12,6 @@ invoices
 google-workspace
 github
 airtable
+authentication
 zoom
 ```


### PR DESCRIPTION
This documents the authentication services that we use for our hubs. Primarily it documents CILogon. It also mentions `Auth0` but states that we no longer user it. It also removes auth0 from our onboarding steps.

- closes https://github.com/2i2c-org/infrastructure/issues/2422