### PR TITLE
Add feedback guide and team practices section

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -53,6 +53,7 @@ myst_enable_extensions = [
     "deflist",
     "dollarmath",
     "linkify",
+    "tasklist",
 ]
 
 intersphinx_mapping = {

--- a/operations/index.md
+++ b/operations/index.md
@@ -7,6 +7,7 @@ This chapter describes some of the practices that we adopt towards these goals.
 overview
 strategy
 governance
+team-practices/overview
 onboarding
 sources
 meetings

--- a/operations/team-practices/feedback.md
+++ b/operations/team-practices/feedback.md
@@ -100,10 +100,10 @@ However, when the intent or the act of giving feedback deviates from this, it is
 “Not now” isn’t a no, and it’s also a reasonable thing to say - if you know you’ll have a hard time receiving feedback right now, suggest another, better time. 
 
 For instance:
-  Molly (Giver): Tod, may I give you some feedback based on…
-  _**Tod (Receiver): I am a bit overwhelmed and not in a place to receive feedback right now!**_
+  Molly (Giver): Todd, may I give you some feedback based on…
+  _**Todd (Receiver): I am a bit overwhelmed and not in a place to receive feedback right now!**_
   Molly: Thank you for sharing with me how you feel I understand. Because this is important, is there a time that you could recommend?
-  Tod: Thanks for understanding, may we try again next week?...
+  Todd: Thanks for understanding, may we try again next week?...
 
 ## Asking for feedback
 You can also ask for feedback if you want to:

--- a/operations/team-practices/feedback.md
+++ b/operations/team-practices/feedback.md
@@ -234,14 +234,15 @@ These levels are taking from the www.risemodel.com:
 
 ## Resources
 Where to learn more about feedback
-1 – [Ladder of inference](https://thesystemsthinker.com/the-ladder-of-inference/)
-2 – [The SCARF model](https://www.mindtools.com/akswgc0/david-rocks-scarf-model)
-3 – [Value judgements](https://laurensergy.com/value-judgements/)
-4 – Radical Candor ([4 mins video](https://www.youtube.com/watch?v=rFgu0nOHCcE))
-5 – [The 3 Levels of Listening](https://medium.com/swlh/strategic-leadership-the-3-levels-of-listening-e3f0c27f8d01)
-6 – Crucial Conversations ([video summary](https://www.youtube.com/watch?v=Q2yG142cyNg)), ([book on Amazon](https://www.amazon.com/Crucial-Conversations-Talking-Stakes-Second/dp/0071771328))
-7 – [GE’s Real-Time Performance Development](https://hbr.org/2015/08/ges-real-time-performance-development) introduces Continue/Consider
-8 – [Impact Feedback](https://vividbreeze.com/impact-feedback/)
-9 – [Primed to Perform](https://yantougas.com/2016/02/15/blame/) REAP explanation
-10 – Rise Model ([2 mins video](https://www.youtube.com/watch?v=3cn306Fo_IU)) [www.risemodel.com](https://www.risemodel.com)
-11 – [The Shit Sandwich and Other Terrible Ways to Give Feedback](https://blog.idonethis.com/sandwich-feedback-performance-management/#:~:text=The%20main%20idea%20behind%20the,results%20in%20the%20exact%20opposite).
+
+1. [Ladder of inference](https://thesystemsthinker.com/the-ladder-of-inference/)
+2. [The SCARF model](https://www.mindtools.com/akswgc0/david-rocks-scarf-model)
+3. [Value judgements](https://laurensergy.com/value-judgements/)
+4. Radical Candor ([4 mins video](https://www.youtube.com/watch?v=rFgu0nOHCcE))
+5. [The 3 Levels of Listening](https://medium.com/swlh/strategic-leadership-the-3-levels-of-listening-e3f0c27f8d01)
+6. Crucial Conversations ([video summary](https://www.youtube.com/watch?v=Q2yG142cyNg)), ([book on Amazon](https://www.amazon.com/Crucial-Conversations-Talking-Stakes-Second/dp/0071771328))
+7. [GE’s Real-Time Performance Development](https://hbr.org/2015/08/ges-real-time-performance-development) introduces Continue/Consider
+8. [Impact Feedback](https://vividbreeze.com/impact-feedback/)
+9. [Primed to Perform](https://yantougas.com/2016/02/15/blame/) REAP explanation
+10. Rise Model ([2 mins video](https://www.youtube.com/watch?v=3cn306Fo_IU)) [www.risemodel.com](https://www.risemodel.com)
+11. [The Shit Sandwich and Other Terrible Ways to Give Feedback](https://blog.idonethis.com/sandwich-feedback-performance-management/#:~:text=The%20main%20idea%20behind%20the,results%20in%20the%20exact%20opposite).

--- a/operations/team-practices/feedback.md
+++ b/operations/team-practices/feedback.md
@@ -1,32 +1,35 @@
-# Quick tips for giving and receiving Effective Feedback
+# Giving and receiving Effective Feedback
 
 The purpose of this document is to act as a short, introductory guide to giving and receiving feedback. After reading this guide, the reader should be equipped with the minimal set of tools to give and receive feedback.
 
-## What is Feedback
+## Quick overview
+
+### What is Feedback
 Feedback is fact-based information that is shared to help individuals grow. It is primarily designed to be constructive for recipients and allows them an opportunity to reflect, then determine what behaviors (attributes, skills, etc.) they choose to change based on the facts that have been shared with them.
 
 Feedback isn’t only about things someone could do differently - Positive feedback can be an effective way to encourage more of a behavior!
 
-## Why is it important
+### Why is it important
 The primary purpose of giving feedback is to create a positive impact on people’s behavior and to help them grow.
 
 Similarly, the primary purpose for receiving feedback is so that we have a fact-based opportunity to improve.
 
-## What isn’t considered feedback
+### What isn’t considered feedback
 Feedback differs from opinions, criticism and compliments primarily because of the intent (helping people to grow).
 
 - Feedback vs opinions – feedback differs from an opinion because feedback is rooted in fact-based observations and is not subjective.
 - Feedback vs criticism/compliments – feedback differs from criticism and compliments because the intent is not to make the individuals feel a particular way (in the moment).
 
-## Who benefits from feedback
+### Who benefits from feedback
 Within an organization, everyone benefits from giving and receiving feedback. As a result of this, we feel that once considerations are made to ensure psychological safety (discussed below), anyone in the organization can use this document to start giving and receiving feedback regardless of role. However, it is crucial for leaders and senior team members to role model these behaviors so that their actions can nurture a growth culture. 
 
-# Give and receiving feedback
+### When to give and receive feedback
+
 Ideally, we want to give feedback as close (or soon as possible) after the relevant observed situation. This keeps the details fresh in everyone’s minds. However, we need to ensure that the recipient is ready to receive the feedback and we are prepared (i.e. mentally, emotionally and cognitively) to give the feedback.
 
 Remember that feedback can and should be a mix of positive (keep that up), constructive (please change that). 
 
-## Caveats to feedback (the fantasies)
+### Caveats to feedback (the fantasies)
 It’s important to be aware of the Giver and Receiver’s Fantasy for feedback and the implicit assumption that results.
 
 > **Giver’s Fantasy**: _They will act on my feedback, and everything will be fine._
@@ -35,10 +38,10 @@ It’s important to be aware of the Giver and Receiver’s Fantasy for feedback 
 
 In reality however, the receiver **is not compelled to act** on your feedback if it’s not relevant or actionable.
 
-## When should you use this tool
+### When should you use this document
 This document provides sufficient information to use feedback as a growth mechanism. **_It does NOT cover physical alterations or life threatening situations._**
 
-# How to give feedback
+## How to give feedback
 Use the checklist below as a guide to give feedback.
 
 - [ ] **Create safety** – This is crucial. We need emotional safety. Be empathetic and make sure that you are not adding stress/tension.
@@ -65,7 +68,7 @@ Here’s an example (Story vs Fact):
   - Don’t cushion your feedback
   - Don’t be a jerk
 
-# How to receive feedback
+## How to receive feedback
 Receiving feedback can sometimes be difficult. Below is a checklist on how to receive feedback from people.
 
 - [ ] **Decide if you want to accept the feedback** - first and foremost, you do have a choice to enter into feedback discussions. You are within your rights to say _“No”_ or _“Not now”_ when someone offers to give you feedback. However, if you do decide to enter into a feedback session, then…
@@ -80,7 +83,7 @@ Receiving feedback can sometimes be difficult. Below is a checklist on how to re
   - Is there value in changing your behaviors?
 - [ ] **Take action** - Once you’ve absorbed the feedback, you can decide what you want to do about it - how do you want to change, “do more” or “do less of” in the future? It can be helpful to discuss your action plans with someone who acts as a coach.
 
-# Saying “No” to receiving feedback
+## Saying “No” to receiving feedback
 Feedback is a tool to help individuals grow, and when practiced well it promotes a culture of growth. For this reason we advocate for people giving and receiving feedback. 
 
 However, when the intent or the act of giving feedback deviates from this, it is perfectly okay to decline receiving feedback. Here are some general examples:
@@ -92,7 +95,7 @@ However, when the intent or the act of giving feedback deviates from this, it is
   - It’s being done publicly
   - It’s not being done to help them grow
 
-### Deferring feedback with “Not now” 
+#### Deferring feedback with “Not now” 
 
 “Not now” isn’t a no, and it’s also a reasonable thing to say - if you know you’ll have a hard time receiving feedback right now, suggest another, better time. 
 
@@ -102,7 +105,7 @@ For instance:
   Molly: Thank you for sharing with me how you feel I understand. Because this is important, is there a time that you could recommend?
   Tod: Thanks for understanding, may we try again next week?...
 
-# Asking for feedback
+## Asking for feedback
 You can also ask for feedback if you want to:
 
 - Improve specific activity-based behaviors. Examples include: 
@@ -113,7 +116,7 @@ You can also ask for feedback if you want to:
   - “Over the next 3 months, I’d like to improve my leadership skills. May I ask you to give me feedback every six weeks on your observations of areas I can improve?”
   - “I have difficulty showing others how to write performance code. May I ask you to give me feedback when you see areas where I could communicate better?”
 
-# Feedback in asynchronous teams
+## Feedback in asynchronous teams
 Although initially used in environments where people were collocated, feedback is still applicable for remote teams that are highly distributed. There are some core principles that translate well to asynchronous teams (see below). We acknowledge that when working across time zones, there will be additional friction in coordinating giving and receiving feedback.  
 
 Effective Feedback translates well to asynchronous teams once we are mindful of the following:
@@ -126,7 +129,7 @@ Effective Feedback translates well to asynchronous teams once we are mindful of 
 3. Optimize to have the feedback over video conversation, especially when you’re first practicing
   - Over time, you’ll build skills at sharing feedback with enough detail and relevance that you’ll be able to write quick notes that help the people you work with most often do more of their best work
 
-# Opportunities to give/solicit feedback
+## Opportunities to give/solicit feedback
 The best time to give or ask for feedback is around activities. Here are some examples (not listed in any order of important):
 
 - **During 1:1 catch-ups** – this creates a regular cadence for feedback
@@ -136,9 +139,9 @@ The best time to give or ask for feedback is around activities. Here are some ex
 - **Mentor/Mentee** – use feedback as a tool to improve specific performance related goals
 - **Performance evaluation** – use continue/consider to provide generalized feedback on behaviors/attributes/skills/attitudes that need to be improved (see below).
 
-# Examples of “Good” vs “Bad” feedback
+## Examples of “Good” vs “Bad” feedback
 
-### Example 1
+#### Example 1
 **Bad Feedback**
 > You’re difficult to work with
 
@@ -154,19 +157,19 @@ In 1A, the feedback is better as it provides more concise information an leads t
 1b is even better because it is more timely. Additionally, it captures the _situation, behavior and the impact_.
 
 
-### Example 2
+#### Example 2
 **Bad Feedback**
 >Let me share some feedback with you… you really should do... because from my personal experience…
 
 The feedback isn’t about you and it should not include your advice or personal experiences
 
-### Example 3
+#### Example 3
 **Bad Feedback**
 >If you aren’t willing to do… then I’m going to have to let you go
 
 This isn’t considered feedback. It’s simply a veiled threat.
 
-### Example 4
+#### Example 4
 **Bad Feedback**
 >Here’s some good news…
 >But the bad news is…
@@ -176,10 +179,10 @@ Nice, nasty filter devalues the feedback. Avoid trying to filter without the nic
 
 This “feedback sandwich” concept was really popular in the past, but researchers have tested it and found that people hear less of the good and bad news when you use a “sandwich” like this. [11]
 
-# Common feedback mechanisms
+## Common feedback mechanisms
 There are many different types and formats for giving feedback. Below we have shared a few of the common formats.
 
-## Continue vs Consider 
+### Continue vs Consider 
 Provide generalized feedback rather than feedback that is reactive to a situation [7].
 Example: Over the last 3 months I have observed how you interacted with the team. Here are some examples of things that could be useful for you given your current development goals to become a better team lead.
 
@@ -190,7 +193,7 @@ Things to consider changing as they may be limiting you:
 Things you should continue doing as they amplify your X:
 - Whenever team members ask for help during support requests, I observe that you typically spend time explaining how to solving the problem instead of simply solving it
 
-## Impact Feedback 
+### Impact Feedback 
 This is also known as Situation-Behaviour-Impact Feedback.
 
 > ‘You give another person feedback from your perspective by
@@ -200,13 +203,13 @@ This is also known as Situation-Behaviour-Impact Feedback.
 >   
 > This structure is often introduced with the sentence: “When you … the impact on me was … Hence, I ask you to …”’ [8]
 
-## Radical Candor
+### Radical Candor
 Being Radically Candid [4] focuses on providing feedback along two dimensions:
 
 - Being more specific and sincere with praise
 - Being more kind and clear with criticism
 
-## REAP Model
+### REAP Model
 The REAP model is from the book Primed to Perform [9]. In summary there are four elements:
 
 - **Remember** to assume a positive intent. Assume the other person means well.
@@ -214,7 +217,7 @@ The REAP model is from the book Primed to Perform [9]. In summary there are four
 - **Ask** the other person why they behaved that way (ask assuming positive intent).
 - **Plan** – Identify the root cause and create a plan of action
 
-## RISE Model
+### RISE Model
 This is a four level process for giving feedback and is popular in schools and universities.
 
 These levels are taking from the www.risemodel.com:
@@ -224,12 +227,12 @@ These levels are taking from the www.risemodel.com:
 - **Level 3: Suggest** – To suggest means to introduce ideas for improvement. At this level of feedback, offer suggestions based on your grasp of the current assignment, issue, or opportunity
 - **Level 4: Elevate** – To elevate means to raise to a higher degree or purpose. At this level of feedback, share any insight or encouragement you have on how to approach or optimize similar situations in the future.
 
-# Follow-up thoughts/article
+## Follow-up thoughts/article
 - How will we give feedback to people in vastly different time zones?
 - Can we give feedback over video messages?
 - How can we encourage feedback as a muscle?
 
-# Resources
+## Resources
 Where to learn more about feedback
 1 – [Ladder of inference](https://thesystemsthinker.com/the-ladder-of-inference/)
 2 – [The SCARF model](https://www.mindtools.com/akswgc0/david-rocks-scarf-model)

--- a/operations/team-practices/feedback.md
+++ b/operations/team-practices/feedback.md
@@ -1,0 +1,244 @@
+# Quick tips for giving and receiving Effective Feedback
+
+The purpose of this document is to act as a short, introductory guide to giving and receiving feedback. After reading this guide, the reader should be equipped with the minimal set of tools to give and receive feedback.
+
+## What is Feedback
+Feedback is fact-based information that is shared to help individuals grow. It is primarily designed to be constructive for recipients and allows them an opportunity to reflect, then determine what behaviors (attributes, skills, etc.) they choose to change based on the facts that have been shared with them.
+
+Feedback isn’t only about things someone could do differently - Positive feedback can be an effective way to encourage more of a behavior!
+
+## Why is it important
+The primary purpose of giving feedback is to create a positive impact on people’s behavior and to help them grow.
+
+Similarly, the primary purpose for receiving feedback is so that we have a fact-based opportunity to improve.
+
+## What isn’t considered feedback
+Feedback differs from opinions, criticism and compliments primarily because of the intent (helping people to grow).
+
+- Feedback vs opinions – feedback differs from an opinion because feedback is rooted in fact-based observations and is not subjective.
+- Feedback vs criticism/compliments – feedback differs from criticism and compliments because the intent is not to make the individuals feel a particular way (in the moment).
+
+## Who benefits from feedback
+Within an organization, everyone benefits from giving and receiving feedback. As a result of this, we feel that once considerations are made to ensure psychological safety (discussed below), anyone in the organization can use this document to start giving and receiving feedback regardless of role. However, it is crucial for leaders and senior team members to role model these behaviors so that their actions can nurture a growth culture. 
+
+# Give and receiving feedback
+Ideally, we want to give feedback as close (or soon as possible) after the relevant observed situation. This keeps the details fresh in everyone’s minds. However, we need to ensure that the recipient is ready to receive the feedback and we are prepared (i.e. mentally, emotionally and cognitively) to give the feedback.
+
+Remember that feedback can and should be a mix of positive (keep that up), constructive (please change that). 
+
+## Caveats to feedback (the fantasies)
+It’s important to be aware of the Giver and Receiver’s Fantasy for feedback and the implicit assumption that results.
+
+> **Giver’s Fantasy**: _They will act on my feedback, and everything will be fine._
+>
+> **Receiver’s Fantasy**: _I have to follow all this feedback, whether it suits me or not. If I do, everything will work out fine._
+
+In reality however, the receiver **is not compelled to act** on your feedback if it’s not relevant or actionable.
+
+## When should you use this tool
+This document provides sufficient information to use feedback as a growth mechanism. **_It does NOT cover physical alterations or life threatening situations._**
+
+# How to give feedback
+Use the checklist below as a guide to give feedback.
+
+- [ ] **Create safety** – This is crucial. We need emotional safety. Be empathetic and make sure that you are not adding stress/tension.
+- [ ] **Ask for permission** – Possible prompts:
+  - Is now a good time for feedback?
+  - Are you in a good space to receive some feedback?
+- [ ] **Make it a private conversation** – Be open to having a discussion that can help them find a way forward, if they want to have the conversation.
+- [ ] **Avoid assumptions** – make the conversation fact-based [1].
+Here’s an example (Story vs Fact):
+  - FACT: Bob Jordan arrived 5 minutes after the meeting started
+  - STORY: Bob Jordan is trying to sabotage the meeting. _This is a story because it attributes other things outside of the facts._
+- [ ] **Prepare** – prepare before giving feedback. 
+  - Think about what you’re going to say before you go into feedback conversations/sessions. 
+  - Put together a list of things you’d like to talk about. Note down specifics to illustrate your points. 
+  - In tense situations, take time to cool down and ensure that you are emotionally ready. Only engage after you have taken time to cool down and have prepared for fair and clear feedback.
+  - Consider how the feedback will be received. See the SCARF model [2]
+- [ ] **Be specific** - note down events to illustrate your comments. Separate personal and emotional baggage from the information you want to share. Make the feedback action so that it can be used to influence future behavior.
+- [ ] **Specify the situation** – Capture the situation when the relevant thing was _observed_. Avoid value judgements [3] or criticism.
+- [ ] **Describe the behavior** – Capture the behavior by specifying what the person did or said. Avoid value judgements [3] or criticism.
+- [ ] **Focus on impact** - What happened as a result of the behavior in the situation? Using “I” statements [6] to share what you observed or felt can help others see their impact.
+- [ ] **Maintain the message** – care personally and challenge directly. See Radical Candor [4]
+  - Don’t back out of the message
+  - Don’t supply your own personal experience
+  - Don’t cushion your feedback
+  - Don’t be a jerk
+
+# How to receive feedback
+Receiving feedback can sometimes be difficult. Below is a checklist on how to receive feedback from people.
+
+- [ ] **Decide if you want to accept the feedback** - first and foremost, you do have a choice to enter into feedback discussions. You are within your rights to say _“No”_ or _“Not now”_ when someone offers to give you feedback. However, if you do decide to enter into a feedback session, then…
+- [ ] **Don’t defend** – It’s our natural, self-serving bias to protect ourselves. In the case of feedback, however, we need to:
+  - Assume _positive intent_
+  - Be curious and open to hearing different perspectives.
+- [ ] **Listen actively** – See the Different levels of listening [5]
+- [ ] **Seek clarification** – When unsure about the information being shared, seek clarification if you are not sure what the person is referring to or you don’t understand. In some situations, you may have had an impact on the person. You can ask how your specific behavior made them feel
+- [ ] **Show gratitude** – Once the person has completed giving you feedback tell them thanks! It takes courage and generosity to give people feedback and showing gratitude reinforces the behavior
+- [ ] **Reflect** – Privately spend time honestly reflecting on the feedback that was shared. Specifically, you should contemplate the information that was shared:
+  - Was the feedback relevant?
+  - Is there value in changing your behaviors?
+- [ ] **Take action** - Once you’ve absorbed the feedback, you can decide what you want to do about it - how do you want to change, “do more” or “do less of” in the future? It can be helpful to discuss your action plans with someone who acts as a coach.
+
+# Saying “No” to receiving feedback
+Feedback is a tool to help individuals grow, and when practiced well it promotes a culture of growth. For this reason we advocate for people giving and receiving feedback. 
+
+However, when the intent or the act of giving feedback deviates from this, it is perfectly okay to decline receiving feedback. Here are some general examples:
+
+- Feedback is being used to criticize or belittle 
+- Feedback is being used to emotionally manipulate 
+- The receiver does not feel psychologically safe to receive the feedback, because…
+  - It’s from a harasser, bully, gossip, etc.
+  - It’s being done publicly
+  - It’s not being done to help them grow
+
+### Deferring feedback with “Not now” 
+
+“Not now” isn’t a no, and it’s also a reasonable thing to say - if you know you’ll have a hard time receiving feedback right now, suggest another, better time. 
+
+For instance:
+  Molly (Giver): Tod, may I give you some feedback based on…
+  _**Tod (Receiver): I am a bit overwhelmed and not in a place to receive feedback right now!**_
+  Molly: Thank you for sharing with me how you feel I understand. Because this is important, is there a time that you could recommend?
+  Tod: Thanks for understanding, may we try again next week?...
+
+# Asking for feedback
+You can also ask for feedback if you want to:
+
+- Improve specific activity-based behaviors. Examples include: 
+  - How you facilitated a workshop
+  - How you presented or communicated something
+  - How helped someone accomplish something, etc.
+- Improve specific performance goals. Examples include:
+  - “Over the next 3 months, I’d like to improve my leadership skills. May I ask you to give me feedback every six weeks on your observations of areas I can improve?”
+  - “I have difficulty showing others how to write performance code. May I ask you to give me feedback when you see areas where I could communicate better?”
+
+# Feedback in asynchronous teams
+Although initially used in environments where people were collocated, feedback is still applicable for remote teams that are highly distributed. There are some core principles that translate well to asynchronous teams (see below). We acknowledge that when working across time zones, there will be additional friction in coordinating giving and receiving feedback.  
+
+Effective Feedback translates well to asynchronous teams once we are mindful of the following:
+
+1. Did you observe the situation first-hand, and can you describe the behavior and impact based on your observations? 
+  - You may not have been awake and working when someone typed out a response or created a pull request, but that’s observable (as long as you avoid telling extra stories about what you observed)
+2. Are you able to have a 1-on-1 with the person and schedule a feedback conversation? 
+  - Be mindful of timezones as the immediacy of the feedback may be limited by the other person's availability.
+  - Resist the urge to “just send” the feedback via a text message. Even if you choose to type up the feedback, schedule time to have a 1:1 (over video) where you take the person through the feedback.
+3. Optimize to have the feedback over video conversation, especially when you’re first practicing
+  - Over time, you’ll build skills at sharing feedback with enough detail and relevance that you’ll be able to write quick notes that help the people you work with most often do more of their best work
+
+# Opportunities to give/solicit feedback
+The best time to give or ask for feedback is around activities. Here are some examples (not listed in any order of important):
+
+- **During 1:1 catch-ups** – this creates a regular cadence for feedback
+- **Session checkout** – at the end of session, ask participants to give you feedback on how you could improve future iterations of the session
+- **Speed networking** – create team opportunities for giving and receive feedback that limit tension and awkwardness related to asking for feedback
+- **Impact feedback** – provide feedback to people at the end of an activity (see below)
+- **Mentor/Mentee** – use feedback as a tool to improve specific performance related goals
+- **Performance evaluation** – use continue/consider to provide generalized feedback on behaviors/attributes/skills/attitudes that need to be improved (see below).
+
+# Examples of “Good” vs “Bad” feedback
+
+### Example 1
+**Bad Feedback**
+> You’re difficult to work with
+
+The initial feedback is not great because it focuses on **_judging the person and not their actions_**. 
+Here are examples of better feedback.
+**Better Feedback (1A)**
+> Over the last 6 weeks several persons had asked to be transferred away from the team, and in each case they indicated that they found it difficult to be productive collaborating with you.
+
+**Even better feedback(1B)**
+> Last week, during the three pairing sessions in which you were involved, the meetings ended in conflict. In each meeting, you repeatedly called people names (such as stupid, idiots, etc.) then you publicly berated these team members. I find it exhausting to have to talk to you about this behavior yet again.  
+
+In 1A, the feedback is better as it provides more concise information an leads to more actionable conversations
+1b is even better because it is more timely. Additionally, it captures the _situation, behavior and the impact_.
+
+
+### Example 2
+**Bad Feedback**
+>Let me share some feedback with you… you really should do... because from my personal experience…
+
+The feedback isn’t about you and it should not include your advice or personal experiences
+
+### Example 3
+**Bad Feedback**
+>If you aren’t willing to do… then I’m going to have to let you go
+
+This isn’t considered feedback. It’s simply a veiled threat.
+
+### Example 4
+**Bad Feedback**
+>Here’s some good news…
+>But the bad news is…
+>But there is still some good news…
+
+Nice, nasty filter devalues the feedback. Avoid trying to filter without the niceties
+
+This “feedback sandwich” concept was really popular in the past, but researchers have tested it and found that people hear less of the good and bad news when you use a “sandwich” like this. [11]
+
+# Common feedback mechanisms
+There are many different types and formats for giving feedback. Below we have shared a few of the common formats.
+
+## Continue vs Consider 
+Provide generalized feedback rather than feedback that is reactive to a situation [7].
+Example: Over the last 3 months I have observed how you interacted with the team. Here are some examples of things that could be useful for you given your current development goals to become a better team lead.
+
+Things to consider changing as they may be limiting you:
+- When doing PRs, I observed X, perhaps you could consider trying Y
+- During the last two Retrospective meetings, I observed that people did A which I feel caused B. Is there value in doing C instead?
+
+Things you should continue doing as they amplify your X:
+- Whenever team members ask for help during support requests, I observe that you typically spend time explaining how to solving the problem instead of simply solving it
+
+## Impact Feedback 
+This is also known as Situation-Behaviour-Impact Feedback.
+
+> ‘You give another person feedback from your perspective by
+> - describing the situation from your point of view (an observation not evaluation)
+> - the impact it has on you (impact, feeling)
+> - and what you would like to be different (need).
+>   
+> This structure is often introduced with the sentence: “When you … the impact on me was … Hence, I ask you to …”’ [8]
+
+## Radical Candor
+Being Radically Candid [4] focuses on providing feedback along two dimensions:
+
+- Being more specific and sincere with praise
+- Being more kind and clear with criticism
+
+## REAP Model
+The REAP model is from the book Primed to Perform [9]. In summary there are four elements:
+
+- **Remember** to assume a positive intent. Assume the other person means well.
+- **Explain** – Come up with 5 scenarios that could explain the behavior, scenarios that do not place the blame on the individual. Consider that culture could have contributed to the outcome.
+- **Ask** the other person why they behaved that way (ask assuming positive intent).
+- **Plan** – Identify the root cause and create a plan of action
+
+## RISE Model
+This is a four level process for giving feedback and is popular in schools and universities.
+
+These levels are taking from the www.risemodel.com:
+
+- **Level 1: Reflect** – To reflect means to recall, ponder, and articulate. At this level of feedback, share what stood out to you and why.
+- **Level 2: Inquire** – To inquire means to seek new information or understanding. At this level of feedback, analyze and ask questions to gain clarity.
+- **Level 3: Suggest** – To suggest means to introduce ideas for improvement. At this level of feedback, offer suggestions based on your grasp of the current assignment, issue, or opportunity
+- **Level 4: Elevate** – To elevate means to raise to a higher degree or purpose. At this level of feedback, share any insight or encouragement you have on how to approach or optimize similar situations in the future.
+
+# Follow-up thoughts/article
+- How will we give feedback to people in vastly different time zones?
+- Can we give feedback over video messages?
+- How can we encourage feedback as a muscle?
+
+# Resources
+Where to learn more about feedback
+1 – [Ladder of inference](https://thesystemsthinker.com/the-ladder-of-inference/)
+2 – [The SCARF model](https://www.mindtools.com/akswgc0/david-rocks-scarf-model)
+3 – [Value judgements](https://laurensergy.com/value-judgements/)
+4 – Radical Candor ([4 mins video](https://www.youtube.com/watch?v=rFgu0nOHCcE))
+5 – [The 3 Levels of Listening](https://medium.com/swlh/strategic-leadership-the-3-levels-of-listening-e3f0c27f8d01)
+6 – Crucial Conversations ([video summary](https://www.youtube.com/watch?v=Q2yG142cyNg)), ([book on Amazon](https://www.amazon.com/Crucial-Conversations-Talking-Stakes-Second/dp/0071771328))
+7 – [GE’s Real-Time Performance Development](https://hbr.org/2015/08/ges-real-time-performance-development) introduces Continue/Consider
+8 – [Impact Feedback](https://vividbreeze.com/impact-feedback/)
+9 – [Primed to Perform](https://yantougas.com/2016/02/15/blame/) REAP explanation
+10 – Rise Model ([2 mins video](https://www.youtube.com/watch?v=3cn306Fo_IU)) [www.risemodel.com](https://www.risemodel.com)
+11 – [The Shit Sandwich and Other Terrible Ways to Give Feedback](https://blog.idonethis.com/sandwich-feedback-performance-management/#:~:text=The%20main%20idea%20behind%20the,results%20in%20the%20exact%20opposite).

--- a/operations/team-practices/overview.md
+++ b/operations/team-practices/overview.md
@@ -1,0 +1,8 @@
+# Team Practices
+
+This chapter presents a collection of soft-skills that help to create a growth culture.
+Collectively, these practicess can be used to increase psychological safety by addressing interpersonal conflict, cultural difference, etc. 
+
+```{toctree}
+feedback
+```


### PR DESCRIPTION
This pull request adds a new section to the Team Operations chapter of the Team Compass. It introduce team-practices sub-sections and feedback as the first guide