### PR TITLE
Document data-sync repo

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,7 +4,7 @@
 version: 2
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-26.04
   tools:
     python: "3.12"
     nodejs: "16"

--- a/operations/data-sync.md
+++ b/operations/data-sync.md
@@ -8,7 +8,7 @@ It runs scheduled GitHub Actions that read from each source and write changes in
 
 Here are a few examples, see [2i2c-org/data-sync](https://github.com/2i2c-org/data-sync) for the current list.
 
-- **Label a GitHub issue `CSH` or `asana-sync`**: an Asana task is created that mirrors things like "hours" from GitHub -> Asana.
+- **Label a GitHub issue `CSH` or `asana-sync`**: an Asana task is created that mirrors fields like `GitHub Hours` (plus title and status) from GitHub -> Asana.
 - **Add an 'Asana Engagement URL' to a HubSpot Deal****: the matching Asana engagement project will now be updated using HubSpot metadata.
 - **Add a HubSpot Deal URL to a GitHub `Sales Issue`**: the issue URL will be added to the HubSpot deal, and HubSpot data will now be synced back to the issue body.
 

--- a/operations/data-sync.md
+++ b/operations/data-sync.md
@@ -1,7 +1,19 @@
 (operations:data-sync)=
 # Data sync automations
 
-[`2i2c-org/data-sync`](https://github.com/2i2c-org/data-sync) is a general-purpose repository for keeping data in sync from one system to another ("sync A to B").
-It runs scheduled GitHub Actions that read from each source system and write changes into the destination.
+[`2i2c-org/data-sync`](https://github.com/2i2c-org/data-sync) keeps data in sync from one system to another ("sync A to B").
+It runs scheduled GitHub Actions that read from each source and write changes into the destination.
 
-See the repository documentation for the syncs that are currently there, and how you can add a new one.
+## What runs today
+
+Here are a few examples, see [2i2c-org/data-sync](https://github.com/2i2c-org/data-sync) for the current list.
+
+- **Label a GitHub issue `CSH` or `asana-sync`**: an Asana task is created that mirrors things like "hours" from GitHub -> Asana.
+- **Add an 'Asana Engagement URL' to a HubSpot Deal****: the matching Asana engagement project will now be updated using HubSpot metadata.
+- **Add a HubSpot Deal URL to a GitHub `Sales Issue`**: the issue URL will be added to the HubSpot deal, and HubSpot data will now be synced back to the issue body.
+
+## Seeing what changed
+
+Syncs append to a shared [audit-log spreadsheet](https://docs.google.com/spreadsheets/d/1j2_YL0l91Xjuo-F_6xDTnZnRkka2A9irsqK517itXM0/edit) when something is worth flagging (e.g., a skipped record, or over-writing a URL in HubSpot). It's a place to spot problems, not a complete record of everything that synced.
+
+See the [repository documentation](https://github.com/2i2c-org/data-sync) for sync details and how to add a new one.

--- a/operations/data-sync.md
+++ b/operations/data-sync.md
@@ -1,0 +1,7 @@
+(operations:data-sync)=
+# Data sync automations
+
+[`2i2c-org/data-sync`](https://github.com/2i2c-org/data-sync) is a general-purpose repository for keeping data in sync from one system to another ("sync A to B").
+It runs scheduled GitHub Actions that read from each source system and write changes into the destination.
+
+See the repository documentation for the syncs that are currently there, and how you can add a new one.

--- a/operations/index.md
+++ b/operations/index.md
@@ -10,6 +10,7 @@ workflow
 team-practices/overview
 onboarding
 sources
+data-sync
 meetings
 communication
 team-compass

--- a/services/community-success-hours/delivery.md
+++ b/services/community-success-hours/delivery.md
@@ -12,27 +12,27 @@ Community Success Hours can be proactively recommended to a community by any tea
 (csh:logging)=
 ## How to log CSH activity
 
-There are two ways to log CSH activity - use whichever fits your workflow:
+There are two ways to log CSH activity - use whichever fits your workflow, but log a given task in only one of them (see [](#delivery:tracking-time)):
 
 - **GitHub** - best if you're already tracking work in GitHub (e.g., engineering work). The instructions below show how to set it up to automatically sync the issue to Asana.
 - **Asana** - best if you need to log something retroactively or your work isn't tied to a GitHub issue.
 
-Before logging new activity with either method, check that `Hours Spent` has not already significantly exceeded `Hours Total` in Asana.
+Before logging new activity with either method, check that the engagement's `Total Time` has not already significantly exceeded the community's contracted hours.
 
 ### Logging via GitHub
 
 - Create a new issue in GitHub.
 - Include the community's name and specific contact people for the request; if the request came from FreshDesk, add the FreshDesk link.
 - Mark GitHub issues on the P&S Project Board with the label `CSH` to indicate this is Community Success Hours activity.
-- A [GitHub automation](#operations:data-sync) will automatically create a corresponding task in Asana. Updates to the title, description, hours spent, and issue status sync one-directionally from GitHub to Asana (changes made in Asana will be overwritten).
+- A [GitHub automation](#operations:data-sync) will automatically create a corresponding task in Asana. Updates to the title, description, `GitHub Hours`, and issue status sync one-directionally from GitHub to Asana (changes made in Asana will be overwritten).
 
 ### Logging via Asana
 
 - Go to [Active Engagements](https://app.asana.com/0/portfolio/1211914502801258/1211914511709245) in Asana.
 - Find the community you're doing CSH for and click it. Find the `Community Success Hours` sub-task for that community.
 - Create a new sub-task directly undern the `Community Success Hours` task.
-- Add a `Date` and `Hours spent` for the task.
-- Ignore the other fields (e.g., `GitHub Issue` is just for the automated workflow above)
+- Log your time on the sub-task with Asana's built-in timer (the `Actual time` field).
+- Ignore the other fields (e.g., `GitHub URL` is just for the automated workflow above)
 
 ## How to deliver Community Success Hours
 
@@ -45,13 +45,13 @@ Before logging new activity with either method, check that `Hours Spent` has not
 ### Counting hours
 
 - **Hours are counted per-person.** If two staff members attend a 1-hour meeting, log 2 hours total.
-- **Include follow-up work** (e.g., writing a summary, drafting a blog post) in the same GitHub issue and add that time to `Hours Spent`.
+- **Include follow-up work** (e.g., writing a summary, drafting a blog post) in the same GitHub issue and add that time to the hours you log there.
 
 ## Managing CSH work (Engagement Management and Community Relations)
 
 - Ensure New Engagements are created in Asana
 - Validate that CSH tasks are associated with the correct community and correct `Community Success Hours` task.
-- Confirm tasks that have been completed but do not have Hours Spent. If needed, estimate the Hours Spent based on the description of the task.
+- Confirm tasks that have been completed but have no time logged (`Total Time` is empty). If needed, estimate the time based on the description of the task.
 - Flag communities to BD that are either exceeding or underusing their expected Community Success Hours
 
 ## Reporting back to the community (BD)

--- a/services/community-success-hours/delivery.md
+++ b/services/community-success-hours/delivery.md
@@ -24,7 +24,7 @@ Before logging new activity with either method, check that `Hours Spent` has not
 - Create a new issue in GitHub.
 - Include the community's name and specific contact people for the request; if the request came from FreshDesk, add the FreshDesk link.
 - Mark GitHub issues on the P&S Project Board with the label `CSH` to indicate this is Community Success Hours activity.
-- A GitHub automation ([sync-asana](https://github.com/2i2c-org/sync-asana)) will automatically create a corresponding task in Asana. Updates to the title, description, hours spent, and issue status sync one-directionally from GitHub to Asana (changes made in Asana will be overwritten).
+- A [GitHub automation](#operations:data-sync) will automatically create a corresponding task in Asana. Updates to the title, description, hours spent, and issue status sync one-directionally from GitHub to Asana (changes made in Asana will be overwritten).
 
 ### Logging via Asana
 

--- a/services/community-success-hours/delivery.md
+++ b/services/community-success-hours/delivery.md
@@ -24,7 +24,9 @@ Before logging new activity with either method, check that the engagement's `Tot
 - Create a new issue in GitHub.
 - Include the community's name and specific contact people for the request; if the request came from FreshDesk, add the FreshDesk link.
 - Mark GitHub issues on the P&S Project Board with the label `CSH` to indicate this is Community Success Hours activity.
-- A [GitHub automation](#operations:data-sync) will automatically create a corresponding task in Asana. Updates to the title, description, `GitHub Hours`, and issue status sync one-directionally from GitHub to Asana (changes made in Asana will be overwritten).
+- A [GitHub automation](#operations:data-sync) will automatically create a corresponding task in Asana. Updates to the title, description, assignee, `GitHub Hours`, and issue status sync one-directionally from GitHub to Asana (changes made in Asana will be overwritten).
+- If the issue has **sub-issues**, they sync automatically as subtasks of the Asana task. You don't need to label each sub-issue.
+- Close the issue as **Completed** to mark the Asana task done. Closing it for any other reason (Not planned, Duplicate) removes the Asana task instead, since the work wasn't delivered.
 
 ### Logging via Asana
 

--- a/services/dedicated-delivery-management/time-tracking.md
+++ b/services/dedicated-delivery-management/time-tracking.md
@@ -13,7 +13,7 @@ A screenshot of the Asana table view for a typical statement of work. The "Estim
 ```
 
 ## Time Tracking
-To track time spent on delivery (e.g. authoring a pull-request and steering it through code review), we use Asana to track both estimated and actual (delivered) hours. See [](fig:ddm-asana-table) for an example built from our [Canvas Authentication and Authorization statement of work](https://2i2c.org/statements-of-work/sow/canvas-authentication/). Asana tracks time at minute-level granularity. These times should be recorded as best-effort — in practice, the time spent working on task is subject to interpretation and 2i2c team members should exercise reasonable judgement.
+To track time spent on delivery (e.g. authoring a pull-request and steering it through code review), we use Asana to track both estimated and actual (delivered) hours. See [](fig:ddm-asana-table) for an example built from our [Canvas Authentication and Authorization statement of work](https://2i2c.org/statements-of-work/sow/canvas-authentication/). Asana tracks time at minute-level granularity. These times should be recorded as best effort. In practice, the time spent working on a task is subject to interpretation, and 2i2c team members should exercise reasonable judgement.
 
 ```{figure} ./images/asana-timer.png
 :name: fig:ddm-asana-timer
@@ -22,5 +22,7 @@ A screenshot of the Asana timer widget that can be used to help keep track of ti
 ```
 
 Asana ships with a timer widget (see [](fig:ddm-asana-timer) that makes it easy to keep track of time spent on a particular task (just as long as one remembers to pause it!) It can also be useful to make use of timing information like shell history e.g. [`atuin`](https://atuin.sh/) to derive time spent on a task from an auxiliary source of truth.
+
+The timer writes to the `Actual time` field, which feeds the engagement's `Total Time` along with any hours logged on linked GitHub issues. See [](#delivery:tracking-time).
 
 Anything outside of regular day-to-day 2i2c activities that is associated with a particular community deliverable should be tracked. This includes code-review from other team members, or work around project management in preparation for a meeting.

--- a/services/delivery/engagement-management.md
+++ b/services/delivery/engagement-management.md
@@ -65,3 +65,16 @@ We don't, **yet**, have any automation to keep status or comments of GitHub issu
 Asana is a project planning tool. Use the Due Date fields for each task to capture the **anticipated** timeline when the task is to be scheduled.  Use the Estimated Time field to list the total time expected for the tast to be completed.  Due Dates and Estimate Time are needed for Asana to show the task on the Timeline view and to be used in capacity planning.
 
 One of the default tasks in any engagement could be 'Confirm Renewal with Community' with a due date set to 60 days before the end of the engagement.
+
+(delivery:tracking-time)=
+## Tracking time on tasks
+
+Each engagement shows a standard set of task columns: `Allocation`, `GitHub URL`, `Estimated time`, `GitHub Hours`, and `Total Time`, plus the native `Assignee`, `Due date`, and `Actual time`.
+
+Log your time in one place per task, and `Total Time` adds them up:
+
+- `Actual time`: time logged directly in Asana with its built-in timer, for work not tracked in a GitHub issue.
+- `GitHub Hours`: hours logged on the linked GitHub issue, synced into Asana automatically. Don't edit it in Asana, since the [sync](#operations:data-sync) overwrites it.
+- `Total Time`: `GitHub Hours` plus `Actual time`, the combined figure to report against an engagement.
+
+Use `Estimated time` for the hours a task is expected to take.

--- a/services/delivery/engagement-management.md
+++ b/services/delivery/engagement-management.md
@@ -1,3 +1,4 @@
+(delivery:engagement-management)=
 # Engagement Management
 
 Project Management Tool: [Asana](https://app.asana.com/)
@@ -13,7 +14,7 @@ We have not, **yet**, automated the creation of Asana Projects from Hubspot Deal
 Engagements are encoded in Asana as *Projects*.  To create a new Engagement, click **Create** in Asana and selection **Project**.
 
 Use the project template *Engagement Project*. Set the name of the project to be the same string as the HubSpot Deal Name. (If the HubSpot Deal Name is incorrect, fix this first).
-Once the `HubSpot Deal URL` field is set (see below), a daily automation ([sync-asana](https://github.com/2i2c-org/sync-asana)) keeps the project name matched to the HubSpot deal name, so later renames in HubSpot propagate automatically.
+Once the `HubSpot Deal URL` field is set (see below), a [daily automation](#operations:data-sync) keeps the project name, contract value, and start/end dates matched to the HubSpot deal, so later changes in HubSpot propagate automatically.
 
 :::{attention}
 Today, there is only one template called *Engagement Project*. In a future iteration of these instructions there could be templates for each type of membership, or equivalents for any class of Engagements that should have the same overall structure


### PR DESCRIPTION
Documents the [data-sync repo](https://github.com/2i2c-org/data-sync) which has logic for a few service-to-service syncs that we use.

---

- closes https://github.com/2i2c-org/data-sync/issues/7
- closes https://github.com/2i2c-org/data-sync/issues/2
- closes https://github.com/2i2c-org/meta/issues/3298
- closes https://github.com/2i2c-org/meta/issues/3367
