### PR TITLE
Add Community Relations to Product & Services

### DIFF
--- a/product-and-services/community-relations.md
+++ b/product-and-services/community-relations.md
@@ -3,7 +3,7 @@
 One of 2i2c's key differentiators is how we combine our technical expertise with social knowledge across science, education and open source communities. We call the social side of that work _Community Relations_, which is focused on growing members’ collective impact. Community Relations is a collection of processes and services provided by the Product & Services team.  
 
 ## Elements of Community Relations
-There are four key elements of Community Relations, all supporting member communities' collective impact through our shared infrastructure.Our core infrastructure service is a reliable, functional part of science and education community building. The technical aspects of our service delivery are documented in our services and infrastructure docs. Community Relations work supports communities' use of our core service.  
+There are four key elements of Community Relations, all supporting member communities' collective impact through our shared infrastructure. Our core infrastructure service is a reliable, functional part of community building for science and education. The technical aspects of our service delivery are documented in our services and infrastructure docs. Community Relations work supports communities' use of our core service.  
 
 Today (early 2026) many of these elements are more ad hoc than we would like, which makes it challenging for communities to engage with us and with each other. We'll be building and refining Community Relations throughout 2026; early thoughts are captured in our [services strategy](https://docs.google.com/document/d/1djix1YrzMRxc7rketJLXgl-R3g8kplljPPCbWIMmh0o/edit?tab=t.ktsf3e28gj1x#heading=h.eldsuysfzza2_).
 

--- a/product-and-services/community-relations.md
+++ b/product-and-services/community-relations.md
@@ -8,7 +8,7 @@ There are four key elements of Community Relations, all supporting member commun
 Today (early 2026) many of these elements are more ad hoc than we would like, which makes it challenging for communities to engage with us and with each other. We'll be building and refining Community Relations throughout 2026; early thoughts are captured in our [services strategy](https://docs.google.com/document/d/1djix1YrzMRxc7rketJLXgl-R3g8kplljPPCbWIMmh0o/edit?tab=t.ktsf3e28gj1x#heading=h.eldsuysfzza2_).
 
 ### Community Experience & Enablement  
