### PR TITLE
Fix broken URLs

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-team-member.md
+++ b/.github/ISSUE_TEMPLATE/new-team-member.md
@@ -16,7 +16,7 @@ The **Onboarding champion** should follow the checklist below to onboard a new t
 **First steps**
 
 - [ ] Send them a welcome e-mail to introduce yourself and mention that you'll be onboarding them.
-- [ ] Point them to [our onboarding documentation](https://compass.2i2c.org/en/latest/operations/onboarding.html)
+- [ ] Point them to [our onboarding documentation](https://compass.2i2c.org/operations/onboarding/)
 
 **Accounts**
 
@@ -28,11 +28,13 @@ Create new accounts and share their account name:
 - [ ] Get member's [NameCheap.com account](https://namecheap.com)
 - [ ] Get member's [PagerDuty account](https://pagerduty.com)
 - [ ] Get member's [bitwarden account](https://bitwarden.com)
+- [ ] Get member's [Zoom account](https://zoom.us)
+- [ ] Get member's [Freshdesk account](https://www.freshworks.com)
 
 Create 2i2c accounts and add to team accounts:
 
 - [ ] Create a @2i2c.org Google account for them
-	- Note that this requires [access to the Admin Panel](https://compass.2i2c.org/en/latest/administration/google-workspace.html?highlight=workspaces#access-and-permissions), a permission held by any 2i2c team lead
+	- Note that this requires [access to the Admin Panel](https://compass.2i2c.org/administration/google-workspace/), a permission held by any 2i2c team lead
 - [ ] Add them to the proper Google group in our Google Admin space.
 - [ ] Add to the proper [2i2c GitHub teams](https://github.com/orgs/2i2c-org/teams/)
 - [ ] Add to the proper [Slack groups](https://2i2c.slack.com/admin/user_groups)
@@ -42,8 +44,8 @@ Create 2i2c accounts and add to team accounts:
 
 **Communication**
 
-- [ ] Send them a link to the [2i2c Team Compass](https://team-compass.2i2c.org/en/latest/) and its [Team Operations section](https://team-compass.2i2c.org/en/latest/operations/index.html)
-- [ ] Send them a link to the [2i2c calendars and meetings](https://team-compass.2i2c.org/en/latest/reference/calendar.html)
+- [ ] Send them a link to the [2i2c Team Compass](https://compass.2i2c.org/) and its [Team Operations section](https://compass.2i2c.org/operations/)
+- [ ] Send them a link to the [2i2c calendars and meetings](https://compass.2i2c.org/reference/calendar/)
 - [ ] Send them a link to the [2i2c Team Google Drive](https://drive.google.com/drive/u/1/folders/0AJcabtB-T0LnUk9PVA)
 - [ ] Schedule an onboarding meeting for after they've read through the docs
 
@@ -81,7 +83,7 @@ _This is only relevant for others that are joining our Engineering team._
 
 **Roles**
 
-- [ ] Onboard into the [Support Steward Role](https://github.com/2i2c-org/team-compass/issues/new?assignees=&labels=type%3A+onboard&template=new-team-member.md&title=Onboarding+%3Cname%3E)
+- [ ] Onboard into the [Support Triager Role](https://github.com/2i2c-org/team-compass/issues/new?assignees=&labels=type%3A+onboard&template=new-team-member.md&title=Onboarding+%3Cname%3E)
 
 **External**
 

--- a/.github/ISSUE_TEMPLATE/offboard-team-member.md
+++ b/.github/ISSUE_TEMPLATE/offboard-team-member.md
@@ -35,7 +35,7 @@ Document accounts:
 Remove 2i2c accounts and remove from team accounts:
 
 - [ ] Deactivate a @2i2c.org Google account for them
-	- Note that this requires [access to the Admin Panel](https://compass.2i2c.org/en/latest/administration/google-workspace.html?highlight=workspaces#access-and-permissions), a permission held by any 2i2c team lead
+	- Note that this requires [access to the Admin Panel](https://compass.2i2c.org/administration/google-workspace/), a permission held by any 2i2c team lead
 - [ ] Remove them from the proper Google group in our Google Admin space.
 - [ ] Remove them from [2i2c GitHub teams](https://github.com/orgs/2i2c-org/teams/)
 - [ ] Remove them from [Slack groups](https://2i2c.slack.com/admin/user_groups)

--- a/conf.py
+++ b/conf.py
@@ -56,8 +56,8 @@ myst_enable_extensions = [
 ]
 
 intersphinx_mapping = {
-    "docs": ("https://docs.2i2c.org/en/latest/", None),
-    "infra": ("https://infrastructure.2i2c.org/en/latest/", None),
+    "docs": ("https://docs.2i2c.org/", None),
+    "infra": ("https://infrastructure.2i2c.org/", None),
 }
 
 # Disable linkcheck for anchors because it throws false errors for any JS anchors

--- a/engineering/secrets.md
+++ b/engineering/secrets.md
@@ -88,7 +88,7 @@ Once you've completed those steps, do the following:
    1. Identify when a file is encrypted or not, and
    2. Use `.gitignore` rules to assist us in not committing unencrypted secrets to the repository
 
-   See our [infrastructure docs](https://infrastructure.2i2c.org/en/latest/topic/access-creds/secrets.html) for more information on this.
+   See our [infrastructure docs](https://infrastructure.2i2c.org/topic/access-creds/secrets/) for more information on this.
    :::
 
 ### Learn more about `sops`

--- a/index.md
+++ b/index.md
@@ -79,7 +79,7 @@ We document some major aspects of this service in the sections below.
 :glob:
 projects/managed-hubs/index
 projects/managed-hubs/*
-List of running hubs <https://infrastructure.2i2c.org/en/latest/reference/hubs.html>
+List of running hubs <https://infrastructure.2i2c.org/reference/hubs/>
 ```
 
 (index:reference)=

--- a/operations/sources.md
+++ b/operations/sources.md
@@ -8,7 +8,7 @@ The most stable form of information in 2i2c is documentation that our teams main
 This is where most information about 2i2c exists.
 Here are a few major documentation sources for 2i2c:
 
-- [**`team-compass.2i2c.org`**](https://team-compass.2i2c.org) (this website): The {term}`Source of Truth` for all 2i2c information and policies.
+- [**`compass.2i2c.org`**](https://compass.2i2c.org) (this website): The {term}`Source of Truth` for all 2i2c information and policies.
 - [**`infrastructure.2i2c.org`**](https://infrastructure.2i2c.org): Information about our cloud infrastructure and deployment configuration.
 - [**`docs.2i2c.org`**](https://docs.2i2c.org): Documentation about our Managed JupyterHub Service.
 

--- a/projects/managed-hubs/support.md
+++ b/projects/managed-hubs/support.md
@@ -88,7 +88,7 @@ Support Stewards
   A **two-person team** of {term}`Support Stewards` work together to triage and communicate with all external support requests.
   Tenure on the support team is **for four weeks**.
   Every **two weeks** (generally at the sprint meeting), a Support Steward cycles off the support team, and a new team member joins the team.
-  The support team rotates through [the “Open Infrastructure Engineering Team” on this page](https://team-compass.2i2c.org/en/latest/reference/team.html), in alphabetical order.
+  The support team rotates through [the “Open Infrastructure Engineering Team”](https://compass.2i2c.org/reference/team/), in alphabetical order.
 
   The primary responsibilities of the Support Stewards are:
 

--- a/projects/managed-hubs/support.md
+++ b/projects/managed-hubs/support.md
@@ -101,11 +101,11 @@ Support Stewards
 
 Community Representative
 Community Representatives
-  See [the service documentation](https://docs.2i2c.org/en/latest/about/service/shared-responsibility.html#std-role-Community-Representative).
+  See [the service documentation](https://docs.2i2c.org/about/service/shared-responsibility.html#std-role-Community-Representative).
 
 Hub Administrator
 Hub Administrators
-  See [the service documentation](https://docs.2i2c.org/en/latest/about/service/shared-responsibility.html#std-role-Hub-Administrator).
+  See [the service documentation](https://docs.2i2c.org/about/service/shared-responsibility.html#std-role-Hub-Administrator).
   
 ```
 


### PR DESCRIPTION
- Fixed and migrated all old URLs starting with "/en/latest/".
- Update new-team-member template