### PR TITLE
Update our technical support procedures

### DIFF
--- a/projects/managed-hubs/support/index.md
+++ b/projects/managed-hubs/support/index.md
@@ -10,11 +10,9 @@ The content on this page might change over time, and we welcome suggested change
 This section contains information that our team uses to triage, communicate, and
 resolve {term}`Support Requests` that come from communities.
 
-Currently, Engineering has the authority to design the system of roles and
+The Product and Services team is responsible for delivering our Technical Support and has the authority to design the system of roles and
 processes that defines "support at 2i2c", and to advocate for the resources
-needed to fill those roles. This will naturally be done in collaboration with
-others in 2i2c, but Engineering leads the effort and has an outsized role in the
-decision-making.
+needed to fill those roles. 
 
 ```{toctree}
 terminology

--- a/projects/managed-hubs/support/process.md
+++ b/projects/managed-hubs/support/process.md
@@ -3,21 +3,24 @@
 
 ## Overview of the support process
 
+:::{admonition} Support Process Flowchart
+See this [Miro Board](https://miro.com/app/board/uXjVJYcJFsk=/) for a flow chart visualization of our suport process.
+:::
+
 Here's a brief overview of our support process[^github-support-issues]:
 
 [^github-support-issues]: We had a lot of discussion around various support and operations systems to take as inspiration. [This GitHub Issue](https://github.com/2i2c-org/infrastructure/issues/1068) has a lot of useful discussion, including a few write-ups of specific support systems to use as inspiration ([example one](https://github.com/2i2c-org/infrastructure/issues/1068#issuecomment-1063138772) [example two](https://github.com/2i2c-org/infrastructure/issues/1068#issuecomment-1063516429))
 
-- A {term}`Community Representative` sends a request to `support@2i2c.org`.
-- This is triaged by our {term}`Support Triager` team.
-  - They assess whether they can resolve it quickly, and potentially do so.
-  - If they cannot resolve it, then we raise this support issue with our engineering team.
+- A {term}`Community Representative` sends a request to `support@2i2c.org` or through the FreshDesk web widget.
+- This request is triaged by our {term}`Support Triager`.
+  - We will acknowledge the request within one working day[^working-day].
 - If the issue is an {term}`Incident`
   - We will designate an {term}`Incident Commander` to orchestrate our efforts around the incident.
   - We will prioritize resolving it over everything else.
   - We will open a dedicated [Incident issue](support:incident-response) to track its progress.
   - We will provide regular communication to the {term}`Community Representative` as we investigate and work to resolve the issue.
   - We will notify them once the incident is resolved.
-- If the issue is a {term}`Change Request` or {term}`Guidance Request`
+- If the issue is a {term}`Change Request`, {term}`Guidance Request`, or [](support:workshop-request)
   - We will incorporate these requests into our work planning pipeline
   - We will [prioritize with our other work](support:prioritize-requests) based on impact, complexity, and whether we have dedicated funding for this work.
   - For these types of support, each community has a {term}`Support Budget` that defines the hours we can sustainably spend on non-incident support requests.
@@ -31,41 +34,27 @@ Here is the process that we follow when triaging and resolving support requests.
 
 The goal of the triage phase is to understand the Support Request, decide if it is related to an incident, and choose the appropriate resolution pathway.
 
-This process is carried out in an ongoing basis by the {term}`Support Triagers`.
+This process is carried out in an ongoing basis by the {term}`Support Triager` and {term}`Support Agents`.
 
-1. **Monitor our support channels**. We use FreshDesk for all support requests, and the Support Triagers should regularly keep an eye on this account for new requests.
+1. **Monitor our support channels**. We use FreshDesk for all support requests, and the Support Triager should regularly keep an eye on this account for new requests.
    When a new support requests comes in, move to the next step.
-2. **Read and understand**. Within one working day[^working-day], read the support request and try to understand what action would resolve it.
-3. **Associate Ticket with a Community**. Verify the support ticket is associated with the correct community.
-4. **Decide if there is an incident**. Determine if a request meets {term}`the definition of an incident <Incident>`.
-5. **Categorize the Support Ticket** in FreshDesk.
-6. **If an Incident**, go to [](support:incident-response).
-7. **If not an Incident**, go to [](support:non-incident-response).
-8. **End of rotation hand-off**, see [below](support:end-of-rotation-hand-off).
+2. **Associate Ticket with a Community**. Verify the support ticket is associated with the correct community. See [](support:community-association)
+3. **Assign a Support Agent to the Ticket**. The Support Triager assigns the ticket to a {term}`Support Agent` based on the considerations:
+   - Who has touched this hub most recently?
+   - Is this a documentation related question?
+   - Who has capacity? Who is already loaded?
+   - Who has the skills? Who could use this as a learning opportunity.
+4. **Acknowledge and notify**. Notify the {term}`Community Representative` that the ticket has been assigned to a {term}`Support Agent`.
+
+The ticket has now been assigned a {term}`Support Agent` who continues the process
+
+5. **Read and understand**. Within one working day[^working-day], read the support request and try to understand what action would resolve it.
+6. **Decide if there is an incident**. Determine if a request meets {term}`the definition of an incident <Incident>`.
+7. **Categorize the Support Ticket** in FreshDesk.
+8. **If an Incident**, go to [](support:incident-response).
+9. **If not an Incident**, go to [](support:non-incident-response).
 
 [^working-day]: We define a working day as a continuous 24 hour period of time from Monday through Friday. This is because our team and the communities we serve are distributed across many time zones, so there is no single "working day" for everyone.
-
-:::{admonition} Freshdesk Communities and Contacts
-FreshDesk has the concept of a 'Company' that can be associated independently with both tickets and contacts. We interpret the 'Company' in Freshdesk to mean the 2i2c Community that is being served.
-
-When a ticket comes into FreshDesk is automatically associated with the Community based on the 'Company' of the Community Representative submitting the ticket.
-
-When a new Community is being onboarding, create a new "company" in FreshDesk:
-```{image} /images/support/freshdesk_newcompany.png
-:width: 200
-```
-
-To update the list of Community Representatives, edit the Company:
-```{image} /images/support/freshdesk_company.png
-:width: 500
-```
-
-For each Community Representative, create a new Contact entry. Contacts may be affliated with multiple Communities if required:
-```{image} /images/support/freshdesk_associatecommunity.png
-:width: 500
-```
-:::
-
 
 (support:non-incident-response)=
 ### Non-incident response process
@@ -75,34 +64,12 @@ The current iteration of the workflow states each step and who should be respons
 
 When a new ticket lands in Freshdesk under the support group and it is not an incident, we aim to respond within 24 working hours with a suggested next action. The next steps should be followed when resolving a ticket:
 
-1. `Who: Support Triager`
 
-   First, we determine if the person *initiating* the support ticket is *authorized* to do actually do so. While we may interact with many folks
-   from a community during resolution of a ticket, we constrain who can *initiate* a ticket to {term}`Community Representative`s only. This prevents our
-   support staff from being overwhelmed by tickets that need to be handled elsewhere. If the person *initiating* the ticket is not a community
-   representative, the support steward should cc the community representatives, and ask for approval. The support steward *may* choose to use the following
-   email template:
-
-   > Hello <names of community representatives>,
-   >
-   > I'm cc'ing you on this support ticket we received from a member of your community. To streamline our support process, 2i2c is accepting
-   > support requests only from communtity representatives. Can you read through the request, and let us know how you wish to proceed?
-   >
-   > Thanks.
-
-   The *source of truth* for Community Representatives is the FreshDesk "Company" entry that is used to represent each of our Communities. Community Representatives are shown adjacent to each FreshDesk ticket:
-
-    ```{image} /images/support/freshdesk_ticket.png
-    :width: 500
-    ```
-
-
-
-2. `Who: Support Triager`
+1. `Who: Support Agent`
 
    **First 24h initial ticket evaluation**. In the first 24h a support ticket was opened, you should do an initial evaluation of the ticket and ask the {term}`Community Representative` about any additional information you may need.
 
-3. `Who: Support Triager`
+2. `Who: Support Agent`
 
    **Spend 30 minutes trying to resolve**. If you believe you can resolve the issue within 30 minutes, try resolving it yourself.
    1. If you resolve the issue, then jump to the "Confirm resolution" step 10.
@@ -110,13 +77,13 @@ When a new ticket lands in Freshdesk under the support group and it is not an in
 
    Follow the guide at [](support:timeboxed-evaluation) to try and reach to a decision.
 
-4. `Who: Support Triager`
+3. `Who: Support Agent`
 
    **Open an issue in the 2i2c/infrastructure repository**. If this is an issue that cannot be resolved within 30 minutes, then open a GitHub issue for the team to discuss.
 
    [{bdg-primary}`Open a "Freshdesk ticket tracker" type of issue`](https://github.com/2i2c-org/infrastructure/issues/new?assignees=&labels=&template=5_freshdesk-ticket.yml). Use this to describe the ticket and provide as many details as possible about the results obtained in the first 30m investigation (if any).
 
-   This issue will then be automatically added to the **Eng & Prod** board by the existing automation alongside the the **type**: `support` and the **impact** level specified in the form project fields.
+   This issue will then be automatically added to the **Product and Services** board by the existing automation alongside the the **type**: `support` and the **impact** level specified in the form project fields.
 
    If the issue has a `critical` impact (we defer that first evaluation to the support triager), an additional ping to the support Slack channel is needed to boost the signal.
    
@@ -136,21 +103,17 @@ When a new ticket lands in Freshdesk under the support group and it is not an in
      * Authentication and authorization updates
    :::
 
-   The support Triager **should** self-assign the `critical` issue and work on it immediately (this is now outside of the 30-minute timebox described in step 3).
+   The Support Agent **should** self-assign the `critical` issue and work on it immediately (this is now outside of the 30-minute timebox described in step 3).
 
-   If the support Triagers (both of them) do not have the capacity to resolve the `critical` issue (ie. working on another `critical` issue, being out of their working time, etc.), they should ping the **Engineering Manager** (or the delegated person) so they can secure resources to resolve that issue on the fly (see step 8 below).
+   If the Support Agent does not have the capacity to resolve the `critical` issue (ie. working on another `critical` issue, being out of their working time, etc.), they should ping the **Engineering Manager** (or the delegated person) so they can secure resources to resolve that issue on the fly (see step 8 below).
 
-   The support Triager **should not** work on issues with impact lower than `critical` (unless they are assigned as part of the "planned" reactive work in the context of a running sprint (see step 8 below).
+   The Support Agent **should not** work on issues with impact lower than `critical` (unless they are assigned as part of the "planned" reactive work in the context of a running sprint (see step 8 below).
 
-5. `Who: Partnerships representative and the Engineering Manager (or respective delegates)`
-
-   **Revisit the impact metadata**. Once a week (at minimum) the [support view in the **Eng & Prod** board](https://github.com/orgs/2i2c-org/projects/22/views/47) should be revisited to validate the impact level on support-related issues. Currently, we allocate a 30-minute working session every Wednesday (open to everyone to participate) to perform such impact revision and further prioritization ("planned" reactive) every other week (see step 8 for more details).
-        
 6. `Who: Support Triager`
 
-   **Add a reference/link to the created engineering issue inside the Freshdesk ticket**. You can use an internal note or make it public when you communicate back to the Community Representative in step 7. Also, move the status of the ticket to the "Pending" state.
+   **Add a reference/link to the created GitHub issue inside the Freshdesk ticket**. You can use an internal note or make it public when you communicate back to the Community Representative in step 7. Also, move the status of the ticket to the "Pending" state.
 
-7. `Who: Support steward`
+7. `Who: Support Agent`
 
    **Communicate status**. Once we have an issue created to track the next steps, send a message to the Community Representative letting them know about the situation: after some initial investigation and no immediate fix, a follow-up issue was created that will be assigned in the future accordingly to the current prioritization. Also, let them know what the next steps will be. Here's a template to help guide you:
 
@@ -161,52 +124,33 @@ When a new ticket lands in Freshdesk under the support group and it is not an in
    when we've got a plan for completing this request.
    ```
 
