### PR TITLE
FEAT: set last-updated from git

### DIFF
--- a/.github/workflows/test-docs.yaml
+++ b/.github/workflows/test-docs.yaml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,6 +8,10 @@ build:
   tools:
     python: "3.12"
     nodejs: "16"
+  jobs:
+    post_checkout:
+      # Make sure last-updated commits are available
+      - git fetch --unshallow || true
 
 sphinx:
   configuration: conf.py

--- a/conf.py
+++ b/conf.py
@@ -21,6 +21,7 @@ extensions = [
     "sphinx_togglebutton",
     "sphinxext.rediraffe",
     "sphinxcontrib.mermaid",
+    "sphinx_last_updated_by_git",
 ]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", ".github", ".nox", "README.md"]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ sphinx-togglebutton
 sphinxcontrib-mermaid
 sphinxext-rediraffe
 tomlkit
+sphinx-last-updated-by-git
 
 # Slack SDK for pulling Support Steward info
 slack-sdk


### PR DESCRIPTION
This PR sets the `last_updated` config using git. In conjunction with https://github.com/2i2c-org/sphinx-2i2c-theme/pull/30, this will enable us to see in our compass when the page content was last modified.