### PR TITLE
Have tech lead review incidents in last sprint

### DIFF
--- a/engineering/workflow/default-workflow.md
+++ b/engineering/workflow/default-workflow.md
@@ -139,15 +139,22 @@ The Engineering Manager will:
 
 #### 📆 At the Planning Session 
 
-The Engineering Manager will:
 
 #### 🔁 Sprint Review & Retrospective
+
+The Engineering Manager will:
 
 - **Review last sprint’s outcomes**
   - Compare *actual velocity* vs. target
   - Document the *status update*
   - Identify questions or blockers on leftover cards
   - Incorporate *retro feedback* to adjust workflows
+
+The Tech Lead will:
+
+- **Review last sprint's outages** (maximum 3 minutes)
+  - List all the P1 outages during the last sprint
+  - Flag any pending incident reports that have not been completed
 
 #### 🎯 Define Sprint Goals
 


### PR DESCRIPTION
This ensures that:

1. The team is aware of the outages we have had this sprint (and the progress we are making)
2. We try to finish the incident reports before the start of next sprint, and if we don't, we flag that as an ongoing issue to be prioritized

I've also intentionally set a max time limit so this doesn't drag on. It's important to respect people's time and finish meetings on time.