### PR TITLE
Adjusts invoicing instructions for contractors

### DIFF
--- a/administration/invoices.md
+++ b/administration/invoices.md
@@ -6,7 +6,7 @@ This includes any team members that are paid off of fixed-term contracts and sub
 
 ## Invoicing process
 
-1. **Read the CS&S invoicing instructions**. CS&S [has instructions to invoice here](https://www.codeforsociety.org/resources/getting-paid-by-css).
+1. **Read the CS&S invoicing instructions**. CS&S periodically updates and sends [instructions to invoice here]([https://www.codeforsociety.org/resources/getting-paid-by-css](https://drive.google.com/file/d/1_nLXaEceI1Y9dhfqZvRHhJUvzMioTm5A/view?usp=drive_link).
    This is what you'll follow.
 2. **Prepare an invoice**. If you do not have one, [here is a template to get you started](https://docs.google.com/document/d/17aTwJkmYFXwqHa2QjYsy81hEXq64yfmo5g1SCGE6aK4/edit?usp=sharing).
 3. **Confirm your grant code**. You will need to supply a **grant code** for your invoice.
@@ -30,14 +30,6 @@ Most reimbursements require a **grant code**.
 Each team member is paid from one or more grants so this helps CS&S know which account to draw from.
 The {role}`Executive Director` is the final say on which grant code is paying a given team member, but generally it is the same grant paying you over time.
 
-To find a list of grant codes:
+As new grants come in, CS&S and our team work together to allocate team members' time across grants. You will receive instructions from CS&S when you first start sending invoices and at any point when grant allocations need to change.
 
-- Locate [our latest monthly account statement from CS&S](accounting:statements).
-- See the `Income Statement (Profit and Loss)` tab.
-- In the `Account` row, each item is a grant, it has the form:
 
-  ```none
-  MMM YYYY-MMM YYYY PROJECTNAME: GRANTCODE
-  ```
-
-  You want the value of `GRANTCODE`.

--- a/administration/invoices.md
+++ b/administration/invoices.md
@@ -32,4 +32,6 @@ The {role}`Executive Director` is the final say on which grant code is paying a 
 
 As new grants come in, CS&S and our team work together to allocate team members' time across grants. You will receive instructions from CS&S when you first start sending invoices and at any point when grant allocations need to change.
 
+Please use both the grant code and grant name on your invoices. CS&S will typically give you both those pieces of information.
+
 

--- a/administration/invoices.md
+++ b/administration/invoices.md
@@ -31,7 +31,9 @@ Each team member is paid from one or more grants so this helps CS&S know which a
 The {role}`Executive Director` is the final say on which grant code is paying a given team member, but generally it is the same grant paying you over time.
 
 As new grants come in, CS&S and our team work together to allocate team members' time across grants. You will receive instructions from CS&S when you first start sending invoices and at any point when grant allocations need to change.
+## If an invoice is not paid when expected
 
+If you have any difficulty in getting paid, reach out to the 2i2c People Lead or Chief of Staff. 
 Please use both the grant code and grant name on your invoices. CS&S will typically give you both those pieces of information.
 
 


### PR DESCRIPTION
Adds the new "Getting paid by CS&S" pdf link (replaces a dead link to their website. Also removes outdated information about grant codes.

Comment for reviewers: this PR represents a small tweak to our docs, but I'd like to hear if anyone who submits invoices for your time has any questions that the Compass doesn't currently answer. 