### PR TITLE
Turn Open Source Development service into SSOT for consortia

### DIFF
--- a/services/index.md
+++ b/services/index.md
@@ -47,9 +47,9 @@ Leadership orientation
 :link: open-source-development/index
 :link-type: doc
 
-⚙️🌍 **Open Source Development**
+⚙️🌍 **Open Source Development via Consortia**
 
-2i2c partners with our communities to create a virtuous cycle between open science communities that **create knowledge** and open source communities that **build the tools** to do so.
+2i2c partners with our communities to create a virtuous cycle between open science communities that **create knowledge** and open source communities that **build the tools** to do so. We're exploring consortia - collecting groups of communities who are interested in solutions to similar problems - as a way to sustainably prioritize, fund, and design solutions together.  
 :::
 
 :::{grid-item-card}

--- a/services/open-source-development/index.md
+++ b/services/open-source-development/index.md
@@ -6,7 +6,7 @@ Creating pathways for communities to share, learn, and collaborate helps us iden
 
 We work with many community leaders 1-to-1. This lets us see both problems and wins that they share with other communities. However, these leaders only see _each other_ if we make introductions between one community with a problem, and another community who has already come up with a solution. 
 
-Introducing consortia gives us a structure for collectively refining and prioritizing 2i2c roadmap work that multiple communities care about, working together to fund for that work, and uilding many:many connections, so communities learn from each other. 
+Consortia give us a structure for collectively refining and prioritizing 2i2c roadmap work that multiple communities care about, working together to fund that work, and building many-to-many connections, so communities learn from each other. 
 
 # What’s a consortium? 
 

