### PR TITLE
Turn key upstream communities into a data object and update the list

### DIFF
--- a/open-source/data/key-communities.toml
+++ b/open-source/data/key-communities.toml
@@ -1,0 +1,19 @@
+# This is the source of truth for "Key Upstream Communities".
+# For more information see: https://compass.2i2c.org/open-source/key-communities/
+# Issue discussing this: https://github.com/2i2c-org/meta/issues/830#issuecomment-1928854772
+communities = [
+  # Jupyter projects
+  "jupyter",
+  "jupyter-server",
+  "jupyterhub",
+  "jupyterlab",
+  "binder-examples",
+  "executablebooks",
+  # Other upstream communities
+  "cryptnono",  # Also used heavily by the Binder project
+  "dask",  # Largely dask-gateway and distributed
+  "pydata",  # Largely pydata-sphinx-theme
+  "rocker-org",  # Heavily used for supporting R environments
+  # Communities of practice
+  "pangeo-data",
+]

--- a/open-source/key-communities.md
+++ b/open-source/key-communities.md
@@ -1,3 +1,16 @@
+---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.13.8
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+---
+
 # Key open source communities
 
 Key open source communities are those that align with 2i2c's values and that are central to 2i2c's mission.
@@ -22,8 +35,22 @@ Here are a few examples of this:
 
 ## List of key communities
 
-Currently, the following communities are considered "key communities" for 2i2c:
+Currently, the following communities are considered "key communities" for 2i2c.
+It is pulled from [this source of truth](data/key-communities.toml).
 
-- [@jupyter](https://github.com/jupyter)
-- [@jupyterhub](https://github.com/jupyterhub) (and Binder)
-- [@executablebooks](https://github.com/executablebooks)
+```{code-cell} ipython3
+---
+mystnb:
+  markdown_format: myst
+tags: [remove-input]
+---
+from tomlkit import parse
+from pathlib import Path
+from IPython.display import Markdown
+with Path("data/key-communities.toml").open() as ff:
+  communities = parse(ff.read())["communities"]
+
+communities = [f"- [@{cc}](https://github.com/{cc})" for cc in communities]
+communities = "\n".join(communities)
+Markdown(communities)
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ sphinx-copybutton
 sphinx-design
 sphinx-togglebutton
 sphinxext-rediraffe
+tomlkit
 
 # Slack SDK for pulling Support Steward info
 slack-sdk


### PR DESCRIPTION
This updates our list of "key upstream communities" so that we capture more of the upstream work that we've done over the past few years. For some communities, we do not "heavily" engage in them, but still treat them as critical to 2i2c's service. For example, Jupyter Server is a fundamental building block of Jupyter even though we don't steward it on a week-to-week basis.

This also makes our list of upstream communities a `TOML` file so that we can ingest it elsewhere if need be. (like in 2i2c.org/kpis)

This is an iterative improvement on the following issue, but doesn't solve it long-term:

- https://github.com/2i2c-org/meta/issues/830