-8. `Who: Engineering Manager (currently assigning reactive work) or someone delegated by the Engineering Manager`
-
-   **Prioritize the request**. Any non-`critical` issue should wait to be included in our sprints (on Wednesdays, every other week) to be worked out as part of the "planned" reactive work. Follow the [how to prioritize Change and Guidance Requests guide](support:prioritize-requests) to decide how we should prioritize this request relative to the other work we need to do. We should be fully transparent about the support queue to our Community Representatives if they ping us for updates.
-
-   If there is any `critical` issue, we could assign people on the fly (during the sprint) to resolve them, but we should minimize that behavior (it should be exceptional cases).
-
-9. `Who: Support Triager`
+9. `Who: Support Agent`
 
    **Resolve the request**. When some engineer is assigned to a support-related GH issue in the context of a sprint, we move ahead with the investigation/resolution for one (1) sprint. If we failed to find a fix during that time, we communicate back that state in the Freshdesk ticket and resolve it.
 
    Exceptional tickets might need more than one sprint. These tickets need to be explicitly approved as exceptions.
 
-10. `Who: Support Triager`
+10. `Who: Support Agent`
 
    **Confirm resolution**. Once we have resolved a support request, send a message to the Community Representative to confirm that we believe it is resolved. In FreshDesk, mark the incident as {guilabel}`Resolved`.
