### PR TITLE
Add contractor hiring process

### DIFF
--- a/administration/contractors.md
+++ b/administration/contractors.md
@@ -1,0 +1,31 @@
+# Set up a contractor with CS&S
+
+If you need to contract work to an external person or organization, follow the steps below.
+Note that this is different from the process of hiring a contractor that is meant to be part of 2i2c's team on an ongoing basis.
+For that use case, see [](#hiring).
+
+1. Fill out the tables in the contractor agreement template
+
+   CS&S has [a contractor agreement template at this Google Doc](https://docs.google.com/document/d/15Vq-pMFEI9xa279ftgNzoxKEPsWyji-WKwHBo1ZA6MM/edit?usp=sharing).
+
+   Copy it and fill out the top tables in coordination with the contractor and others at 2i2c.
+   
+   ```{admonition} Choosing a grant code
+   See [](#reimburse:grant-code).
+   ```
+2. Have the contractor prepare a **Statement of Work**.
+   Most contractors have their own templates for an SOW, but if one doesn't, here are a few pieces of information they should contain:
+
+   - A general description of the service being provided and the need it is meeting.
+   - The outcomes that we aim to achieve with this work.
+   - The specific actions that will be taken as part of the work.
+   - The pricing structure of the contract.
+3. Confirm the contract template with the contractor.
+   Make sure the language looks reasonable and that the information is correct.
+   If they have any changes they'd like to see to the contract, note it in the following step.
+4. Send an e-mail to `fsp@codeforsociety.org` requesting a new contractor agreement.
+   Attach the contractor template you've filled out, as well as the Statement of Work.
+   Add any requests or questions the contractor has about the contract language.
+   `cc` the contractor so that they can follow up with CS&S if need be.
+
+After this, CS&S should provide next steps and take it from there if they need any extra information or clarification.

--- a/administration/index.md
+++ b/administration/index.md
@@ -8,6 +8,7 @@ overview
 structure
 css
 reimburse
+contractors
 invoices
 google-workspace
 github

--- a/people/hiring.md
+++ b/people/hiring.md
@@ -1,3 +1,4 @@
+(hiring)=
 # Hiring process and information
 
 This page contains information about the hiring process at 2i2c.


### PR DESCRIPTION
This adds a lightweight process to follow for contracting out work that 2i2c is doing. It may be missing a few steps here and there so @colliand please give feedback if you follow this and find something obvious is missing so we can update it.