### PR TITLE
Document process for deploying a new hub

### DIFF
--- a/services/interactive-computing/onboard.md
+++ b/services/interactive-computing/onboard.md
@@ -2,4 +2,14 @@
 
 # Onboard a Community
 
-TBD
+## Process to deploy a new hub
+
+1. BD Acccount Manager initiatives the converstion with the community to define the needs for a new hub.
+2. (Optional, but can be very helpful while we are learning: PS engineering is present in this sync call)
+3. Use the Hub Configurator to capture information about the hub request. Capture additional additional information not in the Hub Configurator as free form notes.  With permission of the community, using Google Gemini to record a transcript of the request gathering meeting with the community.
+4. BD requests this new hub use the 'Hub Spot Order' workflow. This kicks off an automation that generates a 'BD request type ticket' that PS can then pick up. This automation has been used a few times so far. It is not yest perfect but the way to improve that process is to use it continuously iterate.
+5. Once the new hub order is received, PS creates the new hub issue(s) and schedules the work.
+6. The hub is deployed and configured.
+7. The community is notified (via an email sent through Freshdesk) that the new hub is available
+8. BD is notified that the hub has been delivered
+9. BD confirms value is being received by this community by checking the Grafana [Engagement Details](https://grafana.pilot.2i2c.cloud/d/eb191919-5ca0-40b4-a696-a0415daf7c6a) dashboard. We expect at least 5 non-2i2c sessions of usage to declare that First Value is being received by a community for this new hub.


### PR DESCRIPTION
Added a detailed process for deploying a new hub, including steps for BD Account Manager and PS engineering involvement.