### PR TITLE
Document solution forum channel

### DIFF
--- a/cross-functional/workflow.md
+++ b/cross-functional/workflow.md
@@ -1,43 +1,34 @@
 (leads:workflow)=
 # Workflow
 
-```{warning} Out of date
-Our cross-team workflow is being significantly re-worked, and this information is out of date.
-```
+(slack:team-updates)=
+## The `#team-updates` Slack channel
 
-This section describes how our leadership team carries out its planning and day-to-day work.
+The [`#team-updates` Slack channel](https://2i2c.slack.com/archives/C01GLCC1VCN) is for organization-wide announcements and team discussion.
+It is a place for the whole organization to talk to one another, share status and life updates, etc.
+There's not a strict limit to topics for discussion, but if your conversation fits within the scope of another Slack channel it's better to discuss there.
 
-(leads:meeting:organizational-strategy)=
-## Meeting for organizational strategy
+(slack:solution-forum)=
+## The `#solution-forum` Slack channel
 
-We have a bi-weekly **Organization and strategy meeting** to discuss and refine major priorities across the organization.
-See [our running notes for more information](https://drive.google.com/open?id=1HoNX8T8IQ1uhS2ryi1r9iS-nSbPT1b1Y7HsjosbHme8&authuser=1&usp=meetingnotes&showmeetingnotespromo=true).
+The [`#solution-forum` Slack channel](https://2i2c.slack.com/archives/C06G5FAAT63) is a space for cross-organization initiatives and strategic conversation.
 
-## Strategic priorities board
+- It is meant for discussing organization-wide practices, policies, and planning.
+- It will have a combination of strategic- and tactical-level discussion. (in the future we may split this into two channels if it's too much)
+- It will initially focus its discussion around our "cross-functional initiatives" board and the items in it.
+- Anyone that participates in conversations in this channel should dedicate the attention to understand the context for discussion and participate until topics are resolved.
+- Area leads are expected to monitor this channel and participate in cross-team conversations as they arise.
+- All 2i2c staff have visibility into the channel and may participate in conversations, but are not expected to do so as part of their daily responsibilities.
 
-We have a special project board to track the priorities of each functional area.
-We update this roughly every quarter.
+### Team members expected to monitor this channel
 
-```{button-link} https://github.com/orgs/2i2c-org/projects/34/views/7
-:color: primary
+Below is a list of the team members that we **expect** to participate in this channel on a regular basis:
 
-Strategic priorities
-```
-
-## Organization-wide backlog
-
-We have a backlog to track organization-wide work items.
-These are generally championed by one of our leads, or by the executive director.
-
-```{button-link} https://github.com/orgs/2i2c-org/projects/34/views/13
-:color: primary
-
-Organizational backlog
-```
-
-We also track [our strategic objectives](strategy:objectives) in this board.
-
-## Slack channel
-
-The [`#team-leads`](https://2i2c.slack.com/archives/C047H7W78M6) channel is a space for dedicated cross-organization and strategic conversation.
-All team leads must be a member of this channel, and any team member is welcome to join this channel.
+- @colliand: To represent our overall partnerships strategy and team
+- @jmunroe: To represent our community success efforts
+- @Gman0909 : To represent our product operations and strategy
+- @damianavila : To represent our engineering team's needs
+- @yuvipanda : To represent our technical and open source strategy
+- @choldgraf : To represent 2i2c's overall strategy and policies
+- @haroldcampbell : To represent 2i2c's overall system of work and operations
+- @aprilmj : To represent 2i2c's People Operations and team support

--- a/engineering/workflow.md
+++ b/engineering/workflow.md
@@ -1,6 +1,11 @@
 (coordination:workflow)=
 # Workflow
 
+```{admonition} Out of date!
+
+Many of the sections below are out of date, particularly those related to the Engineering team's delivery workflow.
+```
+
 This section describes how our development team carries out its planning and day-to-day work.
 
 :::{admonition} Helpful links
@@ -238,3 +243,8 @@ Here is a common column structure:
 - {guilabel}`Blocked`: Deliverables that require another action or delivearable from the 2i2c team to complete before they can move forward.
 - {guilabel}`Waiting`: Deliverables that require another action from a **non-2i2c team member** before they can move forward.
 - {guilabel}`Done`: Deliverables that have been completed. We should close these issues and celebrate the improvements that we have made!
+
+(slack:engineering)=
+## The `#engineering` Slack channel
+
+The [`#engineering` Slack channel](https://2i2c.slack.com/archives/C055A1J1DRP) is a place for the engineering team to coordinate, plan, and discuss their work.

--- a/operations/communication.md
+++ b/operations/communication.md
@@ -33,13 +33,11 @@ We use them in order to have a space for our team to speak freely with one anoth
 
 Below are a list of private channels for our teams.
 For these channels, **all 2i2c staff may get access**.
-This is granted by making a request in our `#team-updates` channel.
 
-To add a non-2i2c staff member, first get approval from our team leads.
-
-- `#team-updates` - organization-wide updates and announcements.
-- `#partnerships` - discussion for our Partnerships team.
-- `#engineering` - discussion for our Engineering team.
+- [`#team-updates`](slack:team-updates)
+- [`#solution-forum`](#slack:solution-forum)
+- [`#partnerships`](#slack:partnerships)
+- [`#engineering`](#slack:engineering)
 
 In addition, we occasionally create private channels for specific projects or topics.
 In this case, the channel creator can invite the people that they believe need visibility into the conversation.

--- a/partnerships/workflow.md
+++ b/partnerships/workflow.md
@@ -23,9 +23,11 @@ The procedures describe action sequences our team will carry out as expression o
 
 2i2c/CS&S use a variety of technologies and subscription services in our overall operation. Personnel involved in supporting 2i2c's leads --> partnerships business processes need to have accounts and appropriate access to these resources. The technologies and servies used in the leads --> partnership procedures are described next: 
 
-### [Slack](https://2i2c.slack.com)
+(slack:partnerships)=
+### The Partnerships Slack channel
 
-2i2c uses Slack for asynchronous team communications, often threaded by focus area. Discussions related to partnerships and the workflows described in this section of the Team Compass mostly take place in the `#leads-and-partnerships` channel in 2i2c's Slack. Questions about the implementation of procedures in the leads, prospects, and partnerships phases are likely best posed in the `#leads-and-partnerships` channel in Slack. 
+The [`#partnerships` Slack channel](https://2i2c.slack.com/archives/G015W2KSBCP) is for discussions around the partnerships and community lifecycle.
+It is primarily used by the Partnerships team in planning, coordinating, and discussing their work.
 
 ### [FreshDesk](https://2i2c.freshdesk.com)
 


### PR DESCRIPTION
This documents a `#solution-forum` channel for cross-organization operational and strategic discussion. It also does some minor editing of our Slack channel descriptions to make them simpler and more discoverable.

- closes https://github.com/2i2c-org/meta/issues/894

This has already been iterated on and discussed a bit. I intend to merge this in 2-3 days if there are no objections.