-This element focuses on the product itself. How good is the documentation? How quickly can a community get from "zero" to "hello world"? They advocate for all 2i2c member communities back to the product team. Part of how we do this today is via hands-on work in support of communities, so this overlaps significantly with service delivery (onboarding, community enablement, offboarding).
+This element focuses on the product itself, and on the ways we support its adoption and use by our member communities. How good is our community-facing documentation? How quickly can a community get from "zero" to "hello world"? Community Experience and Enablement are practices that advocate for all 2i2c member communities back to the product team. Part of how we do this today is via hands-on work in support of communities, so this overlaps significantly with service delivery (onboarding, community enablement, offboarding).
 Elements of Community Experience and Enablement include:
 - Welcoming new communities and helping them navigate the service
 - 1:1 problem solving / [community enablement](https://compass.2i2c.org/services/community-enablement/)

--- a/product-and-services/community-relations.md
+++ b/product-and-services/community-relations.md
@@ -1,0 +1,34 @@
+# Community Relations
+
+2i2c’s differentiator is the combination of our technical expertise along with social knowledge across both science and education communities, as well as open source communities. We call the social side of that work _Community Relations_, which is focused on growing members’ collective impact. Community Relations is a collection of processes and services provided by the Product & Services team; it's not a separate team.  
+
+## Elements of Community Relations
+There are four key elements of Community Relations, all supporting member communities' collective impact through our shared infrastructure.Our core infrastructure service is a reliable, functional part of science and education community building. The technical aspects of our service delivery are documented in our services and infrastructure docs. Community Relations work supports communities' use of our core service.  
+
+Today (early 2026) many of these elements are more ad hoc than we would like, which makes it challenging for communities to engage with us and with each other. We'll be building and refining Community Relations throughout 2026; early thoughts are captured in our [services strategy](https://docs.google.com/document/d/1djix1YrzMRxc7rketJLXgl-R3g8kplljPPCbWIMmh0o/edit?tab=t.ktsf3e28gj1x#heading=h.eldsuysfzza2_).
+
+### Community Experience & Enablement  
+This element focuses on the product itself. How good is the documentation? How quickly can a community get from "zero" to "hello world"? They advocate for all 2i2c member communities back to the product team. Part of how we do this today is via hands-on work in support of communities, so this overlaps significantly with service delivery (onboarding, community enablement, offboarding).
+- Welcoming new communities and helping them navigate the service
+- 1:1 problem solving / [community enablement](https://compass.2i2c.org/services/community-enablement/)
+- Other forms of learning together 
+- Offboarding & handoff 
+
+### Network Effect  
+This involves hands-on community management and curation, nurturing the places where communities gather, like a Discord server, forum, or GitHub. It's about fostering connections between member communities, not just to them. Important point: this needs to be achievable within 2i2c's means.
+- Shaping and enabling collaboration across boundaries
+- Showcases & early access to new infra & docs
+- Help communities showcase their own work 
+
+### Co-funding and Co-creation  
+This is collaborative, hands-on work with one or many communities to build, test, upstream and learn about new platform & service features. As such it overlaps significantly with platform delivery (new features in the product process, project management of feature delivery).
+- Dedicated, delivery management for complex community engagement
+- Previewing, influencing and seeing progress on 2i2c's roadmap
+- Refining and shaping work together
+
+### Advocacy: Sharing knowledge to shape the future  
+We advocate for the product - platform & services - to open science and education communities. We also advocate for those communities in the wider world. Because of the unique position of 2i2c, this also overlaps significantly with upstream advocacy with and for Jupyter. This is our collective technical expertise deployed to create content (blogs, tutorials), speak at conferences, and create demos. 
+- Upstream leadership & navigation assistance
+- Sharing and supporting community building work in and across communities
+
+

--- a/product-and-services/community-relations.md
+++ b/product-and-services/community-relations.md
@@ -1,6 +1,6 @@
 # Community Relations
 
-2i2c’s differentiator is the combination of our technical expertise along with social knowledge across both science and education communities, as well as open source communities. We call the social side of that work _Community Relations_, which is focused on growing members’ collective impact. Community Relations is a collection of processes and services provided by the Product & Services team; it's not a separate team.  
+One of 2i2c's key differentiators is how we combine our technical expertise with social knowledge across science, education and open source communities. We call the social side of that work _Community Relations_, which is focused on growing members’ collective impact. Community Relations is a collection of processes and services provided by the Product & Services team.  
 
 ## Elements of Community Relations
 There are four key elements of Community Relations, all supporting member communities' collective impact through our shared infrastructure.Our core infrastructure service is a reliable, functional part of science and education community building. The technical aspects of our service delivery are documented in our services and infrastructure docs. Community Relations work supports communities' use of our core service.  

--- a/product-and-services/community-relations.md
+++ b/product-and-services/community-relations.md
@@ -9,6 +9,7 @@ Today (early 2026) many of these elements are more ad hoc than we would like, wh
 
 ### Community Experience & Enablement  
 This element focuses on the product itself. How good is the documentation? How quickly can a community get from "zero" to "hello world"? They advocate for all 2i2c member communities back to the product team. Part of how we do this today is via hands-on work in support of communities, so this overlaps significantly with service delivery (onboarding, community enablement, offboarding).
+Elements of Community Experience and Enablement include:
 - Welcoming new communities and helping them navigate the service
 - 1:1 problem solving / [community enablement](https://compass.2i2c.org/services/community-enablement/)
 - Other forms of learning together 

--- a/product-and-services/index.md
+++ b/product-and-services/index.md
@@ -14,6 +14,7 @@ structure.md
 deliveryflow.md
 documentation.md
 prioritization.md
+community-relations.md
 services.md
 cost-model.md
 kpis.md

--- a/product-and-services/services.md
+++ b/product-and-services/services.md
@@ -1,14 +1,14 @@
 (services)=
 # Services
 
-## Service Definition
+## What are services?
 
-A **service** at 2i2c is an organized set of procedures and resources that generate value for stakeholders, 
+A **service** at 2i2c is an organized set of procedures and resources that generate value for community stakeholders, 
 aligning with 2i2c’s mission to enable open science and collaborative research through a global network of
 community hubs for interactive learning and discovery. Qualities of a service:
 
-- A scalable, repeatable activity that is defined by its outcome and has a clear value to the customer.
-- Has to have a direct customer benefit and one or more customer beneficiary archetypes.
+- A scalable, repeatable activity that is defined by its outcome and has a clear value to the communities we serve.
+- Has to have a direct benefit or value to a community member or leader, as well as clear beneficiary archetypes.
 - Can be costed internally for the purposes of maintaining scalability and sustainability for 2i2c.  
 - Can (but does not necessarily have to be) monetized on a cost x time basis, or bundled as a membership benefit.
 - Has a clear and scalable process which is well documented and does not rely on a single individual to execute.


### PR DESCRIPTION
Adds the current state of Community Relations to our team documentation, with references to the evolving services strategy. I opted to split documentation into an internally-facing view (this PR plus the updates we're making to services docs in the compass) and a future externally-facing update. 

Closes https://github.com/2i2c-org/meta/issues/2858