### PR TITLE
Create development (professional development page in the People section)

### DIFF
--- a/people/compensation.md
+++ b/people/compensation.md
@@ -97,11 +97,7 @@ Team members should get approval for travel (and a rough budget) before any book
 
 #### Personal development
 
-2i2c team members should identify opportunities to learn and improve the skills that are related to their role and their learning goals.
-2i2c will cover the cost of these opportunities.
-We particularly encourage area leads and managers to identify these opportunities for others in their area (and for themselves).
-Opportunities should be identified by any team member, and approved by an area lead or manager.
-There is currently no restriction on the funds that can be spent on this. This will likely change to a fixed budget in the future but should be sustainable while we are small.
+Development recommendations and reimbursement are described in our [Personal and professional development section](./development.md)
 
 #### Wellness
 

--- a/people/development
+++ b/people/development
@@ -2,7 +2,7 @@
 
 ## Core skills
 As our team grows, we’re collectively identifying skills needed for each role. All team members should prioritize learning core skills, with each others’ support.
-2i2c will cover the cost of these opportunities and expect the time required to be part of team members’ standard work days. Learning that’s essential to our daily work is part of our daily work. 
+2i2c will cover the cost of these opportunities and expect the time required to be part of team members’ standard work days. Learning for skills that are essential to our daily work is part of our daily work. 
 
 
 ## Coaching

--- a/people/development
+++ b/people/development
@@ -7,7 +7,7 @@ As our team grows, we’re collectively identifying skills needed for each role.
 
 ## Coaching
 Many 2i2c team members have had great experiences working with a coach. Having an external partner in your journey can help you reflect, explore and creatively realize your potential.
-All team members are encouraged to try working with a coach: [guidance on that here] (https://docs.google.com/presentation/d/1r5Sb4BmBgZM3Gyz4gLHfv2kxk6vFfmz2tczrMAqihLg/edit?usp=sharing). 
+All team members are encouraged to try working with a coach: [guidance on working with a coach is in this Google Doc] (https://docs.google.com/presentation/d/1r5Sb4BmBgZM3Gyz4gLHfv2kxk6vFfmz2tczrMAqihLg/edit?usp=sharing). 
 Team members can expense up to USD 1800/year without approval, or ask their area lead to approve more.  
 
 

--- a/people/development
+++ b/people/development
@@ -1,0 +1,30 @@
+# Personal and professional development
+
+## Core skills
+As our team grows, we’re collectively identifying skills needed for each role. All team members should prioritize learning core skills, with each others’ support.
+2i2c will cover the cost of these opportunities and expect the time required to be part of team members’ standard work days. Learning that’s essential to our daily work is part of our daily work. 
+
+
+## Coaching
+Many 2i2c team members have had great experiences working with a coach. Having an external partner in your journey can help you reflect, explore and creatively realize your potential.
+All team members are encouraged to try working with a coach: [guidance on that here] (https://docs.google.com/presentation/d/1r5Sb4BmBgZM3Gyz4gLHfv2kxk6vFfmz2tczrMAqihLg/edit?usp=sharing). 
+Team members can expense up to USD 1800/year without approval, or ask their area lead to approve more.  
+
+
+## Additional professional and personal development
+Team members should also identify opportunities related to their own learning goals, and that will improve their ability to perform their current role or grow into other areas. 
+
+We particularly encourage area leads and managers to identify these opportunities for others in their area (and for themselves). Opportunities should be identified by any team member, and approved by an area lead or manager. 2i2c will cover the cost and time commitment of these opportunities when approved. 
+                                                                                      
+
+## Professional development budget
+We are piloting a targeted reimbursement budget for the Engineering team, with an aim to reimburse at least USD 2500/person. 
+
+There is currently no upper limit on the funds that can be spent on development, while we work to find the right target amount. Our current approach should be sustainable while we are small.
+                                                                                      
+
+:::{admonition} Some additional clarifications
+* We are continuously improving our People practices, so this list is not exhaustive
+* Our goal in defining personal and professional development is to encourage learning, not constrain it
+* If in doubt, just ask a manager or area lead - the answer is probably yes                                                                              
+:::

--- a/people/development
+++ b/people/development
@@ -1,5 +1,12 @@
 # Personal and professional development
 
+Growing our skills is part of what makes 2i2c an effective team. Our professional development policy exists to remind us all to spend time and money on learning. 
+Key points: 
+* Prioritize spending time and money on core skills for each role
+* Coaching has helped many 2i2c team members; we encourage everyone to try it
+* Team members should explore other learning opportunities that will help them grow at 2i2c
+* We aim to spend at least USD 2500/person across these categories 
+
 ## Core skills
 As our team grows, we’re collectively identifying skills needed for each role. All team members should prioritize learning core skills, with each others’ support.
 2i2c will cover the cost of these opportunities and expect the time required to be part of team members’ standard work days. Learning for skills that are essential to our daily work is part of our daily work. 
@@ -15,13 +22,12 @@ Team members can expense up to USD 1800/year without approval, or ask their area
 Team members should also identify opportunities related to their own learning goals, and that will improve their ability to perform their current role or grow into other areas. 
 
 We particularly encourage area leads and managers to identify these opportunities for others in their area (and for themselves). Opportunities should be identified by any team member, and approved by an area lead or manager. 2i2c will cover the cost and time commitment of these opportunities when approved. 
-                                                                                      
 
-## Professional development budget
-We are piloting a targeted reimbursement budget for the Engineering team, with an aim to reimburse at least USD 2500/person. 
+
+## Budget for development
+This is an evolving area of 2i2c. We are piloting a targeted reimbursement budget for the Engineering team, with an aim to reimburse at least USD 2500/person for any professional development expenses listed above. 
 
 There is currently no upper limit on the funds that can be spent on development, while we work to find the right target amount. Our current approach should be sustainable while we are small.
-                                                                                      
 
 :::{admonition} Some additional clarifications
 * We are continuously improving our People practices, so this list is not exhaustive

--- a/people/index.md
+++ b/people/index.md
@@ -5,6 +5,7 @@
 overview.md
 expectations.md
 compensation.md
+development.md
 hiring.md
 titles.md
 time-off.md


### PR DESCRIPTION
We had a tiny section of the Compensation page dedicated to describing professional development reimbursement. 

This page updates that information with more guidance for team members to encourage people to pursue more development opportunities, including coaching.

- Part of https://github.com/2i2c-org/meta/issues/843