### PR TITLE
Add info about Plausible website analytics

### DIFF
--- a/communication/blog.md
+++ b/communication/blog.md
@@ -33,11 +33,3 @@ Click the button below to find it.
 
 Blog post issue template
 ```
-
-## `screen.studio` licenses for screencasts
-
-The [`screen.studio`](https://screen.studio) tool is useful for recording high-quality screencasts of demonstrations.
-It is used to create movies and GIFs like the ones we share on [2i2c.org/platform](https://2i2c.org/platform).
-
-We have **three device slots for `screen.studio`**, and a single activation key that activates a device for one of the slots.
-A list of active slots and the key for adding a new device is in [our team BitWarden account](#account:bitwarden).

--- a/communication/index.md
+++ b/communication/index.md
@@ -12,4 +12,5 @@ mailinglist
 design
 publishing
 talks
+tools
 ```

--- a/communication/social.md
+++ b/communication/social.md
@@ -20,7 +20,7 @@ We just have not had the resources to plan for this kind of engagement.
 ## Twitter
 
 Our Twitter handle is ([@2i2c_org](https://twitter.com/2i2c_org)).
-Currently, there is nobody activately monitoring the Twitter account.
+Currently, there is nobody actively monitoring the Twitter account.
 
 **How to access**: See [](account:bitwarden).
 

--- a/communication/tools.md
+++ b/communication/tools.md
@@ -1,0 +1,23 @@
+# Tools
+
+Here is a list of tools that help with our marketing and outreach activities.
+
+## Buffer
+
+This is a productivity tool for posting across our X/Twitter, Mastodon and LinkedIn channels simultaneously and scheduling social media campaigns with a content calendar.
+
+How to access: See [](account:bitwarden).
+
+## Plausible
+
+[Plausible](https://plausible.io/2i2c.org) is a more ethical alternative to Google Analytics. It is used to analyse traffic to our website. This is a yearly subscription service and the bill date occurs on Aug 14.
+
+How to access: See [](account:bitwarden).
+
+## `screen.studio` licenses for screencasts
+
+The [`screen.studio`](https://screen.studio) tool is useful for recording high-quality screencasts of demonstrations.
+It is used to create movies and GIFs like the ones we share on [2i2c.org/platform](https://2i2c.org/platform).
+
+We have **three device slots for `screen.studio`**, and a single activation key that activates a device for one of the slots.
+A list of active slots and the key for adding a new device is in [our team BitWarden account](#account:bitwarden).


### PR DESCRIPTION
Rearranges all marketing outreach tools into one page and add info about Plausible website analytics

Closes https://github.com/2i2c-org/meta/issues/1310