### PR TITLE
Update engineering structure 

### DIFF
--- a/engineering/roles/engineering-manager.md
+++ b/engineering/roles/engineering-manager.md
@@ -9,7 +9,7 @@ The Engineering Manager focuses on creating a high functioning team. They work c
 
 ### Managing engineering capacity & capability. 
 
-The Engineering Manager is responsible for strategic professional development, ensuring that we grow the capabilities we need and use the capabilities we have well. They partner with the Technical Lead in identifying capability needs, hiring, advising team members, creating structures to grow capabilities, and evaluating our collective progress. Ultimately the Engineering Manager is responsible (and accountable) for the team’s engineering capacity and capabilities.
+The Engineering Manager is responsible for strategic professional development, ensuring that we grow the capabilities we need and use the capabilities we have well. They partner with the Technical Lead in identifying capability needs, hiring, advising team members, creating structures to grow capabilities, and evaluating our collective progress. Ultimately the Engineering Manager is responsible (and accountable) for the team’s engineering capacity and capabilities, but in the case of hiring or exit decisions, they are co-equal with the Technical Lead and the two roles must either reach consensus or disagree but commit. 
 
 ### Health of our delivery.
 They’re primarily responsible for the engineering group’s delivery of the socio-technical product we provide, by creating a team culture and a system of roles and processes that makes our product & services team successful, and allows our team members to thrive. 

--- a/engineering/roles/technology-lead.md
+++ b/engineering/roles/technology-lead.md
@@ -8,6 +8,8 @@ The Tech Lead is the leadership team member responsible for our technology decis
 
 They pair with the Head of Products & Services to make technology choices that meet our communities’ needs, and with the Engineering Manager to support the team as a whole delivering on the commitments we make. They have authority and responsibility to make best effort, “safe to try” technological choices when we cannot reach consensus.
 
+The Tech Lead and Engineering manager are co-equals in the case of hiring or exit decisions, and the two roles must either reach consensus or disagree but commit. 
+
 
 ## Responsibilities
 ### Building engineering capacity & capability. 

--- a/engineering/structure.md
+++ b/engineering/structure.md
@@ -4,7 +4,7 @@
 (engineering:structure)=
 # Structure and roles
 
-Within the Product & Services team, Engineers are jointly led by our {role}`Technology Lead` and {role}`Engineering Manager` and supported by {role}'Delivery Manager'.
+Within the Product & Services team, Engineers are jointly led by our {role}`Technology Lead` and {role}`Engineering Manager`.
 
 
 (engineering:roles)=


### PR DESCRIPTION
Adds an important note that we treat the Engineering Manager and Technology Lead as co-equals in hiring and exit decisions, since we each have a part of the information needed to hire or exit an engineer. Practically that means we must either reach a consensus or disagree but commit to the other person's decision. 