### PR TITLE
Document monthly budget projections process

### DIFF
--- a/finance/accounting.md
+++ b/finance/accounting.md
@@ -4,6 +4,10 @@ Accounting data describes the money that we **know** we have spent or that we **
 
 ## Accounting transactions airtable
 
+:::{admonition} This is not reliable
+This is not currently reliable, and we should update this section once it is.
+:::
+
 {term}`CS&S` provides us a monthly dataset of the last 6 months of all of all our accounting transactions.
 This is [in a Google Sheet that is automatically updated each day][gsheet].
 It includes the last 6 months of any transaction 2i2c has made (if we need more than 6 months of history, ask `fsp@2i2c.org` for a custom data dump).
@@ -48,6 +52,8 @@ Here's a brief video describing the above process.
 
 CS&S generates monthly reports for our current financial situation.
 You can find them in [our financial reports folder](https://drive.google.com/drive/folders/1vM_QX1J8GW5z8W5WemxhhVjcCS2kEovN?usp=sharing).
+
+When these monthly reports come in, it triggers [the monthly budget projection process](monthly-process.md).
 
 Below are some Frequently Asked Questions along with a more detailed description of these reports.
 

--- a/finance/index.md
+++ b/finance/index.md
@@ -8,6 +8,7 @@ strategy
 accounting
 contracts
 projections
+monthly-process
 payments
 cloud
 ```

--- a/finance/monthly-process.md
+++ b/finance/monthly-process.md
@@ -1,0 +1,18 @@
+# Monthly accounting and budget projection process
+
+Each month, we get a new batch of [monthly reports and accounting data](#accounting:statements) from CS&S.
+We use this as an opportunity to:
+
+- Confirm that our Contracts information is correct.
+- Confirm that our accounting transactions look correct.
+- Flag any items that require extra attention, such as Contracts that will expire soon.
+- Update our financial projections and calculate a new runway for 2i2c.
+
+Here's information about expectations and accountability for the process:
+
+- **When**: This process is triggered by the arrival of [new accounting reports](#accounting:statements) from CS&S.
+- **Who**:
+  - **The [](#role:delivery-manager)** is responsible for the overall process, and for monitoring the accounting and contracts statements each month.
+  - The **[](#role:partnerships-lead)** is expected to coordinate with [](#role:delivery-manager), and is responsible for taking action to follow up with communities and/or trigger the proper processes in CS&S to move things forward. 
+
+- **What**: [Here's a document with the process that we follow](https://docs.google.com/document/d/1iG2USbvccMGeobKpH52j37LZpmeNASKedJrb0mX8R8Y/edit?usp=sharing).


### PR DESCRIPTION
This is light documentation about the monthly process that we follow for creating budget projections when CS&S sends us new accounting reports each month.