### PR TITLE
Link to value proposition

### DIFF
--- a/organization/mission.md
+++ b/organization/mission.md
@@ -15,6 +15,15 @@ We strive to make decisions that align with our values, though recognize that th
 
 Our values are currently defined in [the Mission, values, and strategy page](https://2i2c.org/mission/) of our brochure site.
 
+## Value proposition
+
+Our value proposition describes the key problem that our service solves, and how it uniquely solves that problem.
+It defines the way in which we want the service to be useful, and is a guiding principle for how prioritize enhancements.
+
+% TODO: Incorporate aspects of this slide deck into our mission, and/or the other sections of this page.
+Here's [our value proposition slide deck](https://docs.google.com/presentation/d/1kjxPAS7ZptK1OLPiAWmi7WjS5EaDHQtg3E_Gig8ldzE/edit?usp=sharing).
+It contains a core set of slides for reference and re-use.
+
 ## Key stakeholders
 
 2i2c defines some key stakeholders that it uses to assess impact and progress in accomplishing our mission.

--- a/organization/mission.md
+++ b/organization/mission.md
@@ -15,13 +15,13 @@ We strive to make decisions that align with our values, though recognize that th
 
 Our values are currently defined in [the Mission, values, and strategy page](https://2i2c.org/mission/) of our brochure site.
 
+(mission:value-proposition)=
 ## Value proposition
 
-Our value proposition describes the key problem that our service solves, and how it uniquely solves that problem.
-It defines the way in which we want the service to be useful, and is a guiding principle for how prioritize enhancements.
+A Value Proposition is a clear, concise statement that communicates the specific benefits that a product or service offers to a target market segment. It succinctly explains how the product or service uniquely solves a problem or improves a situation for the community partner or customer, the value it adds, and why it is a better choice compared to competitors.
 
 % TODO: Incorporate aspects of this slide deck into our mission, and/or the other sections of this page.
-Here's [our value proposition slide deck](https://docs.google.com/presentation/d/1kjxPAS7ZptK1OLPiAWmi7WjS5EaDHQtg3E_Gig8ldzE/edit?usp=sharing).
+[Our Value Proposition is in this slide deck](https://docs.google.com/presentation/d/1kjxPAS7ZptK1OLPiAWmi7WjS5EaDHQtg3E_Gig8ldzE/edit?usp=sharing).
 It contains a core set of slides for reference and re-use.
 
 ## Key stakeholders

--- a/product/deliveryflow.md
+++ b/product/deliveryflow.md
@@ -8,9 +8,7 @@ As the organization is now more mature, and the breadth and complexity of its of
 
 A North Star is a core value, principle or goal that is used to help make decisions about what to do and when to do it. It starts with the organization’s mission, and is refined through a Value Proposition. Having a good understanding of what 2i2c’s North Star is will be key to ensuring that whatever we do is aligned with where we want the organization to be.
 
-A Value Proposition is a clear, concise statement that communicates the specific benefits that a product or service offers to a target market segment. It succinctly explains how the product or service uniquely solves a problem or improves a situation for the community partner or customer, the value it adds, and why it is a better choice compared to competitors.
-
-We are currently in the process of revising our value proposition to more accurately who we are and where we want to be, and will be sharing it for feedback in the coming months. 
+[Our Value Proposition is defined here](mission:value-proposition).
 
 ## Becoming more intentional
 


### PR DESCRIPTION
This adds a link to the value proposition slides that we have recently been iterating on. While we may eventually want to integrate this more deeply with our compass, this gives us a link to the slides so that we have it formally listed on the site. We can continue to iterate on it incrementally, and create assets throughout our site, sales materials, etc, through the coming iterations.

- part of: https://github.com/2i2c-org/meta/issues/1092

### To do
- [x]  There is a section on the [2i2c product delivery workflow page](https://team-compass.2i2c.org/product/deliveryflow/#identifying-a-value-proposition-as-our-north-star) that also needs to be updated to reflect the new VP.