--- a/services/open-source-development/index.md
+++ b/services/open-source-development/index.md
@@ -25,10 +25,8 @@ And a consortium's shared goals are to build better solutions for all communitie
 Each consortium starts with a shared problem or narrative, and a gathering of people. 
 
 1. **Propose a shared problem.** This can be proposed by a 2i2c team member, or one or more community members. It most often emerges through discussions of the [2i2c roadmap](https://2i2c.org/roadmap/), where we recognize that several related initiatives serve a common narrative.  
-   * **Initiatives:** Units of work that deliver value to open source communities, technology that 2i2c builds, or infrastructure for our services. Designed around a problem statement and a proposed solution. Resolved in weeks-\>months. These are how we plan and share the [2i2c roadmap](https://2i2c.org/roadmap/)  
-   * **Narratives:** Stories of ongoing need for a large class of users or communities. Forms the basis of a consortium. Useful for funding pitches and grant-writing. Designed as a thread that ties multiple initiatives. Resolved in months-\>years.  
-   * So far we have one consortium, organized around one narrative: [Optimize cloud spend on commercial cloud vendors](https://github.com/2i2c-org/narratives/issues/4)   
-       
+   - **Initiatives:** Units of work that deliver value to open source communities, technology that 2i2c builds, or infrastructure for our services. Designed around a problem statement and a proposed solution. Resolved in weeks-\>months. These are how we plan and share the [2i2c roadmap](https://2i2c.org/roadmap/)  
+   - **Narratives:** Stories of ongoing need for a large class of users or communities. Forms the basis of a consortium. Useful for funding pitches and grant-writing. Designed as a thread that ties multiple initiatives. Resolved in months-\>years.           
 2. **Get critical mass.** Find enough other people who agree with the problem statement and are willing to participate in meetings about it.  
 3. **Meet to define goals.** Have a meeting with coalition members to refine the problem, and decide if there’s enough interest in moving forward.
 
@@ -36,17 +34,17 @@ Each consortium starts with a shared problem or narrative, and a gathering of pe
 
 Once a consortium has kicked off, each member community participates in our planning ceremonies and gets the same updates on our work together, although they may contribute in different ways. 
 
-### **How we communicate**
+### How we communicate
 
-We currently have one active consortium, the Cloud Cost Optimization Consortium. 
+We currently have one active consortium, the Cloud Cost Optimization Consortium. It's organized around one narrative: [Optimize cloud spend on commercial cloud vendors](https://github.com/2i2c-org/narratives/issues/4). 
 
-* Consortia typically have a live (virtual) meeting quarterly to set priorities and demo recently completed work.  
-* Each consortium has a guide doc. Today that’s in Google Docs; you can find the [Cloud Cost Consortium’s README](https://docs.google.com/document/d/1_447531g-zozFRrJKXZz9x6hfafYzhe_djsCOqQ4dSQ/edit?tab=t.0#heading=h.7g1kmdukb6vh) in our Drive.   
-* We use \#consortium-cloud-cost on Slack to share quick updates and requests, and as an open space for asynchronous discussion.   
-* We use email updates to send requests (for letters of support, co-proposals, user feedback on features) and demo reels of work in progress.  
-* When the consortium members are interested, we’ll try to organize in-person gatherings, typically as part of a conference where many member communities will already be present. 
+- Consortia typically have a live (virtual) meeting quarterly to set priorities and demo recently completed work.  
+- Each consortium has a guide doc. Today that’s in Google Docs; you can find the [Cloud Cost Consortium’s README](https://docs.google.com/document/d/1_447531g-zozFRrJKXZz9x6hfafYzhe_djsCOqQ4dSQ/edit?tab=t.0#heading=h.7g1kmdukb6vh) in our Drive.   
+- We use [a private channel, #consortium-cloud-cost on Slack](https://2i2c.slack.com/archives/C0B25UEJETB) to share quick updates and requests, and as an open space for asynchronous discussion.   
+- We use email updates to send requests (for letters of support, co-proposals, user feedback on features) and demo reels of work in progress.  
+- When the consortium members are interested, we’ll try to organize in-person gatherings, typically as part of a conference where many member communities will already be present. 
 
-### **Roles consortium members play**
+### Roles consortium members play
 
 Each member community in a consortium is expected to contribute in at least one of the following:
 
@@ -59,13 +57,13 @@ Each member community in a consortium is expected to contribute in at least one 
 
 Consortium members choose how much they want to co-create and influence design, share credit in our media & outreach, and have an opportunity to be early adopters of new features. They also ensure that 2i2c keeps building open source solutions that work for all research and education users. 
 
-### **Prioritizing (quarterly meeting)**
+### Prioritizing (quarterly meeting)
 
 We use every consortium member’s input to set next priorities, and plan to host a meeting once a quarter to showcase what’s done, what’s possible and gather input on what’s next. 
 
 Once we have a first set of priorities and start work, we share updates over Slack and email. We aim to make our updates and requests low effort and high value.
 
-### **Endorsing**
+### Endorsing
 
 When we bring a proposed piece of work that supports the consortium to a funder, we will ask for endorsements, which can include:
 
@@ -73,19 +71,19 @@ When we bring a proposed piece of work that supports the consortium to a funder,
 * User stories of impact  
 * Willingness to be listed as a collaborator on a proposal
 
-### **Testing**
+### Testing
 
 While we’re developing new solutions, testers serve as early adopters, and commit to trying out new features (which can include things that break). Their feedback helps us build the best solution for everyone. 
 
-### **Connecting** 
+### Connecting 
 
 Exactly what it sounds like: consortia members who connect us to other potential members, funders or collaborators directly create new sources of funding and ideas.  
 
-### **Co-proposing**
+### Co-proposing
 
 Member communities seeking grant funding themselves can add 2i2c as a subawardee or collaborator. We encourage consortium members to include initiatives from our roadmap in their proposals, and we can support them with estimates and co-writing. 
 
-### **Co-funding**
+### Co-funding
 
 When a community (or several communities) has funds they can direct towards open source development \- either specific initiatives/features they wish to “buy” or wider sustenance of the Jupyter ecosystem, they work with our Product and Business Development teams to describe and plan the work.   
 

--- a/services/open-source-development/index.md
+++ b/services/open-source-development/index.md
@@ -98,7 +98,7 @@ Membership focuses on the core support 2i2c provides a specific community:
 - Infrastructure hosting for (not every member community uses our infrastructure, but most do)  
 - Consortia-related development will still roll-out to any member communities
 
-Consortium adds connection 
+Consortium adds more connection between communities, a deeper focused on a particular area, and a vehicle for raising additional funds to do the work 
 
 - We’ll explore engaging people as consortia so that we can hear multiple voices at once.  
 - We hope this saves time in designing, validating, and developing solutions for shared problems  

--- a/services/open-source-development/index.md
+++ b/services/open-source-development/index.md
@@ -8,9 +8,9 @@ We work with many community leaders 1-to-1. This lets us see both problems and w
 
 Consortia give us a structure for collectively refining and prioritizing 2i2c roadmap work that multiple communities care about, working together to fund that work, and building many-to-many connections, so communities learn from each other. 
 
-# What’s a consortium? 
+## What’s a consortium? 
 
-## A consortium is:
+### A consortium is:
 
 - A network of stakeholders organized around a shared challenge or goal.   
 - A way to ensure that solutions work for many kinds of stakeholders.  
@@ -18,9 +18,9 @@ Consortia give us a structure for collectively refining and prioritizing 2i2c ro
 
 And a consortium's shared goals are to build better solutions for all communities 2i2c serves, while collaborating and learning from each other. Together, we're able to fund and solve problems by sharing resources and expertise.
 
-# How a consortium operates
+## How a consortium operates
 
-## Getting started. 
+### Getting started. 
 
 Each consortium starts with a shared problem or narrative, and a gathering of people. 
 
@@ -30,11 +30,11 @@ Each consortium starts with a shared problem or narrative, and a gathering of pe
 2. **Get critical mass.** Find enough other people who agree with the problem statement and are willing to participate in meetings about it.  
 3. **Meet to define goals.** Have a meeting with coalition members to refine the problem, and decide if there’s enough interest in moving forward.
 
-## Running the consortium
+### Running the consortium
 
 Once a consortium has kicked off, each member community participates in our planning ceremonies and gets the same updates on our work together, although they may contribute in different ways. 
 
-### How we communicate
+#### How we communicate
 
 We currently have one active consortium, the Cloud Cost Optimization Consortium. It's organized around one narrative: [Optimize cloud spend on commercial cloud vendors](https://github.com/2i2c-org/narratives/issues/4). 
 
@@ -44,7 +44,7 @@ We currently have one active consortium, the Cloud Cost Optimization Consortium.
 - We use email updates to send requests (for letters of support, co-proposals, user feedback on features) and demo reels of work in progress.  
 - When the consortium members are interested, we’ll try to organize in-person gatherings, typically as part of a conference where many member communities will already be present. 
 
-### Roles consortium members play
+#### Roles consortium members play
 
 Each member community in a consortium is expected to contribute in at least one of the following:
 
@@ -57,13 +57,13 @@ Each member community in a consortium is expected to contribute in at least one 
 
 Consortium members choose how much they want to co-create and influence design, share credit in our media & outreach, and have an opportunity to be early adopters of new features. They also ensure that 2i2c keeps building open source solutions that work for all research and education users. 
 
-### Prioritizing (quarterly meeting)
+##### Prioritizing (quarterly meeting)
 
 We use every consortium member’s input to set next priorities, and plan to host a meeting once a quarter to showcase what’s done, what’s possible and gather input on what’s next. 
 
 Once we have a first set of priorities and start work, we share updates over Slack and email. We aim to make our updates and requests low effort and high value.
 
-### Endorsing
+##### Endorsing
 
 When we bring a proposed piece of work that supports the consortium to a funder, we will ask for endorsements, which can include:
 
@@ -71,19 +71,19 @@ When we bring a proposed piece of work that supports the consortium to a funder,
 * User stories of impact  
 * Willingness to be listed as a collaborator on a proposal
 
-### Testing
+##### Testing
 
 While we’re developing new solutions, testers serve as early adopters, and commit to trying out new features (which can include things that break). Their feedback helps us build the best solution for everyone. 
 
-### Connecting 
+##### Connecting 
 
 Exactly what it sounds like: consortia members who connect us to other potential members, funders or collaborators directly create new sources of funding and ideas.  
 
-### Co-proposing
+##### Co-proposing
 
 Member communities seeking grant funding themselves can add 2i2c as a subawardee or collaborator. We encourage consortium members to include initiatives from our roadmap in their proposals, and we can support them with estimates and co-writing. 
 
-### Co-funding
+##### Co-funding
 
 When a community (or several communities) has funds they can direct towards open source development \- either specific initiatives/features they wish to “buy” or wider sustenance of the Jupyter ecosystem, they work with our Product and Business Development teams to describe and plan the work.   
 
@@ -96,7 +96,7 @@ Membership focuses on the core support 2i2c provides a specific community:
 - Infrastructure hosting for (not every member community uses our infrastructure, but most do)  
 - Consortia-related development will still roll-out to any member communities
 
-Consortium adds more connection between communities, a deeper focused on a particular area, and a vehicle for raising additional funds to do the work 
+Becoming part of a consortium adds more connection between communities, a deeper focused on a particular area, and a vehicle for raising additional funds to do the work 
 
 - We’ll explore engaging people as consortia so that we can hear multiple voices at once.  
 - We hope this saves time in designing, validating, and developing solutions for shared problems  

--- a/services/open-source-development/index.md
+++ b/services/open-source-development/index.md
@@ -12,14 +12,11 @@ Consortia give us a structure for collectively refining and prioritizing 2i2c ro
 
 ## A consortium is:
 
-A network of stakeholders organized around a unifying problem.   
-A way to ensure that solutions work for many kinds of stakeholders.  
-A way to join forces in design, development, and funding.
+- A network of stakeholders organized around a shared challenge or goal.   
+- A way to ensure that solutions work for many kinds of stakeholders.  
+- A way to join forces in design, development, and funding.
 
-## With an aim to:
-
-Build better solutions for all communities 2i2c serves.   
-Collaborate and learn from each other.
+And a consortium's shared goals are to build better solutions for all communities 2i2c serves, while collaborating and learning from each other.
 
 # How a consortium operates
 
@@ -53,12 +50,12 @@ We currently have one active consortium, the Cloud Cost Optimization Consortium.
 
 Each member community in a consortium is expected to contribute in at least one of the following:
 
-1. React & prioritize \- Tell us what did or did not resonate in our most recent demo, weigh in on priorities   
-2. Endorse \- Sign a letter of support, tell a story that helps illustrate a problem, or consent to be named in a proposal   
-3. Test \- Be early adopters of new features and provide feedback  
-4. Connect \- Introduce us to a peer or funder  
-5. Co-propose \- Invite or join 2i2c on proposals?  
-6. Co-invest / co-fund \- Commit $X if others invest $3X
+1. **React & prioritize** - Tell us what did or did not resonate in our most recent demo, weigh in on priorities   
+2. **Endorse** - Sign a letter of support, tell a story that helps illustrate a problem, or consent to be named in a proposal   
+3. **Test** - Be early adopters of new features and provide feedback  
+4. **Connect** - Introduce us to a peer or funder  
+5. **Co-propose** - Invite or join 2i2c on proposals?  
+6. **Co-invest / co-fund** - Commit $X if others invest $3X
 
 Consortium members choose how much they want to co-create and influence design, share credit in our media & outreach, and have an opportunity to be early adopters of new features. They also ensure that 2i2c keeps building open source solutions that work for all research and education users. 
 

--- a/services/open-source-development/index.md
+++ b/services/open-source-development/index.md
@@ -4,7 +4,7 @@
 
 Creating pathways for communities to share, learn, and collaborate helps us identify and develop enhancements that serve them all. This network effect is the core of 2i2c’s [theory of impact](https://compass.2i2c.org/organization/theory-of-impact/#our-theory-of-impact). 
 
-Part of how 2i2c creates our network effect today is by working with community leaders 1:1, so we see their shared problems and wins, but they only see each other if we make introductions between one community with a problem they need solved and another community who has already solved that problem. 
+We work with many community leaders 1-to-1. This lets us see both problems and wins that they share with other communities. However, these leaders only see _each other_ if we make introductions between one community with a problem, and another community who has already come up with a solution. 
 
 Introducing consortia gives us a structure for collectively refining and prioritizing 2i2c roadmap work that multiple communities care about, working together to fund for that work, and uilding many:many connections, so communities learn from each other. 
 

--- a/services/open-source-development/index.md
+++ b/services/open-source-development/index.md
@@ -34,16 +34,6 @@ Each consortium starts with a shared problem or narrative, and a gathering of pe
 
 Once a consortium has kicked off, each member community participates in our planning ceremonies and gets the same updates on our work together, although they may contribute in different ways. 
 
-#### How we communicate
-
-We currently have one active consortium, the Cloud Cost Optimization Consortium. It's organized around one narrative: [Optimize cloud spend on commercial cloud vendors](https://github.com/2i2c-org/narratives/issues/4). 
-
-- Consortia typically have a live (virtual) meeting quarterly to set priorities and demo recently completed work.  
-- Each consortium has a guide doc. Today that’s in Google Docs; you can find the [Cloud Cost Consortium’s README](https://docs.google.com/document/d/1_447531g-zozFRrJKXZz9x6hfafYzhe_djsCOqQ4dSQ/edit?tab=t.0#heading=h.7g1kmdukb6vh) in our Drive.   
-- We use [a private channel, #consortium-cloud-cost on Slack](https://2i2c.slack.com/archives/C0B25UEJETB) to share quick updates and requests, and as an open space for asynchronous discussion.   
-- We use email updates to send requests (for letters of support, co-proposals, user feedback on features) and demo reels of work in progress.  
-- When the consortium members are interested, we’ll try to organize in-person gatherings, typically as part of a conference where many member communities will already be present. 
-
 #### Roles consortium members play
 
 Each member community in a consortium is expected to contribute in at least one of the following:

--- a/services/open-source-development/index.md
+++ b/services/open-source-development/index.md
@@ -16,7 +16,7 @@ Consortia give us a structure for collectively refining and prioritizing 2i2c ro
 - A way to ensure that solutions work for many kinds of stakeholders.  
 - A way to join forces in design, development, and funding.
 
-And a consortium's shared goals are to build better solutions for all communities 2i2c serves, while collaborating and learning from each other.
+And a consortium's shared goals are to build better solutions for all communities 2i2c serves, while collaborating and learning from each other. Together, we're able to fund and solve problems by sharing resources and expertise.
 
 # How a consortium operates
 

--- a/services/open-source-development/index.md
+++ b/services/open-source-development/index.md
@@ -1,9 +1,108 @@
 (open-source-development:index)=
 
-# Open Source Development
+# Consortia for Open Source Development
 
-2i2c partners with communities to develop new, upstream contributions to the open source ecosystem to enable our global network of science and higher education communities.
+Creating pathways for communities to share, learn, and collaborate helps us identify and develop enhancements that serve them all. This network effect is the core of 2i2c’s [theory of impact](https://compass.2i2c.org/organization/theory-of-impact/#our-theory-of-impact). 
 
-1. A Statement-of-Work (SOW) is developed.
-2. The work is completed.
-3. The work is shared broadly.
+Part of how 2i2c creates our network effect today is by working with community leaders 1:1, so we see their shared problems and wins, but they only see each other if we make introductions between one community with a problem they need solved and another community who has already solved that problem. 
+
+Introducing consortia gives us a structure for collectively refining and prioritizing 2i2c roadmap work that multiple communities care about, working together to fund for that work, and uilding many:many connections, so communities learn from each other. 
+
+# What’s a consortium? 
+
+## A consortium is:
+
+A network of stakeholders organized around a unifying problem.   
+A way to ensure that solutions work for many kinds of stakeholders.  
+A way to join forces in design, development, and funding.
+
+## With an aim to:
+
+Build better solutions for all communities 2i2c serves.   
+Collaborate and learn from each other.
+
+# How a consortium operates
+
+## Getting started. 
+
+Each consortium starts with a shared problem or narrative, and a gathering of people. 
+
+1. **Propose a shared problem.** This can be proposed by a 2i2c team member, or one or more community members. It most often emerges through discussions of the [2i2c roadmap](https://2i2c.org/roadmap/), where we recognize that several related initiatives serve a common narrative.  
+   * **Initiatives:** Units of work that deliver value to open source communities, technology that 2i2c builds, or infrastructure for our services. Designed around a problem statement and a proposed solution. Resolved in weeks-\>months. These are how we plan and share the [2i2c roadmap](https://2i2c.org/roadmap/)  
+   * **Narratives:** Stories of ongoing need for a large class of users or communities. Forms the basis of a consortium. Useful for funding pitches and grant-writing. Designed as a thread that ties multiple initiatives. Resolved in months-\>years.  
+   * So far we have one consortium, organized around one narrative: [Optimize cloud spend on commercial cloud vendors](https://github.com/2i2c-org/narratives/issues/4)   
+       
+2. **Get critical mass.** Find enough other people who agree with the problem statement and are willing to participate in meetings about it.  
+3. **Meet to define goals.** Have a meeting with coalition members to refine the problem, and decide if there’s enough interest in moving forward.
+
+## Running the consortium
+
+Once a consortium has kicked off, each member community participates in our planning ceremonies and gets the same updates on our work together, although they may contribute in different ways. 
+
+### **How we communicate**
+
+We currently have one active consortium, the Cloud Cost Optimization Consortium. 
+
+* Consortia typically have a live (virtual) meeting quarterly to set priorities and demo recently completed work.  
+* Each consortium has a guide doc. Today that’s in Google Docs; you can find the [Cloud Cost Consortium’s README](https://docs.google.com/document/d/1_447531g-zozFRrJKXZz9x6hfafYzhe_djsCOqQ4dSQ/edit?tab=t.0#heading=h.7g1kmdukb6vh) in our Drive.   
+* We use \#consortium-cloud-cost on Slack to share quick updates and requests, and as an open space for asynchronous discussion.   
+* We use email updates to send requests (for letters of support, co-proposals, user feedback on features) and demo reels of work in progress.  
+* When the consortium members are interested, we’ll try to organize in-person gatherings, typically as part of a conference where many member communities will already be present. 
+
+### **Roles consortium members play**
+
+Each member community in a consortium is expected to contribute in at least one of the following:
+
+1. React & prioritize \- Tell us what did or did not resonate in our most recent demo, weigh in on priorities   
+2. Endorse \- Sign a letter of support, tell a story that helps illustrate a problem, or consent to be named in a proposal   
+3. Test \- Be early adopters of new features and provide feedback  
+4. Connect \- Introduce us to a peer or funder  
+5. Co-propose \- Invite or join 2i2c on proposals?  
+6. Co-invest / co-fund \- Commit $X if others invest $3X
+
+Consortium members choose how much they want to co-create and influence design, share credit in our media & outreach, and have an opportunity to be early adopters of new features. They also ensure that 2i2c keeps building open source solutions that work for all research and education users. 
+
+### **Prioritizing (quarterly meeting)**
+
+We use every consortium member’s input to set next priorities, and plan to host a meeting once a quarter to showcase what’s done, what’s possible and gather input on what’s next. 
+
+Once we have a first set of priorities and start work, we share updates over Slack and email. We aim to make our updates and requests low effort and high value.
+
+### **Endorsing**
+
+When we bring a proposed piece of work that supports the consortium to a funder, we will ask for endorsements, which can include:
+
+* Signed letters of support or references  
+* User stories of impact  
+* Willingness to be listed as a collaborator on a proposal
+
+### **Testing**
+
+While we’re developing new solutions, testers serve as early adopters, and commit to trying out new features (which can include things that break). Their feedback helps us build the best solution for everyone. 
+
+### **Connecting** 
+
+Exactly what it sounds like: consortia members who connect us to other potential members, funders or collaborators directly create new sources of funding and ideas.  
+
+### **Co-proposing**
+
+Member communities seeking grant funding themselves can add 2i2c as a subawardee or collaborator. We encourage consortium members to include initiatives from our roadmap in their proposals, and we can support them with estimates and co-writing. 
+
+### **Co-funding**
+
+When a community (or several communities) has funds they can direct towards open source development \- either specific initiatives/features they wish to “buy” or wider sustenance of the Jupyter ecosystem, they work with our Product and Business Development teams to describe and plan the work.   
+
+## What’s the difference between membership with 2i2c and joining a consortium? 
+
+Membership focuses on the core support 2i2c provides a specific community:
+
+- Strategic guidance and advice around the Jupyter ecosystem  
+- Direct support from 2i2c via [support@2i2c.org](mailto:support@2i2c.org)  
+- Infrastructure hosting for (not every member community uses our infrastructure, but most do)  
+- Consortia-related development will still roll-out to any member communities
+
+Consortium adds connection 
+
+- We’ll explore engaging people as consortia so that we can hear multiple voices at once.  
+- We hope this saves time in designing, validating, and developing solutions for shared problems  
+- We’d like to see member communities build more connections with one another, and build collaborations out of this experience


### PR DESCRIPTION
Rewrote a stub for Open Source Development to be about consortia (still about OSS, of course). 

Closes https://github.com/2i2c-org/team-compass/issues/1119 once complete