### PR TITLE
Improve pricing strategy and services description

### DIFF
--- a/business-development/pricing-strategy.md
+++ b/business-development/pricing-strategy.md
@@ -94,16 +94,3 @@ We review these figures annually and adjust with our costs.
 For some funders (e.g., US federal government), we must directly bill all work that is relevant, rather than putting it behind an indirect.
 Where possible, we scope this work as a funded workstream with its own deliverables, rather than an indirect cost buried in the rate.
 When that is not possible, we may quote a lower rate and accept that we under-recover the open source work.
-
-## What we are missing
-
-Some communities won't be well-served by the options above. During the alpha we're building sustainability so we can meet them in future. If this model doesn't fit your needs (wrong kind of service, too expensive, etc.), please tell us so we can evolve it.
-
-A few things we know we are missing:
-
-- **Under-resourced communities**. $15,000 a year is too much for many communities, and our mission requires serving them too. Ideas to explore: sponsorships, budget-based tiered pricing, and lowering our internal costs.
-- **Lightweight hubs**. Our offerings are more complex than many individuals or small communities need. We'd like a scalable, lightweight hub people can quickly spin up, to prototype after the alpha.
-- **Communities that need multiple hubs**. Organizations with many sub-communities may need their own federation of hubs, with a different pricing and growth model. For now we treat these as partnership opportunities.
-- **Significant differences in community size**. Our pricing assumes communities are similar in size and complexity. Much larger communities create extra support and operations work; we need to understand those costs and recover them.
-- **Cloud payments as a service**. When we manage cloud billing and payments for a community, we take on extra work we don't currently charge for. We should estimate that cost with our fiscal sponsor.
-- **Liability for cloud payments**. Managing a community's cloud billing means paying the provider before they pay us (e.g. a community runs up $50,000, then refuses to pay). We have visibility via per-community [budget alerts](interactive-computing:budget-alerts) and [cost dashboards](https://docs.2i2c.org/admin/monitoring/), but still lack an *enforced* ceiling (a hard cap, pre-billing, or deposit) to bound the one uncapped part of our pricing.

--- a/business-development/pricing-strategy.md
+++ b/business-development/pricing-strategy.md
@@ -3,7 +3,7 @@
 
 This page describes the rationale and strategy behind our pricing.
 
-**Last Updated:** `2026-01-22`
+**Last Updated:** `2026-06-20`
 ## Guiding principles
 
 The following principles guide our decision-making around pricing our services.
@@ -15,6 +15,7 @@ Our prices should:
 - Reflect a holistic understanding of open source support, not just code.
 - Be competitive with other "Data Science environment as a service" offerings (see below for how we consider ourselves relative to similar offerings).
 - Be sustainable for the communities we serve, with mechanisms to accommodate institutions with fewer resources.
+- Be predictable and bounded. Usage is real cash out the door for us, unlike zero-marginal-cost software, so our model is a fixed, capped membership base plus bounded usage and cloud plus opt-in add-ons. We avoid usage-blind flat pricing, which would not be sustainable as a community grows.
 
 
 ## Pricing structure
