### PR TITLE
Keep the list of cloud accounts in one central place instead

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-team-member.md
+++ b/.github/ISSUE_TEMPLATE/new-team-member.md
@@ -56,37 +56,6 @@ Create 2i2c accounts and add to team accounts:
   - [ ] https://readthedocs.org/dashboard/2i2c-team-compass/users/
   - [ ] https://readthedocs.org/dashboard/2i2c-pilot-documentation/users/
 
-**Cloud engineering permissions**
-
-_This is only relevant for others that are joining our Engineering team._
-
-- [ ] Add to 2i2c hubs as an admin and update [`helm-charts/basehub/values.yaml`](https://github.com/2i2c-org/infrastructure/blob/master/helm-charts/basehub/values.yaml)
-- [ ] Add to appropriate GCP organizations and projects
-  - [ ] Organization `2i2c.org`'s [admin group](https://console.cloud.google.com/iam-admin/groups/03znysh73qbio4n?organizationId=184174754493)
-       - can only be done by Yuvi currently 
-  - [ ] Organization `2i2c.org`s [engineering group](https://console.cloud.google.com/iam-admin/groups/01opuj5n2qnifml?organizationId=184174754493)
-  - [ ] Outside-organization project for [`cloudbank`](https://console.cloud.google.com/iam-admin/iam?project=cb-1003-1696)
-  - [ ] Outside-organization project for [`ciroh-jupyterhub`](https://console.cloud.google.com/iam-admin/iam?project=ciroh-jupyterhub-423218)
-
-- [ ] Add to appropriate AWS projects
-  - [ ] Management account [`2i2c-sandbox`](https://2i2c.awsapps.com/start/#/) (Grants SSO access at https://2i2c.awsapps.com/start#/)
-  - [ ] Outside-SSO account [`openscapes`](https://783616723547.signin.aws.amazon.com/console)
-  - [ ] Outside-SSO account [`nmfs-openscapes`](https://891612562472.signin.aws.amazon.com/console)
-  - [ ] Outside-SSO account [`nasa-veda`](https://smce-veda.signin.aws.amazon.com/console)
-  - [ ] Outside-SSO account [`nasa-ghg`](https://smce-ghg-center.signin.aws.amazon.com/console)
-  - [ ] Outside-SSO account [`maap`](https://916098889494.signin.aws.amazon.com/console)
-  - [ ] Outside-SSO account [`disasters`](https://smce-aws-disasters.signin.aws.amazon.com/console)
-  - [ ] Outside-SSO account [`earthscope`](https://762698921361.signin.aws.amazon.com/console)
-  - [ ] Outside-SSO account [`projectpythia`](https://590183926898.signin.aws.amazon.com/console)
-    - An agreement has to be signed first for the smce-accounts
-- [ ] Add to appropriate Azure projects
-  - [ ] Outside-organization subscription for `utoronto` see https://github.com/2i2c-org/team-compass/issues/386
-- [ ] Add to appropriate JetStream2 projects
-  - [ ] CIS250031 - Multicloud and HPC support for interactive computing in open science
-  - [ ] SEE240014 - A Scalable Community Computing and Knowledge Gateway for Project Pythia
-- [ ] Add to [quay.io 2i2c team](https://quay.io/organization/2i2c/teams/owners)
-- [ ] NameCheap administration privileges to `2i2c.org` and `2i2c.cloud`
-
 **Roles**
 
 - [ ] Onboard into the [Support Triager Role](https://github.com/2i2c-org/team-compass/issues/new?assignees=&labels=type%3A+onboard&template=new-team-member.md&title=Onboarding+%3Cname%3E)

--- a/.github/ISSUE_TEMPLATE/offboard-team-member.md
+++ b/.github/ISSUE_TEMPLATE/offboard-team-member.md
@@ -55,30 +55,6 @@ Remove 2i2c accounts and remove from team accounts:
   - [ ] https://readthedocs.org/dashboard/2i2c-team-compass/users/
   - [ ] https://readthedocs.org/dashboard/2i2c-pilot-documentation/users/
 
-**Cloud engineering permissions**
-
-_This is only relevant for others that are leaving our Engineering team._
-
-- [ ] Remove from 2i2c hubs as an admin
-- [ ] Remove from appropriate GCP organizations and projects
-  - [ ] Organization `2i2c.org`'s [admin group](https://console.cloud.google.com/iam-admin/groups/03znysh73qbio4n?organizationId=184174754493)
-  - [ ] Organization `2i2c.org`s [engineering group](https://console.cloud.google.com/iam-admin/groups/01opuj5n2qnifml?organizationId=184174754493)
-  - [ ] Outside-organization project for [`cloudbank`](https://console.cloud.google.com/iam-admin/iam?project=cb-1003-1696)
-  - [ ] Outside-organization project for [`meom-ige`](https://console.cloud.google.com/iam-admin/iam?project=meom-ige-cnrs)
-  - [ ] Outside-organization project for [`callysto`](https://console.cloud.google.com/iam-admin/iam?project=callysto-202316)
-  - [ ] (optional) Outside-organization project for [`pangeo-hubs`](https://console.cloud.google.com/iam-admin/iam?project=columbia)
-
-- [ ] Remove from appropriate AWS projects
-  - [ ] Management account [`2i2c-sandbox`](https://2i2c.awsapps.com/start/#/) (Grants SSO access at https://2i2c.awsapps.com/start#/)
-  - [ ] Outside-SSO account [`carbonplan`](https://631969445205.signin.aws.amazon.com/console)
-  - [ ] Outside-SSO account [`openscapes`](https://783616723547.signin.aws.amazon.com/console)
-  - [ ] Outside-SSO account [`nasa-veda`](https://smce-veda.signin.aws.amazon.com/console)
-    - An agreement has to be signed first, see https://github.com/2i2c-org/leads/issues/104
-- [ ] Remove from appropriate Azure projects
-  - [ ] Outside-organization `utoronto` contact them for removal 
-- [ ] Remove from [quay.io 2i2c team](https://quay.io/organization/2i2c/teams/owners)
-- [ ] Remove NameCheap administration privileges to `2i2c.org` and `2i2c.cloud`
-
 **External**
 
 - [ ] Remove from [2i2c website](https://2i2c.org/organization/)

--- a/.github/workflows/accounts.md
+++ b/.github/workflows/accounts.md
@@ -1,0 +1,31 @@
+
+**Cloud engineering permissions**
+
+_This is only relevant for Product and services team._
+
+- [ ] 2i2c hubs admin [`helm-charts/basehub/values.yaml`](https://github.com/2i2c-org/infrastructure/blob/master/helm-charts/basehub/values.yaml)
+- [ ] GCP organizations and projects
+  - [ ] Organization `2i2c.org`'s [admin group](https://console.cloud.google.com/iam-admin/groups/03znysh73qbio4n?organizationId=184174754493)
+       - can only be done by Yuvi currently 
+  - [ ] Organization `2i2c.org`s [engineering group](https://console.cloud.google.com/iam-admin/groups/01opuj5n2qnifml?organizationId=184174754493)
+  - [ ] Outside-organization project for [`cloudbank`](https://console.cloud.google.com/iam-admin/iam?project=cb-1003-1696)
+  - [ ] Outside-organization project for [`ciroh-jupyterhub`](https://console.cloud.google.com/iam-admin/iam?project=ciroh-jupyterhub-423218)
+
+- [ ] AWS projects
+  - [ ] Management account [`2i2c-sandbox`](https://2i2c.awsapps.com/start/#/) (Grants SSO access at https://2i2c.awsapps.com/start#/)
+  - [ ] Outside-SSO account [`openscapes`](https://783616723547.signin.aws.amazon.com/console)
+  - [ ] Outside-SSO account [`nmfs-openscapes`](https://891612562472.signin.aws.amazon.com/console)
+  - [ ] Outside-SSO account [`nasa-veda`](https://smce-veda.signin.aws.amazon.com/console)
+  - [ ] Outside-SSO account [`nasa-ghg`](https://smce-ghg-center.signin.aws.amazon.com/console)
+  - [ ] Outside-SSO account [`maap`](https://916098889494.signin.aws.amazon.com/console)
+  - [ ] Outside-SSO account [`disasters`](https://smce-aws-disasters.signin.aws.amazon.com/console)
+  - [ ] Outside-SSO account [`earthscope`](https://762698921361.signin.aws.amazon.com/console)
+  - [ ] Outside-SSO account [`projectpythia`](https://590183926898.signin.aws.amazon.com/console)
+    - An agreement has to be signed first for the smce-accounts
+- [ ] Azure projects
+  - [ ] Outside-organization subscription for `utoronto` see https://github.com/2i2c-org/team-compass/issues/386
+- [ ] JetStream2 projects
+  - [ ] CIS250031 - Multicloud and HPC support for interactive computing in open science
+  - [ ] SEE240014 - A Scalable Community Computing and Knowledge Gateway for Project Pythia
+- [ ] [quay.io 2i2c team](https://quay.io/organization/2i2c/teams/owners)
+- [ ] NameCheap administration privileges to `2i2c.org` and `2i2c.cloud`

--- a/.github/workflows/update-onboard-offboard.yaml
+++ b/.github/workflows/update-onboard-offboard.yaml
@@ -1,0 +1,31 @@
+name: Auto-update onboarding/offboarding issues with accounts list
+on:
+  issues:
+    types: [opened, labeled]
+
+jobs:
+  update-issue:
+    runs-on: ubuntu-latest
+
+    if: |
+      contains(github.event.issue.labels.*.name, 'onboarding') ||
+      contains(github.event.issue.labels.*.name, 'offboarding')
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Read accounts.md
+        id: readfile
+        run: |
+          echo "content<<EOF" >> $GITHUB_ENV
+          cat accounts.md >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+
+      - name: Add comment with accounts list
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            ### Current Account List
+
+            ${{ env.content }}


### PR DESCRIPTION
I realized this https://github.com/2i2c-org/team-compass/issues/975 wasn't complete, because I hadn't updated the offboard list while doing https://github.com/2i2c-org/team-compass/pull/972.

Instead of maintaining this list in two different issue templates, we should centralize it and add it automatically to the issue body by a bot.

Ref:
https://github.com/2i2c-org/meta/issues/2249