### PR TITLE
Automatically add readthedocs preview links to PRs

### DIFF
--- a/.github/workflows/autolink-readthedocs-previews-to-prs.yaml
+++ b/.github/workflows/autolink-readthedocs-previews-to-prs.yaml
@@ -1,0 +1,18 @@
+name: Add readthedocs preview link to pull requests
+
+on:
+  pull_request:
+    types:
+      - opened
+    branches:
+      - main
+
+jobs:
+  autolink-rtd-previews:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: readthedocs/actions/preview@v1
+        with:
+          project-slug: "2i2c-team-compass"

--- a/.github/workflows/autolink-readthedocs-previews-to-prs.yaml
+++ b/.github/workflows/autolink-readthedocs-previews-to-prs.yaml
@@ -1,11 +1,7 @@
 name: Add readthedocs preview link to pull requests
 
 on:
-  pull_request:
-    types:
-      - opened
-    branches:
-      - main
+  pull_request_target:
 
 jobs:
   autolink-rtd-previews:


### PR DESCRIPTION
This PR adds a GitHub Actions workflow that will automatically add a readthedocs preview link to a PR description, making it more accessible to see how documentation will look when built. An example PR is here: https://github.com/sgibson91/test-multilingual-sphinx/pull/4