### PR TITLE
Document bitwarden account

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-team-member.md
+++ b/.github/ISSUE_TEMPLATE/new-team-member.md
@@ -20,11 +20,16 @@ The **Onboarding champion** should follow the checklist below to onboard a new t
 
 **Accounts**
 
-- [ ] Get member's GitHub.com account
-- [ ] Get member's ReadTheDocs.org account
-- [ ] Get member's Quay.io account
-- [ ] Get member's NameCheap.com account
-- [ ] Get member's PagerDuty account
+Create new accounts and share their account name:
+
+- [ ] Get member's [GitHub.com account](https://github.com)
+- [ ] Get member's [ReadTheDocs.org account](https://readthedocs.org)
+- [ ] Get member's [Quay.io account](https://quay.io)
+- [ ] Get member's [NameCheap.com account](https://namecheap.com)
+- [ ] Get member's [PagerDuty account](https://pagerduty.com)
+- [ ] Get member's [bitwarden account](https://bitwarden.com)
+
+Create 2i2c accounts and add to team accounts:
 
 - [ ] Create a @2i2c.org Google account for them
 	- Note that this requires [access to the Admin Panel](https://compass.2i2c.org/en/latest/administration/google-workspace.html?highlight=workspaces#access-and-permissions), a permission held by any 2i2c team lead
@@ -33,6 +38,7 @@ The **Onboarding champion** should follow the checklist below to onboard a new t
 - [ ] Add to the proper [Slack groups](https://2i2c.slack.com/admin/user_groups)
 - [ ] Add to the proper [FreshDesk group](https://2i2c.freshdesk.com/a/admin/groups)
 - [ ] Add to propoer [PagerDuty Users group](https://2i2c-org.pagerduty.com/users-new)
+- [ ] Add to our [bitwarden organization](https://vault.bitwarden.com/#/organizations/11313781-4b83-41a3-9d35-afe200c8e9f1/vault) and add to "Default collection"
 
 **Communication**
 

--- a/administration/passwords.md
+++ b/administration/passwords.md
@@ -1,0 +1,8 @@
+(accounts:bitwarden)=
+# Shared bitwarden account
+
+We use [bitwarden](https://bitwarden.com/) to share passwords and secrets across the team.
+This is done via **a bitwarden organization** that all team members have access to.
+You can use this to fill in password fields for shared accounts, as well as to share credentials securely across the team.
+
+Any new team members should have access to this organization.

--- a/administration/zoom.md
+++ b/administration/zoom.md
@@ -9,6 +9,6 @@ We access the zoom account via [a shared Google Workspace group username](google
 To do so, log in with these credentials:
 
 - **username**: `hello@2i2c.org`.
-- **password**: Available upon request, ask one of the team leads.
+- **password**: See [](account:bitwarden).
 
 You may be prompted to type in a one-time code that will be sent to `hello@2i2c.org`.

--- a/communication/mailinglist.md
+++ b/communication/mailinglist.md
@@ -14,8 +14,7 @@ This is a more attentive and personal audience than our blog, so we use the mail
 ## Access Mailchimp
 
 We have a single Mailchimp account and share access to team members via a single `username`/`password`.
-The {role}`Executive Director` is responsible for this information, though others on the team may have it as well.
-If you'd like access, ask the ED or one of the team members with this information.
+See [](account:bitwarden) for access.
 
 ## Send e-mails via Mailchimp
 

--- a/communication/social.md
+++ b/communication/social.md
@@ -21,20 +21,15 @@ We just have not had the resources to plan for this kind of engagement.
 
 Our Twitter handle is ([@2i2c_org](https://twitter.com/2i2c_org)).
 Currently, there is nobody activately monitoring the Twitter account.
-If you'd like to use it please ask the team for access.
 
-**How to access**: We access this account via a shared `username`/`password`.
-If you'd like access, ask the {role}`Executive Director` or somebody else with access.
-It is possible to have [multi-user access to Twitter accounts via TweetDeck](https://twitter.com/settings/teams) but we have not yet set this up.
+**How to access**: See [](account:bitwarden).
 
 ## Mastodon
 
-Our Mastodon handle is (<a rel="me" href="https://hachyderm.io/@2i2c_org">@2i2c_org</a>).
+Our Mastodon handle is ([@2i2c_org](https://hachyderm.io/@2i2c_org)).
 Currently, there is nobody actively monitoring the Mastodon account.
-If you'd like to use it please ask the team for access.
 
-**How to access**: We access this account via a shared `username`/`password`.
-If you'd like access, ask the {role}`Executive Director` or somebody else with access.
+**How to access**: See [](account:bitwarden).
 
 ## LinkedIn
 

--- a/engineering/secrets.md
+++ b/engineering/secrets.md
@@ -97,3 +97,7 @@ For more information about using `sops`, here are a few links to `sops` document
 - [Basic usage of `sops`](https://github.com/mozilla/sops#usage)
 - [Encrypting files with GCP KMS](https://github.com/mozilla/sops#encrypting-using-gcp-kms)
 - [Common examples with `sops`](https://github.com/mozilla/sops#examples)
+
+## 2i2c-wide passwords
+
+For information about 2i2c-wide passwords, see [](account:bitwarden).

--- a/finance/contracts.md
+++ b/finance/contracts.md
@@ -94,8 +94,6 @@ Invoicing and contracts dashboard
 We use [the 2i2c Team Drive -> `Finances and Accounting -> Grants` folder](https://drive.google.com/drive/folders/1VvER_SxLDKjDYwfXYyEbPX9GN7YlsNpT?usp=sharing) to keep track of any materials related to a grant we are applying for or have received.
 We use that same folder to track all of our preparations and materials for grants that we are applying for.
 
-```{admonition} Some old grants are in the CS&S shared drive
-
 
 - The [**Active and In Progress**](https://drive.google.com/drive/folders/1Mgio3WQfpXkuuy_i--ioY_9XHIff4cQe?usp=share_link) folder contains any grant that we've received, or that are in the middle of applying for.
 - The [**Rejected and Not Submitted**](https://drive.google.com/drive/folders/1BqCYoOvDrkv_f5eYbbrkP_3sHv2M6i7b?usp=share_link) folder contains any grant that we applied for and did not get, or that we started but did not finish.

--- a/finance/contracts.md
+++ b/finance/contracts.md
@@ -91,7 +91,11 @@ Invoicing and contracts dashboard
 
 ## Grant folders
 
-We use [the 2i2c Team Drive -> `Finances and Accounting -> Grants` folder](https://drive.google.com/drive/folders/1VvER_SxLDKjDYwfXYyEbPX9GN7YlsNpT?usp=sharing) to keep track of any materials related to a grant we are applying for or have received.  We use that same folder to track all of our preparations and materials for grants that we are applying for.
+We use [the 2i2c Team Drive -> `Finances and Accounting -> Grants` folder](https://drive.google.com/drive/folders/1VvER_SxLDKjDYwfXYyEbPX9GN7YlsNpT?usp=sharing) to keep track of any materials related to a grant we are applying for or have received.
+We use that same folder to track all of our preparations and materials for grants that we are applying for.
+
+```{admonition} Some old grants are in the CS&S shared drive
+
 
 - The [**Active and In Progress**](https://drive.google.com/drive/folders/1Mgio3WQfpXkuuy_i--ioY_9XHIff4cQe?usp=share_link) folder contains any grant that we've received, or that are in the middle of applying for.
 - The [**Rejected and Not Submitted**](https://drive.google.com/drive/folders/1BqCYoOvDrkv_f5eYbbrkP_3sHv2M6i7b?usp=share_link) folder contains any grant that we applied for and did not get, or that we started but did not finish.


### PR DESCRIPTION
This documents our team bitwarden account, adds a step to our onboarding docs to add a team member to it, and points to this account in a few places where we were talking about passwords.

- closes https://github.com/2i2c-org/team-compass/issues/183