### PR TITLE
Explicitly prioritize incident action items

### DIFF
--- a/projects/managed-hubs/incidents.md
+++ b/projects/managed-hubs/incidents.md
@@ -242,6 +242,12 @@ To designate another team member as the Incident Commander, follow these steps:
 2. **Reassign the incident on PagerDuty** to the new commander. This should produce a message in the slack channel for this event,
    thus communicating this change to the rest of the team.
 
+## Post-incident action items
+
+After the incident is over, we *must* prioritize any action items that prevent this kind of incident at the same level as a contract deliverable, and attempt to bring it into the next sprint. While we can't guarantee there shall be no outages, we must do everything we can to prevent known causes of outages from recurring.
+
+It's the tech lead's responsibility to shape an absolute minimum sized task to mitigate the issue that caused this incident, and the responsibility of the tech lead & engineering manager to advocate for bringing it in during the next sprint.
+
 ## Key terms
 
 ```{glossary}


### PR DESCRIPTION
One of our antipatterns is to not take action on our incident action items, because they do not explicitly take priority. So they get left for 'some day' in the future, and unfortunately often that means they cause another outage. This was true for the cloudbank outage - this had happened before, but it recovered itself, so we left it untouched.

We explicitly add process here to make sure we bring this work in during the next sprint.

Ref https://github.com/2i2c-org/infrastructure/issues/6478