@@ -23,11 +24,18 @@ See [2i2c's service offering](https://sales.2i2c.org/service-description) for a 
 
 ### Membership
 
-2i2c provides two tiers of managed interactive computing platform services: General Member and Premier Member.
+2i2c provides two membership tiers: General and Premier.
+Each tier is a fixed annual fee, capped at the listed amount.
+That fee is the member's entire required commitment for membership.
 
-- **General Membership** is priced at $15,000 per year.
-- **Premier Membership** pricing is customized based on your institution's specific needs and the depth of engagement required.
-  - Typical annual investments range from `$50,000` to `$150,000+`, depending on factors such as the number of hubs, level of customization, consulting hours needed, and strategic collaboration scope.
+- **General Membership** is $15,000 per year.
+- **Premier Membership** is $50,000 per year. It includes more service hours and strategic collaboration than General.
+
+Anything above the base is an optional add-on the member chooses, not a higher base fee.
+Members who want more can add service hours or co-fund [project work](#projects) on top of either tier, but doing so never raises the base.
+
+See [2i2c's service offering](https://sales.2i2c.org/service-description) for the current figures, the service hours included in each tier, and add-on pricing.
+That page is our public source of truth for these numbers.
 
 
 ### Pass-through cloud costs
@@ -50,9 +58,15 @@ We do this for two reasons:
 
 For example, 280 active users in a month costs `$1,000` since `$10x10 + $5x90 + $2.50x180 = $1,000`.
 
+Because the rate drops to $0 above 10,000 MAU, this fee is bounded.
+A single community's usage fee tops out at about `$14,050` per month (`$10x10 + $5x90 + $2.50x900 + $1.25x9000`) and never grows beyond that, no matter how large the community becomes.
+This ceiling matters for buyers: the usage fee is not an open-ended "per user" charge.
+
 ## Projects
 
 2i2c provides open source software development to some of our members. We develop software following [our roadmap](https://2i2c.org/roadmap/about/) using a co-funding model and consistent with the [Right to Replicate](https://2i2c.org/right-to-replicate/) and our [Commitment to Open Technology](https://2i2c.org/open-technology/). 
+
+[TODO: Define how we calculate our hourly rate, using engineering salary base + open source maintenance overhead + our own operational overhead + our FSP fee + a sustainability margin]
 
 ## What we are missing
 
@@ -60,9 +74,9 @@ We know that there are some communities that will not be well-served by the opti
 
 Below are a few things that we know we are missing:
 
-- **Under-resourced communities**. For many communities, $12,000 a year is too much cost to justify. Our mission requires that we serve these communities as well, not just the ones with larger budgets. This proposal is a step towards sustainability, with the goal of developing new models that can serve under-resourced organizations as well. A few ideas to explore are sponsorship models, tiered pricing models that adjust price based on a community’s budget size, and reducing our internal costs (and thus the fees for our services).
+- **Under-resourced communities**. For many communities, $15,000 a year is too much cost to justify. Our mission requires that we serve these communities as well, not just the ones with larger budgets. This proposal is a step towards sustainability, with the goal of developing new models that can serve under-resourced organizations as well. A few ideas to explore are sponsorship models, tiered pricing models that adjust price based on a community’s budget size, and reducing our internal costs (and thus the fees for our services).
 - **Lightweight hubs**. For many individuals or communities, these offerings might involve more complexity than what they need. We’d like to offer a much more scalable and lightweight hub service that people could quickly spin up. We hope to prototype and experiment with ideas after the initial roll-out of the alpha service.
 - **Communities that need multiple hubs**. For organizations with many sub-communities and complexity, a single hub is likely not enough to meet their needs. These communities may be better-served by their own dedicated federation of hubs, with a different pricing / growth model than the offerings described here. For now we’ll treat these as partnership opportunities, but may wish to standardize this in a service offering in the future.
 - **Significant differences in community size**. Our pricing model assumes that most communities have a relatively similar degree of complexity and size between them. However, when communities grow to a certain size (say, two orders of magnitude), it generates additional work in supporting users and hub operations. We hope to better-understand the costs associated with serving these larger communities, and identify ways to recover them via our pricing.
 - **Cloud payments as a service**. In some cases we manage the billing infrastructure and payments for communities (as opposed to them paying cloud providers directly). We do not currently charge explicitly for performing this service. In this case we take on extra work and complexity in tracking and paying cloud bills. We should estimate how much work and risk/liability is entailed in this, and work with our fiscal sponsor to understand how to cover these costs.
-- **Liability for cloud payments**. For communities where we manage their cloud billing, we hold some liability because we’ll need to pay the cloud provider for their usage before they pay us. We should work with our fiscal sponsor to understand our risk here (for example, what if a community charges $50,000 in cloud costs and then refuses to pay their invoice). We should also explore potential ways to mitigate this risk (for example, pre-billing communities for *estimated* cloud usage to create a buffer, or asking for a deposit.
+- **Liability for cloud payments**. For communities where we manage their cloud billing, we hold some liability because we’ll need to pay the cloud provider for their usage before they pay us. We should work with our fiscal sponsor to understand our risk here (for example, what if a community charges $50,000 in cloud costs and then refuses to pay their invoice). We already have cost *visibility and early warning* in place: per-community [budget alerts](interactive-computing:budget-alerts) and [cost monitoring dashboards](https://docs.2i2c.org/admin/monitoring/). What we are still missing is an *enforced* ceiling: a committed cloud budget with a hard cap, pre-billing against an estimate, or a deposit buffer. These would bound the cloud line for the buyer (the one part of our pricing that is currently uncapped) and protect us from the unpaid-invoice scenario above.

--- a/business-development/pricing-strategy.md
+++ b/business-development/pricing-strategy.md
@@ -1,51 +1,48 @@
 (product:pricing-strategy)=
 # Pricing strategy
 
-This page describes the rationale and strategy behind our pricing.
+This page describes our pricing rationale and numbers.
+Our service offering is described in [](mission:service-model).
 
-**Last Updated:** `2026-06-20`
+**Last Updated:** `2026-06-26`
 ## Guiding principles
 
-The following principles guide our decision-making around pricing our services.
-We believe that following these principles allows us to deliver the best services for our communities in a way that aligns with our mission and values.
 Our prices should:
 
 - Sustain and grow 2i2c's services and allow it to thrive as an organization.
 - Support the extra cost associated with open source contributions.
-- Reflect a holistic understanding of open source support, not just code.
+- Reflect the full cost of open source support, not just code.
 - Be competitive with other "Data Science environment as a service" offerings (see below for how we consider ourselves relative to similar offerings).
 - Be sustainable for the communities we serve, with mechanisms to accommodate institutions with fewer resources.
-- Be predictable and bounded. Usage is real cash out the door for us, unlike zero-marginal-cost software, so our model is a fixed, capped membership base plus bounded usage and cloud plus opt-in add-ons. We avoid usage-blind flat pricing, which would not be sustainable as a community grows.
+- Be predictable and bounded. Usage is real cash out the door for us, so our model is a fixed, capped membership base plus bounded usage, cloud, and opt-in add-ons. We avoid usage-blind flat pricing, which doesn't scale as a community grows.
 
 
 ## Pricing structure
 
-See [2i2c's service offering](https://sales.2i2c.org/service-description) for a public description of the information in this page.
-
 ### Membership
 
-2i2c provides two membership tiers: General and Premier.
-Each tier is a fixed annual fee, capped at the listed amount.
-That fee is the member's entire required commitment for membership.
+Membership covers all four [areas of our work](mission:service-model). Each tier is a fixed annual fee, capped at the listed amount, and is the member's entire required commitment.
 
 - **General Membership** is $15,000 per year.
 - **Premier Membership** is $50,000 per year. It includes more service hours and strategic collaboration than General.
 
-Anything above the base is an optional add-on the member chooses, not a higher base fee.
-Members who want more can add service hours or co-fund [project work](#projects) on top of either tier, but doing so never raises the base.
+A member with no hub pays the tier base fee only, with no [usage](#pricing:usage-costs) or [cloud](#pricing:cloud) costs.
 
-See [2i2c's service offering](https://sales.2i2c.org/service-description) for the current figures, the service hours included in each tier, and add-on pricing.
-That page is our public source of truth for these numbers.
+Members who want more can fund a [directed engagement](#directed-engagements) on top of either tier.
+
+See [2i2c's service offering](https://sales.2i2c.org/service-description) for current figures, included service hours, and add-on pricing.
 
 
+(pricing:cloud)=
 ### Pass-through cloud costs
 
-In addition to our monthly hub fees, we pass {external+docs:ref}`cloud infrastructure costs <costs:cloud>` directly to the communities we serve, without taking any percentage markup.
+If we pay cloud bills on behalf of communities, we pass {external+docs:ref}`cloud infrastructure costs <costs:cloud>` directly to the communities we serve, without taking any percentage markup.
 We do this for two reasons:
 
-1. In our eyes, we are running infrastructure _on behalf of each community_, and wish to act as if a member of that community were running the infrastructure themselves. We are simply being compensated for our time and expertise.
+1. We run infrastructure _on behalf of each community_, as if a member of that community were running it themselves.
 2. Adding a percentage markup on cloud costs may create perverse incentives for us to avoid optimizing down a community's cloud costs.
 
+(pricing:usage-costs)=
 ### Usage costs
 
 2i2c charges a monthly usage fees based on Monthly Active Users (MAU) as follows:
@@ -60,23 +57,53 @@ For example, 280 active users in a month costs `$1,000` since `$10x10 + $5x90 + 
 
 Because the rate drops to $0 above 10,000 MAU, this fee is bounded.
 A single community's usage fee tops out at about `$14,050` per month (`$10x10 + $5x90 + $2.50x900 + $1.25x9000`) and never grows beyond that, no matter how large the community becomes.
-This ceiling matters for buyers: the usage fee is not an open-ended "per user" charge.
 
-## Projects
+## Directed engagements
 
-2i2c provides open source software development to some of our members. We develop software following [our roadmap](https://2i2c.org/roadmap/about/) using a co-funding model and consistent with the [Right to Replicate](https://2i2c.org/right-to-replicate/) and our [Commitment to Open Technology](https://2i2c.org/open-technology/). 
+Beyond membership, a member can fund a [directed engagement](mission:service-model), such as a co-funded [project](https://2i2c.org/roadmap/about/) that follows our roadmap (consistent with the [Right to Replicate](https://2i2c.org/right-to-replicate/) and [Commitment to Open Technology](https://2i2c.org/open-technology/)).
 
-[TODO: Define how we calculate our hourly rate, using engineering salary base + open source maintenance overhead + our own operational overhead + our FSP fee + a sustainability margin]
+A member raises a need, we scope it together into a rough size and set of deliverables, and we quote from our rate.
+
+(pricing:rate)=
+### How we set our rate
+
+We publish a blended rate of about **$250/hour**. Here's where it comes from.
+
+We pay team members for a full ~2,000-hour year, but assume only about 900 of those hours are directly billed to projects.
+The rest goes to open source stewardship, maintenance, and running 2i2c.
+Membership helps fund that stewardship, but not all of it.
+We use directed engagements and our hourly rate to make up the difference.
+
+```{list-table}
+:header-rows: 1
+
+* - Layer
+  - Running rate
+* - A fully-burdened engineer (~$180k/year, salary plus ~20% benefits and payroll taxes) over ~900 hours we bill directly to funded projects.
+  - ~$200
+* - Plus our fiscal sponsor's fee (~15%), paid on everything we bill.
+  - ~$230
+* - Plus a margin for 2i2c's operations and financial resilience (~9%).
+  - ~$250
+```
+
+This % of "billable hours" is lower than most consultancies, but it reflects the fact that we spend a significant amount of additional time providing leadership, maintenance, and support for the open source communities that our members depend on.
+We review these figures annually and adjust with our costs.
+
+**Federal and other rate-constrained funders.**
+For some funders (e.g., US federal government), we must directly bill all work that is relevant, rather than putting it behind an indirect.
+Where possible, we scope this work as a funded workstream with its own deliverables, rather than an indirect cost buried in the rate.
+When that is not possible, we may quote a lower rate and accept that we under-recover the open source work.
 
 ## What we are missing
 
-We know that there are some communities that will not be well-served by the options described above. Our goal during the alpha is to build sustainability in order to meet these communities in the future. If the model described above doesn’t fit your needs well (e.g., wrong kind of service, too expensive, etc) please provide feedback, as this can help us evolve the service over time.
+Some communities won't be well-served by the options above. During the alpha we're building sustainability so we can meet them in future. If this model doesn't fit your needs (wrong kind of service, too expensive, etc.), please tell us so we can evolve it.
 
-Below are a few things that we know we are missing:
+A few things we know we are missing:
 
-- **Under-resourced communities**. For many communities, $15,000 a year is too much cost to justify. Our mission requires that we serve these communities as well, not just the ones with larger budgets. This proposal is a step towards sustainability, with the goal of developing new models that can serve under-resourced organizations as well. A few ideas to explore are sponsorship models, tiered pricing models that adjust price based on a community’s budget size, and reducing our internal costs (and thus the fees for our services).
-- **Lightweight hubs**. For many individuals or communities, these offerings might involve more complexity than what they need. We’d like to offer a much more scalable and lightweight hub service that people could quickly spin up. We hope to prototype and experiment with ideas after the initial roll-out of the alpha service.
-- **Communities that need multiple hubs**. For organizations with many sub-communities and complexity, a single hub is likely not enough to meet their needs. These communities may be better-served by their own dedicated federation of hubs, with a different pricing / growth model than the offerings described here. For now we’ll treat these as partnership opportunities, but may wish to standardize this in a service offering in the future.
-- **Significant differences in community size**. Our pricing model assumes that most communities have a relatively similar degree of complexity and size between them. However, when communities grow to a certain size (say, two orders of magnitude), it generates additional work in supporting users and hub operations. We hope to better-understand the costs associated with serving these larger communities, and identify ways to recover them via our pricing.
-- **Cloud payments as a service**. In some cases we manage the billing infrastructure and payments for communities (as opposed to them paying cloud providers directly). We do not currently charge explicitly for performing this service. In this case we take on extra work and complexity in tracking and paying cloud bills. We should estimate how much work and risk/liability is entailed in this, and work with our fiscal sponsor to understand how to cover these costs.
-- **Liability for cloud payments**. For communities where we manage their cloud billing, we hold some liability because we’ll need to pay the cloud provider for their usage before they pay us. We should work with our fiscal sponsor to understand our risk here (for example, what if a community charges $50,000 in cloud costs and then refuses to pay their invoice). We already have cost *visibility and early warning* in place: per-community [budget alerts](interactive-computing:budget-alerts) and [cost monitoring dashboards](https://docs.2i2c.org/admin/monitoring/). What we are still missing is an *enforced* ceiling: a committed cloud budget with a hard cap, pre-billing against an estimate, or a deposit buffer. These would bound the cloud line for the buyer (the one part of our pricing that is currently uncapped) and protect us from the unpaid-invoice scenario above.
+- **Under-resourced communities**. $15,000 a year is too much for many communities, and our mission requires serving them too. Ideas to explore: sponsorships, budget-based tiered pricing, and lowering our internal costs.
+- **Lightweight hubs**. Our offerings are more complex than many individuals or small communities need. We'd like a scalable, lightweight hub people can quickly spin up, to prototype after the alpha.
+- **Communities that need multiple hubs**. Organizations with many sub-communities may need their own federation of hubs, with a different pricing and growth model. For now we treat these as partnership opportunities.
+- **Significant differences in community size**. Our pricing assumes communities are similar in size and complexity. Much larger communities create extra support and operations work; we need to understand those costs and recover them.
+- **Cloud payments as a service**. When we manage cloud billing and payments for a community, we take on extra work we don't currently charge for. We should estimate that cost with our fiscal sponsor.
+- **Liability for cloud payments**. Managing a community's cloud billing means paying the provider before they pay us (e.g. a community runs up $50,000, then refuses to pay). We have visibility via per-community [budget alerts](interactive-computing:budget-alerts) and [cost dashboards](https://docs.2i2c.org/admin/monitoring/), but still lack an *enforced* ceiling (a hard cap, pre-billing, or deposit) to bound the one uncapped part of our pricing.

--- a/finance/accounting.md
+++ b/finance/accounting.md
@@ -29,7 +29,7 @@ These help us categorize transactions more effectively. Here is a summary:
 - - 4220 Revenues: Services
   - A parent category for this collection of services, we need this as a parent category for CS&S's system.
 - - 4221 Revenues: Services: Membership fees
-  - For recurring membership fees. This is the recurring part of our 3-tier menu.
+  - For recurring membership fees (the capped base fee for a General or Premier membership). Usage, cloud cost recovery, and service fees are tracked separately in the accounts below.
 - - 4222 Revenues: Services: Cloud cost recovery
   - For pass-through cloud costs. For when we pay for infrastructure on behalf of communities and then pass the costs to them.
 - - 4223 Revenues: Services: Usage fees

--- a/organization/service-model.md
+++ b/organization/service-model.md
@@ -4,9 +4,10 @@
 What 2i2c does for member communities, and how we fund it.
 See [](product:pricing-strategy) for numbers and [](./value-proposition.md) for persona messaging.
 
-## Areas of service
+(service-model:docs)=
+## Areas of service: DOCS
 
-These are four key areas where we support member communities.
+We support member communities in four key areas, which we call **DOCS**: **Develop**, **Operate**, **Connect & Advise**, and **Steward**.
 Memberships blend all four, while directed engagements usually emphasize a subset of them.
 
 ```{list-table}
@@ -14,15 +15,18 @@ Memberships blend all four, while directed engagements usually emphasize a subse
 
 * - Area
   - What it is
-* - **Operate**
-  - Deploy and run infrastructure on behalf of communities, usually via one or more JupyterHubs on s cloud service.
-* - **Build**
+* - **Develop**
   - Develop and customize software to meet community needs, usually via upstream open source contributions.
-* - **Steward**
-  - Maintain and lead the upstream open source projects our communities depend on. This includes both technical and social support.
+* - **Operate**
+  - Deploy and run infrastructure on behalf of communities, usually via one or more JupyterHubs on a cloud service.
 * - **Connect & Advise**
   - Connect communities and funders, sense shared problems, and advise on strategy and design with our communities.
+* - **Steward**
+  - Maintain and lead the upstream open source projects our communities depend on. This includes both technical and social support.
 ```
+
+**Develop** covers member-driven contributions that address a specific member community's need.
+**Steward** covers [foundational contributions](https://2i2c.org/blog/good-citizen/) that keep the ecosystem healthy regardless of any one member's need, along with broader project leadership and community support.
 
 ## Membership and directed engagements
 
@@ -40,7 +44,7 @@ Directed engagements
 : add dedicated capacity on top, at [our rate](product:pricing-strategy).
 A member puts extra funding behind one or more areas and helps steer it.
 
-Example 1: a member community co-funds roadmap project that leads with **Build**, but also involves running a prototype hub (**Operate**) and extra upstream engagement (**Steward**) as result.
+Example 1: a member community co-funds roadmap project that leads with **Develop**, but also involves running a prototype hub (**Operate**) and extra upstream engagement (**Steward**) as result.
 
 Example 2: A member with no hub points a directed engagement entirely at **Steward** because they wish for directed support to go towards an upstream community they depend on.
 

--- a/organization/service-model.md
+++ b/organization/service-model.md
@@ -15,7 +15,7 @@ Memberships blend all four, while directed engagements usually emphasize a subse
 * - Area
   - What it is
 * - **Operate**
-  - Deploy and run infrastructure on behalf of communities, usually via one or more JupyterHubs on commercial cloud.
+  - Deploy and run infrastructure on behalf of communities, usually via one or more JupyterHubs on s cloud service.
 * - **Build**
   - Develop and customize software to meet community needs, usually via upstream open source contributions.
 * - **Steward**
@@ -43,3 +43,5 @@ A member puts extra funding behind one or more areas and helps steer it.
 Example 1: a member community co-funds roadmap project that leads with **Build**, but also involves running a prototype hub (**Operate**) and extra upstream engagement (**Steward**) as result.
 
 Example 2: A member with no hub points a directed engagement entirely at **Steward** because they wish for directed support to go towards an upstream community they depend on.
+
+Example 3: A member joins another community's hub. They share the cost of that community's **Operate** and use **Connect & Advise** to design their shared sociotechnical community.

--- a/organization/service-model.md
+++ b/organization/service-model.md
@@ -1,66 +1,45 @@
+(mission:service-model)=
 # Service model
 
-This page describes how we engage with member communities and fund our work.
-It's the primary way we implement [our strategy](./strategy.md).
-For persona-driven messaging about outcomes for stakeholders, see [our value proposition](./value-proposition.md).
+What 2i2c does for member communities, and how we fund it.
+See [](product:pricing-strategy) for numbers and [](./value-proposition.md) for persona messaging.
 
-## Membership overview
+## Areas of service
 
-Our primary engagement model is **membership** in a network.
-This centers our mission-driven nature, and builds a feeling of mutual support and status between our member organizations.
+These are four key areas where we support member communities.
+Memberships blend all four, while directed engagements usually emphasize a subset of them.
 
-Membership primarily drives cycles of a **development and operations flywheel**: membership **comes with standardized managed infrastructure**, and drives cycles of collaborative and **co-funded project work** that improve the infrastructure for everyone.
+```{list-table}
+:header-rows: 1
 
-This creates a collaborative flywheel where our relatively  small team can efficiently manage infrastructure and facilitate collaboration between many different communities to support open source development.
+* - Area
+  - What it is
+* - **Operate**
+  - Deploy and run infrastructure on behalf of communities, usually via one or more JupyterHubs on commercial cloud.
+* - **Build**
+  - Develop and customize software to meet community needs, usually via upstream open source contributions.
+* - **Steward**
+  - Maintain and lead the upstream open source projects our communities depend on. This includes both technical and social support.
+* - **Connect & Advise**
+  - Connect communities and funders, sense shared problems, and advise on strategy and design with our communities.
+```
 
-- **Framing**: Membership is a way to pool resources on a shared service team (operations, development, and community engagement).
-- **Cost recovery**: Membership covers core costs in operations, engagement, and upstream support.
-- **Benefit**:
-  - Participation in our core DevOps system.
-  - Comes with managed infrastructure. This ensures we have a cycle between operations and development work.
-  - Access to spaces and conversations communities otherwise would not have.
-  - A way for communities to pool resources to contribute upstream.
+## Membership and directed engagements
 
-## Membership
+There are two ways to support our work - **membership** is a common base for every contract, and **directed engagements** stack in addition.
 
-Our target business model includes membership with an optional "Premier membership" upgrade:
+General Membership
+: sustains a shared baseline across all four areas, renewed annually.
+  See the [service description](https://sales.2i2c.org/service-description) for what each tier includes.
+  It keeps hubs running and funds upstream work.
 
-**Membership**
-- **For**: Discrete communities with a homogeneous user base (e.g., a single research group or collaboration).
-- **Impact**: The core loop that sustains 2i2c and covers the cost of making open infrastructure accessible and supported with foundational contributions.
-- **Offers**:
-  - Site Reliability Engineering for managed infrastructure.
-  - Basic guidance in usage.
-  - Participation in roadmapping exercises and co-funding opportunities.
+Premier membership
+: adds additional capacity for our impact, provides deeper roadmap influence, as well as additional time for engaging in the four areas described above.
 
-**Premier membership option** (strategic for some communities)
-- **For**: Strategic partners that want deeper engagement or investment in open source development. Usually serve more than one community that fits our membership profile.
-- **Impact**: Drives deeper engagement and investment in open source, strategic guidance for 2i2c, and larger-scale growth within a community.
-- **Offers**:
-  - Strategic-level engagement from 2i2c, with more direction over our roadmap.
-  - Coordination and guidance in planning and delivering technical improvements.
-  - Tighter feedback loops and reporting between development and operations.
+Directed engagements
+: add dedicated capacity on top, at [our rate](product:pricing-strategy).
+A member puts extra funding behind one or more areas and helps steer it.
 
-**Accessible service mechanism** (WIP, described as "Starter" membership; not currently prioritized)
-- **For**: Communities that need standardized, commodity infrastructure with minimal customization.
-- **Offers**: Commodified SRE evolving with open source. Automated operations with community-driven support.
-- **Impact**: Makes open infrastructure largely accessible, even to communities that cannot cover the costs of foundational contributions and development.
+Example 1: a member community co-funds roadmap project that leads with **Build**, but also involves running a prototype hub (**Operate**) and extra upstream engagement (**Steward**) as result.
 
-## Co-funded projects with members
-
-Project-based work gives members a way to influence our new development, and make it possible with funding. It is the engine that drives innovation and enhancement of our shared technical system.
-
-- **For**: Any member organization that wants their infrastructure to be better (we do not distinguish between members with Premier membership and other members for co-funding).
-- **Cost recovery**: Covers all R&D-style costs for new development.
-- **Benefits**:
-  - A mechanism to fund fractions of new development work to make it more likely to happen faster.
-  - Engages communities to talk about shared problems, and to learn from one another.
-  - A way to get credit for supporting open source infrastructure development.
-
-## How membership and project work feed into one another
-
-Each line of business benefits from network effects, and crucially depends on our development work and our operations work feeding into one another. As the number of member communities grows:
-
-- They share more of the cost of operations, which decreases cost of service or increases support for open infrastructure.
-- They increase the resources available for new development, which benefits the entire network.
-- They have a larger group of communities to learn from, which increases learning and adoption of new workflows.
+Example 2: A member with no hub points a directed engagement entirely at **Steward** because they wish for directed support to go towards an upstream community they depend on.

--- a/organization/value-proposition.md
+++ b/organization/value-proposition.md
@@ -3,7 +3,7 @@
 
 The value [our service model](./service-model.md) provides to key stakeholder personas.
 
-We create a high-bandwidth connection between those who **develop** open technology, those who **operate** it, and those who **use** it. We only develop infrastructure that serves the communities we manage it for.
+We create a high-bandwidth connection between those who **develop** open technology, those who **operate** it, and those who **use** it. We develop infrastructure that serves the communities we manage it for, and make those infrastructure changes widely available.
 
 We also connect communities to each other, so a problem solved for one becomes a fix everyone shares, and we help funders invest in the open source they all rely on. Many groups can run a hub; the network we cultivate across these communities is what sets us apart, and the part we most want to grow.
 

--- a/organization/value-proposition.md
+++ b/organization/value-proposition.md
@@ -1,33 +1,23 @@
 (mission:value-proposition)=
 # Value proposition
 
-This describes the value [our service model](./service-model.md) provides to key stakeholder personas for 2i2c.
+The value [our service model](./service-model.md) provides to key stakeholder personas.
 
-We create a high-bandwidth connection between people **developing** open technology, people **operating** the technology, and people **using** the technology. We only develop infrastructure that serves the network of communities for whom we manage infrastructure.
+We create a high-bandwidth connection between those who **develop** open technology, those who **operate** it, and those who **use** it. We only develop infrastructure that serves the communities we manage it for.
 
-2i2c delivers value to the communities we serve when we:
+We also connect communities to each other, so a problem solved for one becomes a fix everyone shares, and we help funders invest in the open source they all rely on. Many groups can run a hub; the network we cultivate across these communities is what sets us apart, and the part we most want to grow.
 
-1. run hubs (using reproducible, open infra)
-2. sense problems (shared by many communities with common factors)
-3. shape solutions (to those common problems)
-4. connect horizontally (across downstream user communities)
-5. connect vertically (to upstream software communities)
-6. nurture ecosystem (keeping OSS healthy)
-7. advise on strategy (helping communities think bigger)
-8. transfer knowledge (about the infra and how to use it and the ecosystem and how to engage within it)
-
-These `value activities` are building blocks for 2i2c's service design and differentiation from other infrastructure providers. 
+We deliver this value through [four areas of work](mission:service-model): **Operate**, **Build**, **Steward**, and **Connect & Advise**.
 
 
 ## For hub users (researchers, students, practitioners)
 
 **Stop managing servers. Start doing your work.**
 
-Get instant access to the same battle-tested interactive computing infrastructure used by top research communities globally. Focus on your science, not the server.
+Get instant access to the same interactive computing infrastructure used by leading research communities. Focus on your science, not the server.
 
 **What you get:**
 - Instant, standardized access to JupyterHub and interactive computing tools
-- Battle-tested infrastructure that just works
 - Access to shared data, computing resources, and collaborative tools
 
 ## For hub administrators (technical leads, research computing staff)
@@ -37,8 +27,7 @@ Get instant access to the same battle-tested interactive computing infrastructur
 Leverage tools and workflows co-developed by the scientific community. Benefit instantly from open source enhancements while learning from a network of administrators like you.
 
 **What you get:**
-- Community-standard tools you could run yourself.
-- Self-service customization using community-standard tools
+- Self-service customization with community-standard tools you could run yourself
 - Automatic deployment of ecosystem improvements
 - Peer learning network of administrators solving similar challenges
 - Freedom to replicate and modify ([Right to Replicate](https://2i2c.org/right-to-replicate))
@@ -58,13 +47,13 @@ Join a network of peer organizations that collectively fund the open source tool
 
 ## For the open science ecosystem (funders, OSS maintainers, advocates)
 
-**Turn usage into investment. Drive systemic change.**
+**Turn usage into investment.**
 
 We demonstrate that community-governed infrastructure is a scalable, reliable alternative to proprietary silos.
 
 **What we enable:**
 - **Strengthen OSS sustainability**: Usage becomes active investment in the tools research depends on
-- **Spread innovation**: Best practices and tools flow rapidly across disciplinary boundaries
+- **Spread innovation**: Best practices and tools move quickly across disciplines
 - **Prove the alternative**: Scalable, community-driven infrastructure without vendor lock-in
 - **Evidence of impact**: Connections to and reports from communities who get value from their use of open source software
 

--- a/organization/value-proposition.md
+++ b/organization/value-proposition.md
@@ -7,7 +7,7 @@ We create a high-bandwidth connection between those who **develop** open technol
 
 We also connect communities to each other, so a problem solved for one becomes a fix everyone shares, and we help funders invest in the open source they all rely on. Many groups can run a hub; the network we cultivate across these communities is what sets us apart, and the part we most want to grow.
 
-We deliver this value through [four areas of work](mission:service-model): **Operate**, **Build**, **Steward**, and **Connect & Advise**.
+We deliver this value through [four areas of work](#service-model:docs), which we call **DOCS**: **Develop**, **Operate**, **Connect & Advise**, and **Steward**.
 
 
 ## For hub users (researchers, students, practitioners)

--- a/people/compensation.md
+++ b/people/compensation.md
@@ -1,5 +1,6 @@
 # Compensation and Benefits
 
+(compensation:philosophy)=
 ## Compensation philosophy
 
 :::{admonition} Aspirational

--- a/services/interactive-computing/budget-alerts.md
+++ b/services/interactive-computing/budget-alerts.md
@@ -1,4 +1,4 @@
-
+(interactive-computing:budget-alerts)=
 # Budget alerts response
 
 We now have setup budget alerts for all cloud projects where we pay the bill from the cloud provider, independently if we pass through these costs or not to the community. However, we currently don’t look to setup budget alerts for communities paying their cloud provider bill directly.


### PR DESCRIPTION
This improves, clarifies, and cleans up some of our pricing documentation and our service description. Here are the main changes:

- Our Service Description makes clearer mention of four areas of work where we provide service. This is similar to @colliand 's "value streams" document, but simplified a bit. I'm trying to more explicitly call out these streams in our docs.
- Our pricing now includes mention of "Directed engagements" as a mechanism for delivering additional work on top of base membership, but still connected to those areas of work above.
- I have a brief rationale justifying our hourly rate as a combination of salary against billable hours, additional mission work we do, indirects, and a sustainability margin.

### Questions

I'd like feedback on the quality of this content in general, and whether it's safe to merge and start to work into our sales assets, but here are a few questions on my mind:

- Does any of this language deviate too much from how we're already offering service?
- Does it miss anything critically important about the way we provide service? Does it mis-represent anything?
- Is the hourly rate estimate rationale safe to share and correct?

---

- closes https://github.com/2i2c-org/meta/issues/3406