### PR TITLE
Add note on discretionary budgets

### DIFF
--- a/cross-functional/index.md
+++ b/cross-functional/index.md
@@ -5,4 +5,5 @@ overview.md
 structure.md
 workflow.md
 governance
+money
 ```

--- a/cross-functional/money.md
+++ b/cross-functional/money.md
@@ -1,0 +1,35 @@
+# Spending money
+
+This page describes when and how to spend money at 2i2c.
+
+## Discretionary budgets per area
+
+Each functional area has a **$2,000 annual (each fiscal year) discretionary budget** that they can use as they wish.
+
+The following areas receive this budget:
+
+- Cross-functional / operations (Harold Campbell)
+- Partnerships (Jim Colliander)
+- Engineering (Damian Avila)
+- Product (Giuliano Maciocci)
+
+:::{admonition} Revisit if this is hard to keep track of
+For now we do not strictly track the budgetary spending of each area, and expect area leads to be responsible for managing their budgets accordingly.
+We may revisit this if this becomes confusing or stressful for the team.
+:::
+
+### Why types of purchases does this cover?
+
+This covers any purchases that do not already have a dedicated line item in our budget. For example, benefits for team members (like equipment purchases) are not included in this budget.
+
+## Subscribing to services
+
+When deciding to subscribe to an ongoing product or service, we should ask a few additional questions to ensure that doing so will not create confusion (e.g., multiple teams subscribing to different providers of the same service) or strategic risk (e.g., subscribing to a service that may lock-in our data and make it hard to act independently).
+
+When using funds to subscribe to a service, here are a few questions that should be answered and approved by the area lead:
+
+1. What's the purpose for this service? What problem do we hope it will solve?
+2. What are our hypotheses for why this service will be useful? How will we measure its utility in 1, 3, and 12 months?
+3. What alternatives exist and why is this the right choice?
+4. Are there any obvious risks to using this service? E.g., are we creating a dependence for one of 2i2c’s core operations?
+5. Does this change any of 2i2c's standard operating procedures? And if so, where will we document them?


### PR DESCRIPTION
This adds a policy to give functional areas a discretionary budget each year, so that we can more fluidly use tools and services that require payment.

- closes https://github.com/2i2c-org/meta/issues/892

This has already been discussed, and I plan to merge in a few days if there are no objections.