### PR TITLE
Clarify slack access policy

### DIFF
--- a/communication/design.md
+++ b/communication/design.md
@@ -3,9 +3,10 @@
 There are several design and images assets that we use in our websites and online materials.
 For example, logos, banners, images for GitHub Teams, etc.
 
+(design:figma)=
 ## Figma board
 
-Almost all of our design assets [exist in this Figma board](https://www.figma.com/file/EYFRCag2gfYGdEZGFrXgzv/2i2c-Logos?node-id=0%3A1&t=0C2Sudf1pYmaY3Xr-0).
+Almost all of our design assets [exist in this Figma board](https://www.figma.com/file/pp9e4cNYthJnm8u6MzpUdp/Logo-and-brand-assets?type=design&node-id=0%3A1&mode=design&t=B2tDcpyIUmfnazdk-1).
 Any team member should be able to access it and re-use assets as you wish.
 
 This uses [Figma's free plan](https://www.figma.com/pricing/) and so only the owner of a board (`@choldgraf` in this case) can make edits.

--- a/operations/communication.md
+++ b/operations/communication.md
@@ -19,22 +19,31 @@ See [](coordination:workflow) for more information.
 ## Slack
 
 Most of our synchronous communication [happens in Slack](communication:slack).
+There are a combination of private and public channels for different kinds of communication.
 
-### Who is invited to the Slack?
+### Public channels
 
-Currently, anyone who is interested can join the 2i2c Slack. Initially this is people that mentioned they would like to join via our blog post. Any Slack member is welcome to send an invite link to another person that would like to join.
+Our public channels cover general topics that are relevant to 2i2c, and a space for us to connect with other community members that reside in our Slack.
+Generally speaking, anybody can be invited or added to a public channel.
 
-### Private and Public channels
+### Private channels
 
-We try to keep the number of channels to a minimum, and only add new rooms if it really feels necessary (e.g. if we keep having "off topic" conversations about the same topic in one room).
-There are a mix of private and public rooms in the Slack. In general, conversations about projects, development, etc should be in public rooms. **Most conversation in the 2i2c Slack should be in public channels**.
+Private channels are spaces for the 2i2c staff to have internal discussions that benefit from extra privacy and clearer scope.
+We use them in order to have a space for our team to speak freely with one another, discuss sensitive topics, etc.
 
-There are private channels for a few specific topics that probably warrant private conversation. By default, we'll start with:
+Below are a list of private channels for our teams.
+For these channels, **all 2i2c staff may get access**.
+This is granted by making a request in our `#team-updates` channel.
 
-- `#team-updates` - is for 2i2c team members to share information with one another about what they are up to
-- `#leads-and-partnerships` - is for discussing **prospective** collaborations, communities we may serve, or funding opportunities
+To add a non-2i2c staff member, first get approval from our team leads.
 
-In addition, we may create private rooms on a short-term basis for specific events (such as discussing hiring a specific role).
+- `#team-updates` - organization-wide updates and announcements.
+- `#partnerships` - discussion for our Partnerships team.
+- `#engineering` - discussion for our Engineering team.
+
+In addition, we occasionally create private channels for specific projects or topics.
+In this case, the channel creator can invite the people that they believe need visibility into the conversation.
+
 
 ### Conversations that should not be in Slack
 

--- a/partnerships/index.md
+++ b/partnerships/index.md
@@ -7,6 +7,7 @@ This includes partnerships involving paid contracts, as well as via informal and
 overview.md
 structure.md
 workflow.md
-../communication/index
+../communication/index.md
 community_success/freshdesk.md
+stickers.md
 ```

--- a/partnerships/stickers.md
+++ b/partnerships/stickers.md
@@ -1,0 +1,9 @@
+# Printing stickers
+
+2i2c has a [stickerninja account](https://stickerninja.com/) that can be used to purchase stickers.
+The username and password for the account are in our [team Bitwarden account](account:bitwarden).
+
+You can find designs meant for printing stickers in the stickers section of [our Figma design board](design:figma).
+Look for the `stickers` section, and at the top are drafts that work well for stickers.
+
+As a general rule, stickers should be about **2 inches in their shortest axis**.


### PR DESCRIPTION
This clarifies that our private Slack channels are primarily meant for 2i2c staff use. It adds some guidelines about how and when to add non-2i2c-staff to these channels as well.