### PR TITLE
Add an organizational chart

### DIFF
--- a/engineering/roles/engineering-manager.md
+++ b/engineering/roles/engineering-manager.md
@@ -8,13 +8,14 @@ The Engineering Manager focuses on creating a high functioning team. They work c
 ## Responsibilities
 
 ### Managing engineering capacity & capability. 
-As our product evolves, our team will need to learn and adapt. The Engineering Manager is responsible for strategic professional development, ensuring that we grow the capabilities we need and use the capabilities we have well. They partner with the Technical Lead in identifying capability needs, hiring, advising team members, creating structures to grow capabilities, and evaluating our collective progress. Ultimately the Engineering Manager is responsible (and accountable) for the team’s engineering capacity and capabilities.
 
-### Health of our delivery. 
+The Engineering Manager is responsible for strategic professional development, ensuring that we grow the capabilities we need and use the capabilities we have well. They partner with the Technical Lead in identifying capability needs, hiring, advising team members, creating structures to grow capabilities, and evaluating our collective progress. Ultimately the Engineering Manager is responsible (and accountable) for the team’s engineering capacity and capabilities.
+
+### Health of our delivery.
 They’re primarily responsible for the engineering group’s delivery of the socio-technical product we provide, by creating a team culture and a system of roles and processes that makes our product & services team successful, and allows our team members to thrive. 
 
-
 ## How they work with the team
+
 - Advocates for the needs and goals of our engineers in defining organizational and team goals, in partnership with the Executive Director and other group leads
 - Owns systems of work - in partnership with the Delivery Enablement team, ensures engineering follows agreed processes and structures for managing work, following through on deliverables and holds ourselves accountable 
 - Makes sure work is consistently completed and showcased within each sprint 

--- a/organization/structure.md
+++ b/organization/structure.md
@@ -2,11 +2,11 @@
 
 This section describes the major structure of 2i2c and how it is broken into functional groups and teams.
 
-(structure:fiscal-sponsor)=
-## Fiscal sponsorship
+Here's an overview of our organizational structure and reporting lines. See the links in the digram for more information about each team.
 
-2i2c is a [fiscally sponsored project](https://en.wikipedia.org/wiki/Fiscal_sponsorship) of {term}`Code for Science and Society`, a US 501(c)(3) public charity.
+<iframe width="768" height="496" src="https://miro.com/app/live-embed/uXjVIiFUM3Q=/?focusWidget=3458764633437513770&embedMode=view_only_without_ui&embedId=915001613516" frameborder="0" scrolling="no" allow="fullscreen; clipboard-read; clipboard-write" allowfullscreen></iframe>
 
+(structure:areas)=
 ## Functional teams
 
 Functional areas are organized around _responsibilities, skills, and career tracks_.
@@ -36,3 +36,8 @@ The Steering Council provides accountability to the Executive Director, and prov
 :maxdepth: 2
 role/steering-council.md
 ```
+
+(structure:fiscal-sponsor)=
+## Fiscal sponsorship and non-profit status
+
+2i2c is a [fiscally sponsored project](https://en.wikipedia.org/wiki/Fiscal_sponsorship) of {term}`Code for Science and Society`, a US 501(c)(3) public charity.

--- a/organization/structure.md
+++ b/organization/structure.md
@@ -4,6 +4,8 @@ This section describes the major structure of 2i2c and how it is broken into fun
 
 Here's an overview of our organizational structure and reporting lines. See the links in the digram for more information about each team.
 
+% To modify, see the following link:
+% https://miro.com/app/board/uXjVIiFUM3Q=/?moveToWidget=3458764633437513770&cot=14
 <iframe width="768" height="496" src="https://miro.com/app/live-embed/uXjVIiFUM3Q=/?focusWidget=3458764633437513770&embedMode=view_only_without_ui&embedId=915001613516" frameborder="0" scrolling="no" allow="fullscreen; clipboard-read; clipboard-write" allowfullscreen></iframe>
 
 (structure:areas)=


### PR DESCRIPTION
This adds an organizational chart, with a link to a Miro board that we can edit. The chart is **public** in read-only, and editable by any team member. My goal is to describe the current relationships between all the roles in the organization, and who is in each role. A few thoughts:

- I kept a few roles that are drawing capacity but don't have a person explicitly added in.
- There's some kind of "community engagement" role drawing capacity but we don't know if it's a BD or a P&S role, so I left it floating intentionally.
- We had some debate about whether Yuvi's relationship to the engineers was a dotted or a direct line, and I opted for dotted because of [this language in the compass](http://compass.2i2c.org/engineering/roles/engineering-manager/).

I'm going to merge this in because I've already had a few rounds of review from folks. Thanks!