### PR TITLE
Add link to cost reduction proposal doc

### DIFF
--- a/finance/projections.md
+++ b/finance/projections.md
@@ -16,6 +16,10 @@ It is stored as a Google Sheet at the following link:
 Budget projections model
 ```
 
+:::{admonition} Check out this video overview
+See [this video overview of the budget model](https://drive.google.com/file/d/1acDkO3jWifNtDl2LDkD37lKHtnjRf_jC/view?usp=drive_link) for an idea of how it is structured and how to use it.
+:::
+
 ## Update our budget projections model
 
 Each month, we get a new batch of accounting data from CS&S.

--- a/people/cost-reduction.md
+++ b/people/cost-reduction.md
@@ -1,0 +1,6 @@
+# Cost reduction decision making framework
+
+In some cases, 2i2c will need to reduce its costs in either the short or the long term due to changes in its financial outlook.
+The following document is an early proposal for a framework to help us make decisions in this case.
+
+[Cost reduction framework proposal](https://docs.google.com/document/d/1zgNxdWVNDbcY-J34bhjavI1fbSmPrv5MJO3HdNb1ED4/edit?usp=sharing)

--- a/people/index.md
+++ b/people/index.md
@@ -5,6 +5,7 @@
 overview.md
 expectations.md
 compensation.md
+cost-reduction.md
 development.md
 hiring.md
 titles.md


### PR DESCRIPTION
Links our cost reduction proposal document in the compass. Also adds a link to our budget model explainer video

- relates to https://github.com/2i2c-org/meta/issues/1357