### PR TITLE
Create a "Engineering work definition of ready" section

### DIFF
--- a/engineering/definition-of-ready.md
+++ b/engineering/definition-of-ready.md
@@ -30,25 +30,25 @@ The following non-exhaustive initial list of the different kinds of tasks that t
 The following describes what is the information needed for a member of the engineering team to start working on a specific type of work item.
 
 (ready:feature-enablement)=
-### Feature Enablement
+### Feature enablement
 
 (ready:routine-maintenance)=
 ### Routine maintenance
 
 (ready:new-hub)=
-### New Hub
+### New hub
 
 (ready:config-change)=
-### Config Change
+### Config change
 
 (ready:fault-fixing)=
-### Fault Fixing
+### Fault fixing
 
 (ready:community-review)=
-### Community Config Change Review
+### Community config change review
 
 (ready:incident-response)=
-### Incident Response
+### Incident response
 
 (ready:routing)=
 ### Routing

--- a/engineering/definition-of-ready.md
+++ b/engineering/definition-of-ready.md
@@ -1,0 +1,24 @@
+(engineering:definition-of-ready)=
+# Engineering work definition of ready
+
+The engineering team gets many different kinds of work from many different sources. An important question for solving these work items is: _**is something ready to be worked on?**_
+
+Answering this question, requires at least the following information:
+
+- What kind of work item something is
+- Does it have all the information needed for a member of the engineering team to start working on?
+- If it does not, what exactly is the information needed? And who is responsible for providing it?
+- Once all the information is provided, is there explicit documentation on what actually needs to be done?
+
+## Work categorization
+
+The following non-exhaustive initial list of the different kinds of tasks that the engineering team performs during a sprint cycle.
+
+1. Feature Enablement
+2. Routine maintenance
+3. New Hub
+4. Config Change
+5. Fault Fixing
+6. Community Config Change Review
+7. Incident Response
+8. Routing

--- a/engineering/definition-of-ready.md
+++ b/engineering/definition-of-ready.md
@@ -15,14 +15,14 @@ Answering this question, requires at least the following information:
 
 The following non-exhaustive initial list of the different kinds of tasks that the engineering team performs during a sprint cycle.
 
-1. Feature Enablement
-2. Routine maintenance
-3. New Hub
-4. Config Change
-5. Fault Fixing
-6. Community Config Change Review
-7. Incident Response
-8. Routing
+1. [](ready:feature-enablement)
+2. [](ready:routine-maintenance)
+3. [](ready:new-hub)
+4. [](ready:config-change)
+5. [](ready:fault-fixing)
+6. [](ready:community-review)
+7. [](ready:incident-Response)
+8. [](ready:routing)
 
 (dor:ready)=
 ## Definition of ready

--- a/engineering/definition-of-ready.md
+++ b/engineering/definition-of-ready.md
@@ -5,11 +5,12 @@ The engineering team gets many different kinds of work from many different sourc
 
 Answering this question, requires at least the following information:
 
-- What kind of work item something is
-- Does it have all the information needed for a member of the engineering team to start working on?
+- [What kind of work item something is](dor:categorization)
+- [Does it have all the information needed for a member of the engineering team to start working on?](dor:ready)
 - If it does not, what exactly is the information needed? And who is responsible for providing it?
 - Once all the information is provided, is there explicit documentation on what actually needs to be done?
 
+(dor:categorization)=
 ## Work categorization
 
 The following non-exhaustive initial list of the different kinds of tasks that the engineering team performs during a sprint cycle.
@@ -22,3 +23,32 @@ The following non-exhaustive initial list of the different kinds of tasks that t
 6. Community Config Change Review
 7. Incident Response
 8. Routing
+
+(dor:ready)=
+## Definition of ready
+
+The following describes what is the information needed for a member of the engineering team to start working on a specific type of work item.
+
+(ready:feature-enablement)=
+### Feature Enablement
+
+(ready:routine-maintenance)=
+### Routine maintenance
+
+(ready:new-hub)=
+### New Hub
+
+(ready:config-change)=
+### Config Change
+
+(ready:fault-fixing)=
+### Fault Fixing
+
+(ready:community-review)=
+### Community Config Change Review
+
+(ready:incident-response)=
+### Incident Response
+
+(ready:routing)=
+### Routing

--- a/engineering/index.md
+++ b/engineering/index.md
@@ -6,6 +6,7 @@ These sections have information about accounts, technology, and practices that a
 overview
 structure
 workflow
+definition-of-ready
 strategy
 access
 secrets


### PR DESCRIPTION
Solves first bullet of https://github.com/2i2c-org/meta/issues/953#issuecomment-2043457740 by porting @haroldcampbell's words describing the issue and adds the structure for the next sub-task.

Docs page rendered at https://2i2c-team-compass--835.org.readthedocs.build/engineering/definition-of-ready/