### PR TITLE
Update explanations of accounting and contracts airtable

### DIFF
--- a/finance/accounting-statement-overview.md
+++ b/finance/accounting-statement-overview.md
@@ -77,15 +77,3 @@ Grants
 : All of our income/expenses are tied to a particular grant, which is encoded here. We have a grant option for every active grant (e.g. the Columbia University Pangeo grant).
 
   There is a special persistent category called `2i2c: General`. This is a general fund where our contract revenue is placed and spent from. It is essentially "disposable income" with no strings attached.
-
-### How much cash on-hand does 2i2c have?
-
-- Look to the bottom-right cell of the [Income Statement](accounting:income-statement).
-- This is the `Net Income` across all of 2i2c's history with CS&S. This number is the amount of disposable cash on hand.
-
-### How much remaining funds should we expect in a grant?
-
-- Find the column for that grant in the latest [Income Statement](accounting:income-statement).
-- Find the `Net Income` row for that grant.
-- Compare this with the total budget that we submitted for the grant (including our FSP fee).
-- The difference between the two is the amount we expect to receive in the future.

--- a/finance/accounting.md
+++ b/finance/accounting.md
@@ -49,6 +49,32 @@ Here's a brief video describing the above process.
 CS&S generates monthly reports for our current financial situation.
 You can find them in [our financial reports folder](https://drive.google.com/drive/folders/1vM_QX1J8GW5z8W5WemxhhVjcCS2kEovN?usp=sharing).
 
+Below are some Frequently Asked Questions along with a more detailed description of these reports.
+
+### How much Net Income does 2i2c have?
+
+`Net Income` is a combination of the following things:
+
+- Our Cash on Hand.
+- Income for which CS&S has `Authorized` an invoice.
+- Costs for which CS&S has received an invoice but not yet paid.
+
+To find this number, follow these steps:
+
+- Open [](accounting:income-statement).
+- Scroll to the bottom of **the `FSP: 2i2c` column**.
+- Use the number in the **`Net Income`** row.
+
+```{admonition} This will be at least one month out of date
+:class: warning
+CS&S prepares our monthly reports using last-month's data.
+This means that the definition of `Net Income` is true as of the end of the window used in that report.
+This is usually about a month in the past.
+See [](accounting:remaining-in-contracts) for how to correct for this gap.
+```
+
+### Detailed monthly reports description
+
 See [](accounting-statement-overview.md) for more information about these sheets.
 
 ```{toctree}

--- a/finance/contracts.md
+++ b/finance/contracts.md
@@ -22,6 +22,21 @@ There may be multiple contracts (rows) for a single community, representing diff
 Contracts AirTable
 ```
 
+(contracts:amount-remaining)=
+### What funds remain in a contract or grant?
+
+Whenever an invoice is created by CS&S, it is recorded in [our Invoices AirTable](contracts:invoices) and linked to an active grant.
+Invoices begin in a `Draft` state, and become `Authorized` when they are ready to be sent out.
+
+When an invoice is `Authorized` we consider it `Net Income` and subtract its total from the grant.
+
+```{card} Remaining income in active contracts and grants
+:link: https://airtable.com/appbjBTRIbgRiElkr/tbliwB70vYg3hlkb1/viwbDeJ6Y0ruw5XH5/fldORbyrkf9uKyOa9
+
+This AirTable view shows our active contracts, as well as the remaining funds in each after subtracting all `Authorized` invoices
+```
+
+
 ### Special columns
 
 There are a few special columns worth highlighting, they are described below.


### PR DESCRIPTION
This adds more information about our accounting and contracts airtables, with the goal of making it clearer what those numbers mean.

@colliand can you provide feedback on what changes here could make this information easier to digest and follow? I have a feeling it is too complex and messy but not sure how to improve it.