### PR TITLE
Note books related to responsibilities are reimbursible

### DIFF
--- a/administration/reimburse.md
+++ b/administration/reimburse.md
@@ -28,7 +28,7 @@ Currently, these are the expenses that we regularly reimburse:
 - Cloud infrastructure costs incurred as part of our services.
 - Conference registration for conferences that we agree are in-scope for 2i2c's attendance.
 - Travel: see [](reimburse:travel).
-- Personal development / training for skills that are directly related to team responsibilities.
+- Personal development / books / training for skills that are directly related to team responsibilities.
 - Infrequent equipment purchases for team members (computers, desks, etc) provided they are within a reasonable spend amount.
 
 (reimburse:travel)=


### PR DESCRIPTION
I was going to buy and reimburse https://www.oreilly.com/library/view/the-staff-engineers/9781098118723/, which I think is very helpful for my role in the team. However, it isn't entirely clear if that is reimbursible (as it isn't 'training', and 'personal development' feels too broad?).

So explicitly list 'books' here. This isn't *any* book - the filter in the latter part of the sentence constraints this well still.

<!-- readthedocs-preview 2i2c-team-compass start -->
----
📚 Documentation preview 📚: https://2i2c-team-compass--790.org.readthedocs.build/en/790/

<!-- readthedocs-preview 2i2c-team-compass end -->