### PR TITLE
Add link to the Fluency chart for Engineering

### DIFF
--- a/engineering/structure.md
+++ b/engineering/structure.md
@@ -38,7 +38,13 @@ We have adapted pieces from both ladders as follows:
 5. We also introduce **steps** for each numbered level as a way to build salary bands and enhance the granularity. It is expected that engineers advance step by step before entering a new level, although a whole-level jump may exist if there are enough reasons to justify it.
 6. Steps are evaluated every 6 months for 1-3 levels and every year for 4-7 levels, whereas numbered levels are evaluated every year for 1-3 levels and every 2 years for 4-7 levels.
 
-We have an internal and engineering-specific salary bands matrix associated with each level at https://docs.google.com/spreadsheets/d/1D_-RzXhyWw8jFs7KQQXKVRV4VrmOyXjQni2UTnk1044/edit#gid=0.
+### Fluency chart for Engineering
+
+Recently, as a way to add more structure around professional development and to help engineers know better about the shared expectations for each other, we have developed a [Fluency chart for Engineering](https://docs.google.com/spreadsheets/d/1-IDEpySWDh5NrxRu8yxPxsj9PRkG1yE9EvXnXQRnb6A/edit#gid=1665179918) based on the ladder we described in the previous section. This is a tool that will help us in the development of professional development plans for each of our engineers.
+
+### Salary bands for Engineeering
+
+We have an [internal and engineering-specific salary bands matrix](https://docs.google.com/spreadsheets/d/1D_-RzXhyWw8jFs7KQQXKVRV4VrmOyXjQni2UTnk1044/edit#gid=1576917309) based on the levels outlined in the carreer ladder.
 
 ### EM4
 

--- a/engineering/structure.md
+++ b/engineering/structure.md
@@ -42,6 +42,7 @@ We have adapted pieces from both ladders as follows:
 
 Recently, as a way to add more structure around professional development and to help engineers know better about the shared expectations for each other, we have developed a [Fluency chart for Engineering](https://docs.google.com/spreadsheets/d/1-IDEpySWDh5NrxRu8yxPxsj9PRkG1yE9EvXnXQRnb6A/edit#gid=1665179918) based on the ladder we described in the previous section. This is a tool that will help us in the development of professional development plans for each of our engineers.
 
+(engineering:salary)=
 ### Salary bands for Engineeering
 
 We have an [internal and engineering-specific salary bands matrix](https://docs.google.com/spreadsheets/d/1D_-RzXhyWw8jFs7KQQXKVRV4VrmOyXjQni2UTnk1044/edit#gid=1576917309) based on the levels outlined in the carreer ladder.

--- a/people/compensation.md
+++ b/people/compensation.md
@@ -61,6 +61,7 @@ We are working on updating our salary bands across 2i2c, see [this issue for det
 
 We have an [internal salary sheet listing current positions and levels](https://docs.google.com/spreadsheets/d/1JZaudP91jABvlKof_A1EUHJAXa7DywLSG69PpQi-Cck/edit?usp=sharing).
 
+We recently developed an [internal Engineering-specific salary bands matrix](../engineering/structure.md#salary-bands-for-engineeering) as well.
 
 ## Benefits and expenses policy
 

--- a/people/compensation.md
+++ b/people/compensation.md
@@ -61,7 +61,7 @@ We are working on updating our salary bands across 2i2c, see [this issue for det
 
 We have an [internal salary sheet listing current positions and levels](https://docs.google.com/spreadsheets/d/1JZaudP91jABvlKof_A1EUHJAXa7DywLSG69PpQi-Cck/edit?usp=sharing).
 
-We recently developed an [internal Engineering-specific salary bands matrix](../engineering/structure.md#salary-bands-for-engineeering) as well.
+We recently developed an [internal Engineering-specific salary bands matrix](engineering:salary) as well.
 
 ## Benefits and expenses policy
 

--- a/people/compensation.md
+++ b/people/compensation.md
@@ -61,7 +61,6 @@ We are working on updating our salary bands across 2i2c, see [this issue for det
 
 We have an [internal salary sheet listing current positions and levels](https://docs.google.com/spreadsheets/d/1JZaudP91jABvlKof_A1EUHJAXa7DywLSG69PpQi-Cck/edit?usp=sharing).
 
-We recently created a [new version](https://docs.google.com/spreadsheets/d/1D_-RzXhyWw8jFs7KQQXKVRV4VrmOyXjQni2UTnk1044/edit#gid=511920228) (still mostly a WIP document) with levels and salaries (without the corresponding mapping) for each area.
 
 ## Benefits and expenses policy
 

--- a/people/compensation.md
+++ b/people/compensation.md
@@ -59,7 +59,7 @@ Here are a few tips to understand the GuideStar reports:
 We are working on updating our salary bands across 2i2c, see [this issue for details](https://github.com/2i2c-org/meta/issues/171).
 :::
 
-We have a [internal salary sheet listing current positions and levels](https://docs.google.com/spreadsheets/d/1JZaudP91jABvlKof_A1EUHJAXa7DywLSG69PpQi-Cck/edit?usp=sharing).
+We have an [internal salary sheet listing current positions and levels](https://docs.google.com/spreadsheets/d/1JZaudP91jABvlKof_A1EUHJAXa7DywLSG69PpQi-Cck/edit?usp=sharing).
 
 We recently created a [new version](https://docs.google.com/spreadsheets/d/1D_-RzXhyWw8jFs7KQQXKVRV4VrmOyXjQni2UTnk1044/edit#gid=511920228) (still mostly a WIP document) with levels and salaries (without the corresponding mapping) for each area.
 

--- a/people/compensation.md
+++ b/people/compensation.md
@@ -59,7 +59,9 @@ Here are a few tips to understand the GuideStar reports:
 We are working on updating our salary bands across 2i2c, see [this issue for details](https://github.com/2i2c-org/meta/issues/171).
 :::
 
-We have [internal salary documents for the specific positions and levels](https://docs.google.com/spreadsheets/d/1JZaudP91jABvlKof_A1EUHJAXa7DywLSG69PpQi-Cck/edit?usp=sharing).
+We have a [internal salary sheet listing current positions and levels](https://docs.google.com/spreadsheets/d/1JZaudP91jABvlKof_A1EUHJAXa7DywLSG69PpQi-Cck/edit?usp=sharing).
+
+We recently created a [new version](https://docs.google.com/spreadsheets/d/1D_-RzXhyWw8jFs7KQQXKVRV4VrmOyXjQni2UTnk1044/edit#gid=511920228) (still mostly a WIP document) with levels and salaries (without the corresponding mapping) for each area.
 
 ## Benefits and expenses policy
 


### PR DESCRIPTION
Closes #https://github.com/2i2c-org/meta/issues/1032.
Additionally fix a few typos and update links for better discoverablity.
I will merge it right away since consensus about the fluency chart status has been achieved (at least for this iteration/version).