### PR TITLE
Update new team member issue template.

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-team-member.md
+++ b/.github/ISSUE_TEMPLATE/new-team-member.md
@@ -60,7 +60,7 @@ Create 2i2c accounts and add to team accounts:
 
 _This is only relevant for others that are joining our Engineering team._
 
-- [ ] Add to 2i2c hubs as an admin and update `helm-charts/basehub/values.yaml`
+- [ ] Add to 2i2c hubs as an admin and update [`helm-charts/basehub/values.yaml`](https://github.com/2i2c-org/infrastructure/blob/master/helm-charts/basehub/values.yaml)
 - [ ] Add to appropriate GCP organizations and projects
   - [ ] Organization `2i2c.org`'s [admin group](https://console.cloud.google.com/iam-admin/groups/03znysh73qbio4n?organizationId=184174754493)
   - [ ] Organization `2i2c.org`s [engineering group](https://console.cloud.google.com/iam-admin/groups/01opuj5n2qnifml?organizationId=184174754493)

--- a/.github/ISSUE_TEMPLATE/new-team-member.md
+++ b/.github/ISSUE_TEMPLATE/new-team-member.md
@@ -60,7 +60,7 @@ Create 2i2c accounts and add to team accounts:
 
 _This is only relevant for others that are joining our Engineering team._
 
-- [ ] Add to 2i2c hubs as an admin
+- [ ] Add to 2i2c hubs as an admin and update `helm-charts/basehub/values.yaml`
 - [ ] Add to appropriate GCP organizations and projects
   - [ ] Organization `2i2c.org`'s [admin group](https://console.cloud.google.com/iam-admin/groups/03znysh73qbio4n?organizationId=184174754493)
   - [ ] Organization `2i2c.org`s [engineering group](https://console.cloud.google.com/iam-admin/groups/01opuj5n2qnifml?organizationId=184174754493)


### PR DESCRIPTION
Add prompt to update helm charts when adding team members to 2i2c hubs as admin. See example [here](https://github.com/2i2c-org/infrastructure/pull/3372).

<!-- readthedocs-preview 2i2c-team-compass start -->
----
📚 Documentation preview 📚: https://2i2c-team-compass--783.org.readthedocs.build/en/783/

<!-- readthedocs-preview 2i2c-team-compass end -->