+
+   Marking a ticket as {guilabel}`Resolved` will automatically trigger a Freshdesk Satisfaction Survey. If sending out this survey is not applicable, mark the ticket as {guilabel}`Closed` instead.
 
 11. `Who: Support Triager`
 
     **Close the request**. If the Community Representative confirms that their request has been fulfilled, consider this request closed. In FreshDesk, mark the incident as {guilabel}`Closed`.
 
-(support:end-of-rotation-hand-off)=
-### End of rotation hand-off
+    **Reopen the request**. If the Community Representative reports that their request has not be fulfilled, consider this request open and repeat the Support Procss. In FreshDesk, mark the incident as {guilabel}`Open`.
 
-Below is the process describing the expectations before a triager's end of rotation.
+(support:workshop-request)=
+### Workshop Request
 
-1. Processed ~all unassigned tickets
-
-_Support triagers should aim to process each unassigned ticket before the end of the rotation._
-
-This helps us ensure no tickets becomes stale and unattended, and nudges us to get tickets closed or resolved rather than stuck open or pending indefinitively. Tickets left open becomes weight over time.
-
-2. Unassign from tickets
-
-_Support triagers should by end of rotation unassign themselves as agents from all tickets._
-
-This helps making responsibilities unambigious. A ticket's assigned agent should be either nobody or one of the current triagers.
-
-3. Write handover notes
-
-_Support triagers should, when they unassign from a ticket ensure a handover note is available and up to date towards the end of the ticket._
-
-A ticket handover note should _summarize whats relevant_ to know in order to drive the ticket towards a resolution without needing to read through the conversation up to that point.
-
-This should be written using the [private notes](https://support.freshdesk.com/en/support/solutions/articles/37580-private-notes-for-internal-sharing)
-feature of freshdesk.
-
+Requests for set up of workshops (including changing shared passwords) are not assigned a Support Agent and need to be scheduled for future action.
+  - Create GitHub issue in the Infrastructure repository
+  - Acknowledge the Workshop Request and link to the GitHub issue.
+  - GitHub issue gets planned in iteration planning
+  - Freshdesk ticket marked as Pending
+  - When the request has been completed, mark the ticket as resolved.
 
 (support:prioritize-requests)=
 ## Prioritizing non-incident support requests
@@ -231,4 +175,53 @@ We have a few roles that are particularly useful for triaging and prioritizing o
 
 When deciding how to prioritize a Change Request, ask for guidance from these two team members.
 
+:::
+
+
+(support:community-association)=
+### Associating Support Tickets with Communities
+
+1. `Who: Support Triager`
+
+   Support Tickets are associated with Commuities based on the identity of the Ticket Requestor. 
+
+1. `Who: Support Triager`
+
+   We also need determine if the person *initiating* the support ticket is *authorized* to do actually do so. While we may interact with many folks
+   from a community during resolution of a ticket, we constrain who can *initiate* a ticket to {term}`Community Representative`s only. This prevents our
+   support staff from being overwhelmed by tickets that need to be handled elsewhere. If the person *initiating* the ticket is not a community
+   representative, the support steward should cc the community representatives, and ask for approval. The support steward *may* choose to use the following
+   email template:
+
+   > Hello <names of community representatives>,
+   >
+   > I'm cc'ing you on this support ticket we received from a member of your community. To streamline our support process, 2i2c is accepting
+   > support requests only from communtity representatives. Can you read through the request, and let us know how you wish to proceed?
+   >
+   > Thanks.
+
+   The *source of truth* for Community Representatives is the FreshDesk "Company" entry that is used to represent each of our Communities. Community Representatives are shown adjacent to each FreshDesk ticket:
+
+    ```{image} /images/support/freshdesk_ticket.png
+    :width: 500
+    ```
+:::{admonition} Freshdesk Communities and Contacts
+FreshDesk has the concept of a 'Company' that can be associated independently with both tickets and contacts. We interpret the 'Company' in Freshdesk to mean the 2i2c Community that is being served.
+
+When a ticket comes into FreshDesk is automatically associated with the Community based on the 'Company' of the Community Representative submitting the ticket.
+
+When a new Community is being onboarding, create a new "company" in FreshDesk:
+```{image} /images/support/freshdesk_newcompany.png
+:width: 200
+```
+
+To update the list of Community Representatives, edit the Company:
+```{image} /images/support/freshdesk_company.png
+:width: 500
+```
+
+For each Community Representative, create a new Contact entry. Contacts may be affliated with multiple Communities if required:
+```{image} /images/support/freshdesk_associatecommunity.png
+:width: 500
+```
 :::

--- a/projects/managed-hubs/support/roles-and-team.md
+++ b/projects/managed-hubs/support/roles-and-team.md
@@ -1,27 +1,28 @@
 # Roles and team structure
 
-Supporting a 2i2c hub is a collaborative process between 2i2c and the community we serve.
+Supporting a 2i2c hub is a collaborative process between 2i2c and the community we serve. 
 
 The **Support Team** is one of the main teams in our **Managed JupyterHub Service Team**.
 
-This consists of three main roles: {term}`Support Triagers`, {term}`Community Representatives`, and {term}`Hub Administrators`.
+This consists of these main roles: {term}`Support Triager`, {term}`Support Agent`, {term}`Community Representative`s, and {term}`Hub Administrator`s.
 
 ```{glossary}
 Support Triager
 Support Triagers
-  A **two-person team** of {term}`Support Triagers` work together to triage and communicate with all external support requests.
-  Tenure on the support team is **for four weeks**.
-  Every **two weeks** (generally at the sprint meeting), a Support Triager cycles off the support team, and a new team member joins the team.
-  The support team rotates through [the “Open Infrastructure Engineering Team”](https://compass.2i2c.org/reference/team/), in alphabetical order.
-
-  The primary responsibilities of the Support Triagers are:
+  
+  The primary responsibilities of the Support Triager is to:
 
   - Ensure that we meet {external+docs:ref}`our Support Service Level Objectives <objectives:support>`.
   - Carry out [our support process](support:process).
-  - Act as primary points of contact with {term}`Community Representative`s.
+  - Act as the initial point of contact with {term}`Community Representative`s.
   - Trigger an [Incident Response](support:incident-response) if need be.
+  - Assign {term}`Support Agent`s to incoming tickets.
 
-  Common alternate terms: **Customer Liason**, **External Liason**, or **Customer Support**.
+  The `Support Triager` role is currently filled by the Engineering Manager or their delegate.
+
+Support Agent
+Support Agents
+  A `Support Agent` is tasked with performing the work related to a support request and communicating with the {term}`Community Representatives`.
 
 Community Representative
 Community Representatives
@@ -30,11 +31,4 @@ Community Representatives
 Hub Administrator
 Hub Administrators
   See [the service documentation](https://docs.2i2c.org/about/service/shared-responsibility.html#std-role-Hub-Administrator).
-```
-
-## Who are our Support Team?
-
-The Support Triager role rotates through the below Support Team members.
-
-```{include} ../../../_data/tmp/support-triagers.txt
 ```

--- a/projects/managed-hubs/support/terminology.md
+++ b/projects/managed-hubs/support/terminology.md
@@ -5,7 +5,7 @@ The following are important terms in the support process.
 ```{glossary}
 Support Request
 Support Requests
-  Any request that a community sends to us via `support@2i2c.org`.
+  Any request that a community sends to us via `support@2i2c.org` or the FreshDesk Support widget.
   Support requests are generally un-planned and happen in response to a community needing assistance with something unexpected.
   There are a few main categories of support that we consider, each is described below.
 


### PR DESCRIPTION
Resolves https://github.com/2i2c-org/infrastructure/issues/6573

Following a review of our technical support processes, this PR updates our documentation to more closely reflect our current practice of splitting the work between a continuing Support Triager role and team of Support Agents. 